### PR TITLE
Feature/task 24 calculation engine doe

### DIFF
--- a/de.dlr.sc.virsat.model.calculation.tests/src/de/dlr/sc/virsat/model/calculation/compute/NumberLiteralResultHelperTest.java
+++ b/de.dlr.sc.virsat.model.calculation.tests/src/de/dlr/sc/virsat/model/calculation/compute/NumberLiteralResultHelperTest.java
@@ -76,5 +76,11 @@ public class NumberLiteralResultHelperTest {
 		assertEquals("Quantity Kind Compuation correct", EXPECTED_QUANTITY_KINDS_POTENCY, resultMultiply.getQuantityKinds().get(qk), EPSILON);
 		assertEquals("Quantity Kind Compuation correct", -1d, resultDivide.getQuantityKinds().get(qk), EPSILON);
 		assertEquals("Quantity Kind Compuation correct", 1, resultSqrt.getQuantityKinds().get(qk), EPSILON);
+		
+		quantityKindsRHS.put(qk, 1d);
+		resultPlus = numLitResultHelperLHS.applyMathOperator(MathOperator.PLUS, numberLiteralResultRHS);
+		resultMinus = numLitResultHelperLHS.applyMathOperator(MathOperator.MINUS, numberLiteralResultRHS);
+		assertEquals("Quantity Kind Compuation correct", 1d, resultPlus.getQuantityKinds().get(qk), EPSILON);
+		assertEquals("Quantity Kind Compuation correct", 1d, resultMinus.getQuantityKinds().get(qk), EPSILON);
 	}
 }

--- a/de.dlr.sc.virsat.model.calculation.tests/src/de/dlr/sc/virsat/model/calculation/compute/NumberLiteralResultHelperTest.java
+++ b/de.dlr.sc.virsat.model.calculation.tests/src/de/dlr/sc/virsat/model/calculation/compute/NumberLiteralResultHelperTest.java
@@ -10,6 +10,7 @@
 package de.dlr.sc.virsat.model.calculation.compute;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,7 +34,6 @@ public class NumberLiteralResultHelperTest {
 
 	@Test
 	public void testApplyMathOperator() {
-		
 		final double EPSILON = 0.000001;
 		final double TEST_VALUE_LHS = 40;
 		final double TEST_VALUE_RHS = 20;
@@ -68,12 +68,13 @@ public class NumberLiteralResultHelperTest {
 		assertEquals("Value Computation correct", "800.0", resultMultiply.getNumberLiteral().getValue());
 		assertEquals("Value Computation correct", "2.0", resultDivide.getNumberLiteral().getValue());
 		
-		assertEquals("Quantity Kind Compuation correct", 1d, resultPlus.getQuantityKinds().get(qk), EPSILON);
-		assertEquals("Quantity Kind Compuation correct", 1d, resultMinus.getQuantityKinds().get(qk), EPSILON);
+		assertEquals("Quantity Kind Compuation correct", Double.NaN, resultPlus.getQuantityKinds().get(QudvUnitHelper.getInstance().getUndefinedQK()), EPSILON);
+		assertNull("Quantity Kind Compuation correct", resultPlus.getQuantityKinds().get(qk));
+		assertEquals("Quantity Kind Compuation correct", Double.NaN, resultMinus.getQuantityKinds().get(QudvUnitHelper.getInstance().getUndefinedQK()), EPSILON);
+		assertNull("Quantity Kind Compuation correct", resultMinus.getQuantityKinds().get(qk));
 		final double EXPECTED_QUANTITY_KINDS_POTENCY = 3d;
 		assertEquals("Quantity Kind Compuation correct", EXPECTED_QUANTITY_KINDS_POTENCY, resultMultiply.getQuantityKinds().get(qk), EPSILON);
 		assertEquals("Quantity Kind Compuation correct", -1d, resultDivide.getQuantityKinds().get(qk), EPSILON);
 		assertEquals("Quantity Kind Compuation correct", 1, resultSqrt.getQuantityKinds().get(qk), EPSILON);
 	}
-
 }

--- a/de.dlr.sc.virsat.model.calculation.tests/src/de/dlr/sc/virsat/model/calculation/compute/NumberLiteralResultHelperTest.java
+++ b/de.dlr.sc.virsat.model.calculation.tests/src/de/dlr/sc/virsat/model/calculation/compute/NumberLiteralResultHelperTest.java
@@ -68,9 +68,9 @@ public class NumberLiteralResultHelperTest {
 		assertEquals("Value Computation correct", "800.0", resultMultiply.getNumberLiteral().getValue());
 		assertEquals("Value Computation correct", "2.0", resultDivide.getNumberLiteral().getValue());
 		
-		assertEquals("Quantity Kind Compuation correct", Double.NaN, resultPlus.getQuantityKinds().get(QudvUnitHelper.getInstance().getUndefinedQK()), EPSILON);
+		assertEquals("Quantity Kind Compuation correct", 1d, resultPlus.getQuantityKinds().get(QudvUnitHelper.getInstance().getUndefinedQK()), EPSILON);
 		assertNull("Quantity Kind Compuation correct", resultPlus.getQuantityKinds().get(qk));
-		assertEquals("Quantity Kind Compuation correct", Double.NaN, resultMinus.getQuantityKinds().get(QudvUnitHelper.getInstance().getUndefinedQK()), EPSILON);
+		assertEquals("Quantity Kind Compuation correct", 1d, resultMinus.getQuantityKinds().get(QudvUnitHelper.getInstance().getUndefinedQK()), EPSILON);
 		assertNull("Quantity Kind Compuation correct", resultMinus.getQuantityKinds().get(qk));
 		final double EXPECTED_QUANTITY_KINDS_POTENCY = 3d;
 		assertEquals("Quantity Kind Compuation correct", EXPECTED_QUANTITY_KINDS_POTENCY, resultMultiply.getQuantityKinds().get(qk), EPSILON);

--- a/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/compute/extensions/EnumPropertySetter.java
+++ b/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/compute/extensions/EnumPropertySetter.java
@@ -11,14 +11,14 @@ package de.dlr.sc.virsat.model.calculation.compute.extensions;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import de.dlr.sc.virsat.model.calculation.compute.IExpressionResult;
 import de.dlr.sc.virsat.model.calculation.compute.IResultSetter;
-import de.dlr.sc.virsat.model.calculation.compute.problem.UnknownExpressionProblem;
 import de.dlr.sc.virsat.model.calculation.compute.problem.EvaluationProblem;
 import de.dlr.sc.virsat.model.calculation.compute.problem.IncompatibleQuantityKindsProblem;
+import de.dlr.sc.virsat.model.calculation.compute.problem.UnknownExpressionProblem;
 import de.dlr.sc.virsat.model.dvlm.calculation.CalculationFactory;
 import de.dlr.sc.virsat.model.dvlm.calculation.NumberLiteral;
 import de.dlr.sc.virsat.model.dvlm.categories.ATypeInstance;
@@ -63,7 +63,7 @@ public class EnumPropertySetter implements IResultSetter {
 		
 		AUnit targetUnit = ((EnumUnitPropertyInstance) instance).getUnit();
 		if (targetUnit != null) {
-			HashMap<AQuantityKind, Double> targetBaseQuantityKinds = QudvUnitHelper.getInstance().getBaseQuantityKinds(targetUnit.getQuantityKind());
+			Map<AQuantityKind, Double> targetBaseQuantityKinds = QudvUnitHelper.getInstance().getBaseQuantityKinds(targetUnit.getQuantityKind());
 			boolean compatibleQuantityKinds = QudvUnitHelper.getInstance().haveSameQuantityKind(targetBaseQuantityKinds, result.getQuantityKinds());
 			if (!compatibleQuantityKinds) {
 				IncompatibleQuantityKindsProblem incompatibleQuantityKindsProblem = new IncompatibleQuantityKindsProblem(instance, targetBaseQuantityKinds, result.getQuantityKinds());

--- a/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/compute/extensions/NumberLiteralResultHelper.java
+++ b/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/compute/extensions/NumberLiteralResultHelper.java
@@ -94,7 +94,9 @@ public class NumberLiteralResultHelper {
 		if (operator.equals(MathOperator.PLUS)) {
 			Sum sum = new Sum();
 			doubleResult = sum.evaluate(values);
-			
+			if (!QudvUnitHelper.getInstance().haveSameQuantityKind(lhsBaseQuantityKinds, rhsBaseQuantityKinds)) {
+				resultBaseQuantityKinds = QudvUnitHelper.getInstance().createUndefinedQKMap();
+			}
 		} else if (operator.equals(MathOperator.MINUS)) {
 			Subtract subtract = new Subtract();
 			doubleResult = subtract.value(values[0], values[1]);

--- a/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/compute/extensions/NumberLiteralResultHelper.java
+++ b/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/compute/extensions/NumberLiteralResultHelper.java
@@ -94,9 +94,13 @@ public class NumberLiteralResultHelper {
 		if (operator.equals(MathOperator.PLUS)) {
 			Sum sum = new Sum();
 			doubleResult = sum.evaluate(values);
+			
 		} else if (operator.equals(MathOperator.MINUS)) {
 			Subtract subtract = new Subtract();
 			doubleResult = subtract.value(values[0], values[1]);
+			if (!QudvUnitHelper.getInstance().haveSameQuantityKind(lhsBaseQuantityKinds, rhsBaseQuantityKinds)) {
+				resultBaseQuantityKinds = QudvUnitHelper.getInstance().createUndefinedQKMap();
+			}
 		} else if (operator.equals(MathOperator.MULTIPLY)) {
 			Product multiply = new Product();
 			doubleResult = multiply.evaluate(values);

--- a/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/compute/extensions/NumberLiteralSetter.java
+++ b/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/compute/extensions/NumberLiteralSetter.java
@@ -12,14 +12,14 @@ package de.dlr.sc.virsat.model.calculation.compute.extensions;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import de.dlr.sc.virsat.model.calculation.compute.IExpressionResult;
 import de.dlr.sc.virsat.model.calculation.compute.IResultSetter;
-import de.dlr.sc.virsat.model.calculation.compute.problem.UnknownExpressionProblem;
 import de.dlr.sc.virsat.model.calculation.compute.problem.EvaluationProblem;
 import de.dlr.sc.virsat.model.calculation.compute.problem.IncompatibleQuantityKindsProblem;
+import de.dlr.sc.virsat.model.calculation.compute.problem.UnknownExpressionProblem;
 import de.dlr.sc.virsat.model.dvlm.calculation.CalculationFactory;
 import de.dlr.sc.virsat.model.dvlm.calculation.NumberLiteral;
 import de.dlr.sc.virsat.model.dvlm.categories.ATypeInstance;
@@ -64,7 +64,7 @@ public class NumberLiteralSetter implements IResultSetter {
 			AUnit targetUnit = ((UnitValuePropertyInstance) instance).getUnit();
 			if (targetUnit != null) {
 				
-				HashMap<AQuantityKind, Double> targetBaseQuantityKinds = QudvUnitHelper.getInstance().getBaseQuantityKinds(targetUnit.getQuantityKind());
+				Map<AQuantityKind, Double> targetBaseQuantityKinds = QudvUnitHelper.getInstance().getBaseQuantityKinds(targetUnit.getQuantityKind());
 				boolean compatibleQuantityKinds = QudvUnitHelper.getInstance().haveSameQuantityKind(targetBaseQuantityKinds, result.getQuantityKinds());
 				if (!compatibleQuantityKinds) {
 					IncompatibleQuantityKindsProblem incompatibleQuantityKindsProblem = new IncompatibleQuantityKindsProblem(instance, targetBaseQuantityKinds, result.getQuantityKinds());

--- a/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelperTest.java
+++ b/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelperTest.java
@@ -41,6 +41,7 @@ import de.dlr.sc.virsat.model.dvlm.qudv.QudvFactory;
 import de.dlr.sc.virsat.model.dvlm.qudv.SimpleUnit;
 import de.dlr.sc.virsat.model.dvlm.qudv.SystemOfQuantities;
 import de.dlr.sc.virsat.model.dvlm.qudv.SystemOfUnits;
+import de.dlr.sc.virsat.model.dvlm.qudv.util.QudvUnitHelper.QudvCalcMethod;
 
 /**
  * Qudv Unit Helper Test class  
@@ -610,6 +611,9 @@ public class QudvUnitHelperTest {
 		assertEquals(4.2f, mergedMap.get(electricCurrent), TEST_EPSILON);
 		assertEquals(2.0, mergedMap.get(temperature), TEST_EPSILON);
 		
+		// merging a map with the undefined qk with any other map yields again the map with the undefined qk
+		Map<AQuantityKind, Double> undefinedQKMap = qudvHelper.createUndefinedQKMap();
+		assertEquals(undefinedQKMap, qudvHelper.mergeMaps(undefinedQKMap, map1, QudvCalcMethod.ADD));
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelperTest.java
+++ b/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelperTest.java
@@ -614,6 +614,7 @@ public class QudvUnitHelperTest {
 		// merging a map with the undefined qk with any other map yields again the map with the undefined qk
 		Map<AQuantityKind, Double> undefinedQKMap = qudvHelper.createUndefinedQKMap();
 		assertEquals(undefinedQKMap, qudvHelper.mergeMaps(undefinedQKMap, map1, QudvCalcMethod.ADD));
+		assertEquals(undefinedQKMap, qudvHelper.mergeMaps(map2, undefinedQKMap, QudvCalcMethod.SUBTRACT));
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelperTest.java
+++ b/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelperTest.java
@@ -463,7 +463,7 @@ public class QudvUnitHelperTest {
 	@Test
 	public void haveSameQuantityKindWithMapTest() {
 		//make some simple quantityKinds
-		AQuantityKind dimensionlessQK = qudvHelper.createSimpleQuantityKind(qudvHelper.dimensionlessQKname, "U", "dimensionlessQK", "");
+		AQuantityKind dimensionlessQK = qudvHelper.createSimpleQuantityKind(QudvUnitHelper.DIMENSIONLESS_QK_NAME, "U", "dimensionlessQK", "");
 		AQuantityKind length = qudvHelper.createSimpleQuantityKind("length", "L", "long John", "http://length.virsat.dlr.de");
 		AQuantityKind mass = qudvHelper.createSimpleQuantityKind("mass", "M", "heavy Mass", "http://mass.virsat.dlr.de");
 		AQuantityKind time = qudvHelper.createSimpleQuantityKind("Time", "T", "timeQK", "");
@@ -567,7 +567,7 @@ public class QudvUnitHelperTest {
 	@Test
 	public void isDimensionlessTest() {
 		//make some simple quantityKinds
-		AQuantityKind dimensionlessQK = qudvHelper.createSimpleQuantityKind(qudvHelper.dimensionlessQKname, "U", "dimensionlessQK", "");
+		AQuantityKind dimensionlessQK = qudvHelper.createSimpleQuantityKind(QudvUnitHelper.DIMENSIONLESS_QK_NAME, "U", "dimensionlessQK", "");
 		AQuantityKind length = qudvHelper.createSimpleQuantityKind("length", "L", "long John", "http://length.virsat.dlr.de");
 		AUnit m = qudvHelper.createSimpleUnit("metre", "m", "meters are used to measure lengths", "http://meters.virsat.dlr.de", length);
 		AUnit unitWithoutQK = qudvHelper.createSimpleUnit("noUnit", "nU", "", "", null);

--- a/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelperTest.java
+++ b/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelperTest.java
@@ -513,9 +513,9 @@ public class QudvUnitHelperTest {
 		AQuantityKind mass = qudvHelper.createSimpleQuantityKind("mass", "M", "heavy Mass", "http://mass.virsat.dlr.de");
 		AQuantityKind time = qudvHelper.createSimpleQuantityKind("Time", "T", "timeQK", "");
 		
-		HashMap<AQuantityKind, Double> factorMap = new HashMap<AQuantityKind, Double>();
-		HashMap<AQuantityKind, Double> forceBaseMap = new HashMap<AQuantityKind, Double>();
-		HashMap<AQuantityKind, Double> accelerationBaseMap = new HashMap<AQuantityKind, Double>();
+		Map<AQuantityKind, Double> factorMap = new HashMap<AQuantityKind, Double>();
+		Map<AQuantityKind, Double> forceBaseMap = new HashMap<AQuantityKind, Double>();
+		Map<AQuantityKind, Double> accelerationBaseMap = new HashMap<AQuantityKind, Double>();
 		
 		// some coefficient 
 		final Double M2 = -2.0;
@@ -597,7 +597,7 @@ public class QudvUnitHelperTest {
 		map2.put(electricCurrent, 4.2);
 		
 		//now merge the maps and make some checks
-		HashMap<AQuantityKind, Double> mergedMap = new HashMap<AQuantityKind, Double>();
+		Map<AQuantityKind, Double> mergedMap = new HashMap<AQuantityKind, Double>();
 		mergedMap = qudvHelper.mergeMaps(map1, map2, QudvUnitHelper.QudvCalcMethod.ADD);
 		
 		//check if all four keys are present
@@ -991,5 +991,17 @@ public class QudvUnitHelperTest {
 		
 		String stringRepresentationDouble = qudvHelper.convertToString(qkMap);
 		assertEquals("Correct representation", "T^-3.5 ", stringRepresentationDouble);
+	}
+	
+	@Test
+	public void testGetUndefinedQK() {
+		assertEquals(QudvUnitHelper.UNDEFINED_QK_NAME, qudvHelper.getUndefinedQK().getName());
+	}
+	
+	@Test
+	public void testCreateUndefinedQKMap() {
+		Map<AQuantityKind, Double> undefinedQKMap = qudvHelper.createUndefinedQKMap();
+		assertEquals(1, undefinedQKMap.size());
+		assertEquals(1, undefinedQKMap.get(qudvHelper.getUndefinedQK()), TEST_EPSILON);
 	}
 }

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelper.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelper.java
@@ -1501,6 +1501,10 @@ public class QudvUnitHelper {
 	public static final String UNDEFINED_QK_NAME = "Undefined"; 
 	private AQuantityKind undefinedQuantityKind;
 	
+	/**
+	 * Creates a map containing the undefined QK only
+	 * @return a map containing the undefined QK only
+	 */
 	public Map<AQuantityKind, Double> createUndefinedQKMap() {
 		Map<AQuantityKind, Double> undefinedQKMap = new HashMap<>();
 		undefinedQKMap.put(getUndefinedQK(), Double.NaN);

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelper.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelper.java
@@ -1351,9 +1351,9 @@ public class QudvUnitHelper {
 		}
 
 		boolean flag = false;
-		HashMap<AQuantityKind, Double> outputQKbaseMap = new HashMap<AQuantityKind, Double>();
+		Map<AQuantityKind, Double> outputQKbaseMap = new HashMap<AQuantityKind, Double>();
 		outputQKbaseMap = getBaseQuantityKinds(unit2QK); 
-		HashMap<AQuantityKind, Double> inputQKbaseMap = new HashMap<AQuantityKind, Double>();
+		Map<AQuantityKind, Double> inputQKbaseMap = new HashMap<AQuantityKind, Double>();
 		inputQKbaseMap = getBaseQuantityKinds(unit1QK);
 		
 		//now the only thing left to do is comparing the input and output map
@@ -1406,8 +1406,8 @@ public class QudvUnitHelper {
 	 * @param qk the QuantityKind of which you want to know the base quantity kind
 	 * @return a HashMap with base QuantityKinds
 	 */
-	public HashMap<AQuantityKind, Double> getBaseQuantityKinds(AQuantityKind qk) {
-		HashMap<AQuantityKind, Double> myMap = new HashMap<AQuantityKind, Double>();
+	public Map<AQuantityKind, Double> getBaseQuantityKinds(AQuantityKind qk) {
+		Map<AQuantityKind, Double> myMap = new HashMap<AQuantityKind, Double>();
 		
 		if (qk instanceof DerivedQuantityKind) {
 			DerivedQuantityKind dqk = (DerivedQuantityKind) qk;
@@ -1448,7 +1448,12 @@ public class QudvUnitHelper {
 	 * @param calcMethod QudvCalcMethod defines if exponents should be added or subtracted
 	 * @return the merged Map of QuantityKinds with matching exponents
 	 */
-	public HashMap<AQuantityKind, Double> mergeMaps(Map<AQuantityKind, Double> map1, Map<AQuantityKind, Double> map2, QudvCalcMethod calcMethod) {
+	public Map<AQuantityKind, Double> mergeMaps(Map<AQuantityKind, Double> map1, Map<AQuantityKind, Double> map2, QudvCalcMethod calcMethod) {
+		// Merging a map with the undefined QK with any other map also yields a map containing only the undefined QK
+		if (map1.get(getUndefinedQK()) != null || map2.get(getUndefinedQK()) != null) {
+			return createUndefinedQKMap();
+		}
+		
 		HashMap<AQuantityKind, Double> merged = new HashMap<AQuantityKind, Double>();
 
 		//include elements from the first map and add or subtract values of the second map if they exist
@@ -1507,7 +1512,7 @@ public class QudvUnitHelper {
 	 */
 	public Map<AQuantityKind, Double> createUndefinedQKMap() {
 		Map<AQuantityKind, Double> undefinedQKMap = new HashMap<>();
-		undefinedQKMap.put(getUndefinedQK(), Double.NaN);
+		undefinedQKMap.put(getUndefinedQK(), 1d);
 		return undefinedQKMap;
 	}
 	

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelper.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelper.java
@@ -24,10 +24,10 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.ExtendedMetaData;
-
 import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.emf.ecore.xmi.impl.XMLResourceImpl;
 
+import de.dlr.sc.virsat.model.dvlm.general.GeneralPackage;
 import de.dlr.sc.virsat.model.dvlm.qudv.AQuantityKind;
 import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
 import de.dlr.sc.virsat.model.dvlm.qudv.AffineConversionUnit;
@@ -43,7 +43,6 @@ import de.dlr.sc.virsat.model.dvlm.qudv.SimpleUnit;
 import de.dlr.sc.virsat.model.dvlm.qudv.SystemOfQuantities;
 import de.dlr.sc.virsat.model.dvlm.qudv.SystemOfUnits;
 import de.dlr.sc.virsat.model.dvlm.qudv.UnitFactor;
-import de.dlr.sc.virsat.model.dvlm.general.GeneralPackage;
 import de.dlr.sc.virsat.model.dvlm.types.impl.VirSatUuid;
 
 /**
@@ -383,7 +382,7 @@ public class QudvUnitHelper {
 		return systemOfUnits;
 	}
 		
-	final String dimensionlessQKname = "Dimensionless"; 
+	static final String DIMENSIONLESS_QK_NAME = "Dimensionless"; 
 	
 	AQuantityKind dimensionlessQK;
 	AQuantityKind length;
@@ -447,7 +446,7 @@ public class QudvUnitHelper {
 		factorMap.clear();	
 
 		//create the 8 SI base QuantityKinds as reference in the helper class	
-		dimensionlessQK = createSimpleQuantityKind(dimensionlessQKname, "U", "dimensionlessQK", "");
+		dimensionlessQK = createSimpleQuantityKind(DIMENSIONLESS_QK_NAME, "U", "dimensionlessQK", "");
 		length = createSimpleQuantityKind("Length", "L", "lengthQK", "");
 		mass = createSimpleQuantityKind("Mass", "M", "massQK", "");
 		time = createSimpleQuantityKind("Time", "T", "timeQK", "");
@@ -1326,7 +1325,7 @@ public class QudvUnitHelper {
 			return false;
 		}
 		
-		if (unitQK.getName().equals(dimensionlessQKname)) {
+		if (unitQK.getName().equals(DIMENSIONLESS_QK_NAME)) {
 			return true;
 		}
 		
@@ -1377,13 +1376,13 @@ public class QudvUnitHelper {
 			//if on map is empty we have to check for the special case of dimensionless
 			if (map1.isEmpty()) {
 				for (AQuantityKind key: map2.keySet()) {
-					if (key.getName().equals(dimensionlessQKname)) {
+					if (key.getName().equals(DIMENSIONLESS_QK_NAME)) {
 						areSame = true;
 					}
 				}
 			} else if (map2.isEmpty()) {
 				for (AQuantityKind key: map1.keySet()) {
-					if (key.getName().equals(dimensionlessQKname)) {
+					if (key.getName().equals(DIMENSIONLESS_QK_NAME)) {
 						areSame = true;
 					}
 				}
@@ -1490,13 +1489,36 @@ public class QudvUnitHelper {
 		//remove elements which are dimensionless, because they don't have any influence
 		for (Iterator<Map.Entry<AQuantityKind, Double>> iter = merged.entrySet().iterator(); iter.hasNext();) {
 			Map.Entry<AQuantityKind, Double> entry = iter.next();
-			if (entry.getKey().getName().equals(dimensionlessQKname)) {
+			if (entry.getKey().getName().equals(DIMENSIONLESS_QK_NAME)) {
 				iter.remove();
 				//break; // if we only want to remove the first match.
 			}
 		}
 		
 		return merged;
+	}
+	
+	public static final String UNDEFINED_QK_NAME = "Undefined"; 
+	private AQuantityKind undefinedQuantityKind;
+	
+	public Map<AQuantityKind, Double> createUndefinedQKMap() {
+		Map<AQuantityKind, Double> undefinedQKMap = new HashMap<>();
+		undefinedQKMap.put(getUndefinedQK(), Double.NaN);
+		return undefinedQKMap;
+	}
+	
+	/**
+	 * Gets the QK representing the Undefined Quantity Kind.
+	 * Intended to be used for operations on incompatible quantity kinds.
+	 * Example: Performing an addition where the summands have differing quantity kinds.
+	 * @return the undefined QK
+	 */
+	public AQuantityKind getUndefinedQK() {
+		if (undefinedQuantityKind == null) {
+			undefinedQuantityKind = createSimpleQuantityKind(UNDEFINED_QK_NAME, "UNDEFINED", "undefinedQK", "");
+		}
+		
+		return undefinedQuantityKind;
 	}
 	
 	/**


### PR DESCRIPTION
- Created undefinedQK quantity kind which is now used when performing calculations with non compatible quantity kinds. Example: mass + mass * mass = UNDEFINED.
- Small refactoring replacing HashMap return signatures with Map return signatures
- Small refactoring making the constant dimensionlessQKName a static final string DIMENIONLESS_QK_NAME to keep consistency in naming and declaring constants