### PR TITLE
Removed system exit on port binding exception - (Task #42)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: java
 
+dist: trusty
+
 jdk:
 - oraclejdk8
  

--- a/de.dlr.sc.virsat.model.extension.visualisation/src/de/dlr/sc/virsat/model/extension/visualisation/treemanager/networking/ZMQSocket.java
+++ b/de.dlr.sc.virsat.model.extension.visualisation/src/de/dlr/sc/virsat/model/extension/visualisation/treemanager/networking/ZMQSocket.java
@@ -51,7 +51,6 @@ public class ZMQSocket {
 			}
 		} catch (Exception e) {
 			activator.getLog().log(new Status(Status.ERROR, Activator.getPluginId(), "Error during port binding.", e));
-			System.exit(-1);
 		}
 		socket.setReceiveTimeOut(receiveTimeout);
 	}


### PR DESCRIPTION
Closes #42 
---
Task #42: Don't crash the whole VirSat if visualisation ports are in use