### PR TITLE
Feature/task 79 navigator multiline cut

### DIFF
--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/dvlm/categories/propertyinstances/provider/DVLMValuePropertyInstanceItemProviderTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/dvlm/categories/propertyinstances/provider/DVLMValuePropertyInstanceItemProviderTest.java
@@ -91,6 +91,24 @@ public class DVLMValuePropertyInstanceItemProviderTest {
 		String actual = dvlmUviip.getText(vpi);
 		assertEquals("The output is like expected", EXPECTED, actual);
 	}
+	
+	@Test
+	public void testGetStringTextWithLineEnding() {
+		DVLMValuePropertyInstanceItemProvider dvlmUviip = new DVLMValuePropertyInstanceItemProvider(adapterFactory);
+		
+		final String firstLine = "Line1";
+		final String testString = firstLine + System.getProperty("line.separator") + "Line2";
+		
+		StringProperty sp = PropertydefinitionsFactory.eINSTANCE.createStringProperty();
+		sp.setName("SP");
+		ValuePropertyInstance vpi = PropertyinstancesFactory.eINSTANCE.createValuePropertyInstance();
+		vpi.setType(sp);
+		vpi.setValue(testString);
+		
+		final String EXPECTED = "SP: " + firstLine + "...";
+		String actual = dvlmUviip.getText(vpi);
+		assertEquals("The output is like expected", EXPECTED, actual);
+	}
 
 	@Test
 	public void testCreateSetCommand() {

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/dvlm/categories/propertyinstances/provider/DVLMValuePropertyInstanceItemProviderTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/dvlm/categories/propertyinstances/provider/DVLMValuePropertyInstanceItemProviderTest.java
@@ -97,7 +97,7 @@ public class DVLMValuePropertyInstanceItemProviderTest {
 		DVLMValuePropertyInstanceItemProvider dvlmUviip = new DVLMValuePropertyInstanceItemProvider(adapterFactory);
 		
 		final String firstLine = "Line1";
-		final String testString = firstLine + System.getProperty("line.separator") + "Line2";
+		final String testString = firstLine + System.lineSeparator() + "Line2";
 		
 		StringProperty sp = PropertydefinitionsFactory.eINSTANCE.createStringProperty();
 		sp.setName("SP");

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/dvlm/categories/propertyinstances/provider/DVLMValuePropertyInstanceItemProvider.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/dvlm/categories/propertyinstances/provider/DVLMValuePropertyInstanceItemProvider.java
@@ -25,7 +25,6 @@ import de.dlr.sc.virsat.model.dvlm.command.SetValuePropertyInstanceCommand;
  */
 public class DVLMValuePropertyInstanceItemProvider extends ValuePropertyInstanceItemProvider {
 
-	private static final String LINE_SEPERATOR_PROPERTY = "line.separator";
 	private static final String CUT_APPENDIX = "...";
 	
 	/**
@@ -44,7 +43,7 @@ public class DVLMValuePropertyInstanceItemProvider extends ValuePropertyInstance
 			String value = vpi.getValue() == null ? "" : vpi.getValue();
 
 			//If string is multiline then just show the first line
-			String lineSeperator = System.getProperty(LINE_SEPERATOR_PROPERTY);
+			String lineSeperator = System.lineSeparator();
 			if (value.indexOf(lineSeperator) > 0) {
 				value = value.substring(0, value.indexOf(lineSeperator)) + CUT_APPENDIX;
 			}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/dvlm/categories/propertyinstances/provider/DVLMValuePropertyInstanceItemProvider.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/dvlm/categories/propertyinstances/provider/DVLMValuePropertyInstanceItemProvider.java
@@ -26,6 +26,7 @@ import de.dlr.sc.virsat.model.dvlm.command.SetValuePropertyInstanceCommand;
 public class DVLMValuePropertyInstanceItemProvider extends ValuePropertyInstanceItemProvider {
 
 	private static final String LINE_SEPERATOR_PROPERTY = "line.separator";
+	private static final String CUT_APPENDIX = "...";
 	
 	/**
 	 * this class constructor is an instance of the factory and notifier 
@@ -45,7 +46,7 @@ public class DVLMValuePropertyInstanceItemProvider extends ValuePropertyInstance
 			//If string is multiline then just show the first line
 			String lineSeperator = System.getProperty(LINE_SEPERATOR_PROPERTY);
 			if (value.indexOf(lineSeperator) > 0) {
-				value = value.substring(0, value.indexOf(lineSeperator));
+				value = value.substring(0, value.indexOf(lineSeperator)) + CUT_APPENDIX;
 			}
 			
 			return vpi.getType().getName() + ": " + value;

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/dvlm/categories/propertyinstances/provider/DVLMValuePropertyInstanceItemProvider.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/dvlm/categories/propertyinstances/provider/DVLMValuePropertyInstanceItemProvider.java
@@ -25,6 +25,8 @@ import de.dlr.sc.virsat.model.dvlm.command.SetValuePropertyInstanceCommand;
  */
 public class DVLMValuePropertyInstanceItemProvider extends ValuePropertyInstanceItemProvider {
 
+	private static final String LINE_SEPERATOR_PROPERTY = "line.separator";
+	
 	/**
 	 * this class constructor is an instance of the factory and notifier 
 	 * @param adapterFactory 
@@ -39,6 +41,13 @@ public class DVLMValuePropertyInstanceItemProvider extends ValuePropertyInstance
 		if (object instanceof ValuePropertyInstance) {
 			ValuePropertyInstance vpi = (ValuePropertyInstance) object;
 			String value = vpi.getValue() == null ? "" : vpi.getValue();
+			
+			//If string is multiline then just show the first line
+			String lineSeperator = System.getProperty(LINE_SEPERATOR_PROPERTY);
+			if (value.indexOf(lineSeperator) > 0) {
+				value = value.substring(0, value.indexOf(lineSeperator));
+			}
+			
 			return vpi.getType().getName() + ": " + value;
 		}
 		

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/dvlm/categories/propertyinstances/provider/DVLMValuePropertyInstanceItemProvider.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/dvlm/categories/propertyinstances/provider/DVLMValuePropertyInstanceItemProvider.java
@@ -41,7 +41,7 @@ public class DVLMValuePropertyInstanceItemProvider extends ValuePropertyInstance
 		if (object instanceof ValuePropertyInstance) {
 			ValuePropertyInstance vpi = (ValuePropertyInstance) object;
 			String value = vpi.getValue() == null ? "" : vpi.getValue();
-			
+
 			//If string is multiline then just show the first line
 			String lineSeperator = System.getProperty(LINE_SEPERATOR_PROPERTY);
 			if (value.indexOf(lineSeperator) > 0) {


### PR DESCRIPTION
Fixes string properties with multiple lines in navigator by only showing the first line. 

Labels are shown with all lines in linux eclipse-wide... So there is no simple global fix. But as string properties are more likely to have many lines this at least improves the overview in the navigator.

Closes #79 