### PR TITLE
Don't send unnecessary notifications to editor listener - (Task #299)

### DIFF
--- a/de.dlr.sc.virsat.project/src/de/dlr/sc/virsat/project/editingDomain/VirSatTransactionalEditingDomain.java
+++ b/de.dlr.sc.virsat.project/src/de/dlr/sc/virsat/project/editingDomain/VirSatTransactionalEditingDomain.java
@@ -469,8 +469,9 @@ public class VirSatTransactionalEditingDomain extends TransactionalEditingDomain
 						
 						// Always run all diagnostics
 						for (Resource resource : virSatResourceSet.getResources()) {
-							virSatResourceSet.updateDiagnostic(resource);
-							virSatResourceSet.notifyDiagnosticListeners(resource);
+							if (virSatResourceSet.updateDiagnostic(resource)) {
+								virSatResourceSet.notifyDiagnosticListeners(resource);
+							}
 						}
 						
 						// Rework the dirty states of the resources

--- a/de.dlr.sc.virsat.project/src/de/dlr/sc/virsat/project/markers/VirSatProblemMarkerHelper.java
+++ b/de.dlr.sc.virsat.project/src/de/dlr/sc/virsat/project/markers/VirSatProblemMarkerHelper.java
@@ -365,9 +365,16 @@ public class VirSatProblemMarkerHelper implements IMarkerHelper {
 			markers = getMarkers(eObject, markerId);
 			TreeIterator<EObject> contentsIterator = eObject.eAllContents();
 
-			while (contentsIterator.hasNext()) {
-				EObject child = contentsIterator.next();
-				markers.addAll(getMarkers(child, markerId));
+			try {
+				while (contentsIterator.hasNext()) {
+					EObject child = contentsIterator.next();
+					markers.addAll(getMarkers(child, markerId));
+				}
+			} catch (Exception e) {
+				// We can get an exception if the contents are changed by a new command while we are traversing it
+				// It is probably safe to just ignore it, since all the refreshing will be called again after the new command
+				Activator.getDefault().getLog().log(
+						new Status(Status.WARNING, Activator.getPluginId(), "Error getting problem markers", e));
 			}
 		}
 		

--- a/de.dlr.sc.virsat.project/src/de/dlr/sc/virsat/project/resources/VirSatResourceSet.java
+++ b/de.dlr.sc.virsat.project/src/de/dlr/sc/virsat/project/resources/VirSatResourceSet.java
@@ -1078,8 +1078,10 @@ public class VirSatResourceSet extends ResourceSetImpl implements ResourceSet {
 	 * 
 	 * @param resource
 	 *            the resource of which to update the diagnostic
+	 * @return true iff resource diagnostic changed
 	 */
-	public void updateDiagnostic(Resource resource) {
+	public boolean updateDiagnostic(Resource resource) {
+		boolean changes = false;
 		if (resource != null) {
 			Diagnostic diagnostic = analyzeResourceProblems(resource);
 
@@ -1090,6 +1092,7 @@ public class VirSatResourceSet extends ResourceSetImpl implements ResourceSet {
 
 			if (diagnostic.getSeverity() != Diagnostic.OK) {
 				resourceToDiagnosticMap.put(resource, diagnostic);
+				changes = true;
 				Activator.getDefault().getLog()
 						.log(new Status(Status.INFO, Activator.getPluginId(), Status.INFO,
 								"VirSatResourceSet: Current Diagnostic Map adding Resource ("
@@ -1103,9 +1106,11 @@ public class VirSatResourceSet extends ResourceSetImpl implements ResourceSet {
 											+ resource.getURI().toPlatformString(true) + ")",
 									null));
 					resourceToDiagnosticMap.remove(resource);
+					changes = true;
 				}
 			}
 		}
+		return changes;
 	}
 
 	/**

--- a/de.dlr.sc.virsat.project/src/de/dlr/sc/virsat/project/resources/VirSatResourceSetUtil.java
+++ b/de.dlr.sc.virsat.project/src/de/dlr/sc/virsat/project/resources/VirSatResourceSetUtil.java
@@ -87,7 +87,10 @@ public class VirSatResourceSetUtil {
 			// First try to store the current Resource into Memory
 			InMemoryByteArrayOutputStream inMemoryBuffer = new InMemoryByteArrayOutputStream();
 			try {
+				boolean resourceSendsNotifications = resource.eDeliver();
+				resource.eSetDeliver(false);
 				resource.save(inMemoryBuffer, saveOptions);
+				resource.eSetDeliver(resourceSendsNotifications);
 			} finally {
 				inMemoryBuffer.close();
 			}


### PR DESCRIPTION
- Disabled notifications in resource isChanged
- Don't activate problem marker update in the editor if there was no
change to the resource diagnostic

---
Task #299: Editor update listeners are triggered multiple times on every
command