### PR TITLE
Added refresh after a git update action - (Task #341)

### DIFF
--- a/de.dlr.sc.virsat.team.ui/src/de/dlr/sc/virsat/team/ui/action/git/GitUpdateAction.java
+++ b/de.dlr.sc.virsat.team.ui/src/de/dlr/sc/virsat/team/ui/action/git/GitUpdateAction.java
@@ -59,7 +59,7 @@ public class GitUpdateAction extends AbstractHandler {
 				try {
 					ResourcesPlugin.getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
 				} catch (CoreException e) {
-					Activator.getDefault().getLog().log(new Status(Status.ERROR, Activator.getPluginId(), "Failed to perform a refresh after a git pull! " + e.getMessage()));
+					Activator.getDefault().getLog().log(new Status(Status.ERROR, Activator.getPluginId(), "Failed to perform a refresh after a git pull! " + e.getMessage(), e));
 				}
 			}
 		}; 


### PR DESCRIPTION
- Peforming an update action with git now also triggers a refresh

---
Task #341: Updating with Git doesn't refresh Navigator