### PR TITLE
Updated build.xml with more precise exclusion statements - (Task #367)

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -69,7 +69,8 @@ SPDX-License-Identifier: EPL-2.0
 				<classfiles>
 					<fileset dir="${projectDir}/target/classes">
 						<include name="**/*"/>
-						<exclude name="**/*Test*.class" />
+						<exclude name="**/AllTests.class" />
+						<exclude name="**/*Test.class" />
 						<exclude name="**/model/extension/**/A*.class" />
 						<exclude name="**/AExcelIo.class" />
 						<exclude name="**/parser/antlr/**/*.class" />


### PR DESCRIPTION
- Explicitly excluding the "AllTests" test suite
- Only excluding classes that end with Test instead of having "Test"
somewhere in their name

Closes #367

---
Task #367: Improve code coverage report regarding classes with "Test" in
their name