### PR TITLE
Replaced about.html in team.ui plugin with default about.html - (Task #335)

### DIFF
--- a/de.dlr.sc.virsat.team.ui/about.html
+++ b/de.dlr.sc.virsat.team.ui/about.html
@@ -2,27 +2,26 @@
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1"/>
 <title>About</title>
 </head>
 <body lang="EN-US">
 <h2>About This Content</h2>
  
-<p>July, 2016</p>	
+<p>December 18, 2018</p>	
 <h3>License</h3>
 
-<p>The German Aerospace Center (DLR e.V.) makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
-indicated below, the Content is provided to you for DLR internal use only! Distribution of this content is not permitted</p>
+<p>The German Aerospace Center (DLR) makes available all content in this plug-in (&quot;Content&quot;).  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 2.0 (&quot;EPL&quot;).  A copy of the EPL is available 
+at <a href="https://www.eclipse.org/legal/epl-2.0">https://www.eclipse.org/legal/epl-2.0</a>.
+For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
 
-<h3>Third Party Content</h3>
-
-<p>
-The Content includes items that have been sourced from third parties as set out below. If you 
-did not receive this Content directly from the German Aerospace Center (DLR e.V.), the following is provided 
-for informational purposes only, and you should look to the Redistributor&rsquo;s license for 
-terms and conditions of use. Third party licenses are aggregated in the &quot;about_files&quot; folder of this plugin.
-</p>
-
+<p>If you did not receive this Content directly from German Aerospace Center (DLR), the Content is 
+being redistributed by another party (&quot;Redistributor&quot;) and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to this content.<p>
 
 </body>
 </html>


### PR DESCRIPTION
It seems there was an out-of-date about.html in the team.ui plugin.
Replaced with the new default about html.

---
Task #335: Update about.html in team.ui