### PR TITLE
Only show concept section in palette if there are non-abstract types in it - (Task #400)

### DIFF
--- a/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uieingine/ui/palette/ConceptPaletteView.java
+++ b/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uieingine/ui/palette/ConceptPaletteView.java
@@ -121,21 +121,24 @@ public class ConceptPaletteView extends ViewPart {
 			ActiveConceptConfigurationElement acce = (ActiveConceptConfigurationElement) object;
 			Concept concept = acce.loadConceptFromPlugin();
 			
-			// Create the group entry in the palette
-			GalleryItem conceptGroup = new GalleryItem(gallery, SWT.NONE);
-			if (concept.getDisplayName() != null) {
-				conceptGroup.setText(concept.getDisplayName());
-			} else {
-				conceptGroup.setText(concept.getName());
-			}
-			conceptGroup.setImage(getImage(concept));
-			conceptGroup.setExpanded(false);
-			
 			// Create the actual item entries for the concept
 			List<IConceptTypeDefinition> conceptTypeDefinitions = new ArrayList<>();
 			conceptTypeDefinitions.addAll(concept.getStructuralElements());
 			conceptTypeDefinitions.addAll(concept.getNonAbstractCategories());
-			conceptTypeDefinitions.forEach(conceptTypeDefinition -> createItem(conceptGroup, conceptTypeDefinition));
+			
+			// Create the group entry in the palette
+			if (!conceptTypeDefinitions.isEmpty()) {
+				GalleryItem conceptGroup = new GalleryItem(gallery, SWT.NONE);
+				if (concept.getDisplayName() != null) {
+					conceptGroup.setText(concept.getDisplayName());
+				} else {
+					conceptGroup.setText(concept.getName());
+				}
+				conceptGroup.setImage(getImage(concept));
+				conceptGroup.setExpanded(false);
+				
+				conceptTypeDefinitions.forEach(conceptTypeDefinition -> createItem(conceptGroup, conceptTypeDefinition));
+			}
 		}
 	}
 	


### PR DESCRIPTION
This change hides a concept group from the palette if the concept does not contain any types that can be instantiated.

Closes #400 