### PR TITLE
Only create editor snippet extension if needed

### DIFF
--- a/de.dlr.sc.virsat.model.concept/src/de/dlr/sc/virsat/model/concept/generator/plugin/GenerateUiPluginXml.xtend
+++ b/de.dlr.sc.virsat.model.concept/src/de/dlr/sc/virsat/model/concept/generator/plugin/GenerateUiPluginXml.xtend
@@ -107,7 +107,7 @@ class GenerateUiPluginXml {
 				</menuContribution>
 			</extension>
 			«declareEditorSection(concept)»
-			«IF !concept.categories.empty»
+			«IF !concept.nonAbstractCategories.empty»
 			<extension point="de.dlr.sc.virsat.uiengine.ui.EditorUiSnippets">
 				«FOR category : concept.nonAbstractCategories»
 					«declareUiSnippetTables(concept, category)»

--- a/de.dlr.sc.virsat.model.concept/xtend-gen/de/dlr/sc/virsat/model/concept/generator/plugin/GenerateUiPluginXml.java
+++ b/de.dlr.sc.virsat.model.concept/xtend-gen/de/dlr/sc/virsat/model/concept/generator/plugin/GenerateUiPluginXml.java
@@ -250,7 +250,7 @@ public class GenerateUiPluginXml {
     _builder.append(_declareEditorSection, "\t");
     _builder.newLineIfNotEmpty();
     {
-      boolean _isEmpty = concept.getCategories().isEmpty();
+      boolean _isEmpty = concept.getNonAbstractCategories().isEmpty();
       boolean _not = (!_isEmpty);
       if (_not) {
         _builder.append("\t");


### PR DESCRIPTION
- Fix checking if a editor snippet extension definition is needed not by
empty-check on categories but by non-abstract categories -> abstract
categries do not have UI