### PR TITLE
Return null if IntProperty is not set - (Task #523)

### DIFF
--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyIntTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyIntTest.java
@@ -12,6 +12,7 @@ package de.dlr.sc.virsat.model.concept.types.property;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.eclipse.emf.common.command.Command;
@@ -89,18 +90,21 @@ public class BeanPropertyIntTest extends ABeanPropertyTest {
 		assertEquals("Value correctly set", TEST_INT, beanProperty.getValue());
 	}
 	
-	@Test(expected = NumberFormatException.class)
-	public void testGetValueExceptionNull() {
+	public void testGetValuenNull() {
 		uvpi.setValue(null);
-		beanProperty.getValue();
+		assertNull(beanProperty.getValue());
+	}
+
+	public void testGetValueEmpty() {
+		uvpi.setValue("");
+		assertNull(beanProperty.getValue());
 	}
 
 	@Test(expected = NumberFormatException.class)
-	public void testGetValueExceptionEmpty() {
-		uvpi.setValue("");
+	public void testGetInvalidValue() {
+		uvpi.setValue("invalid");
 		beanProperty.getValue();
 	}
-
 	
 	private Repository repo;
 	private Concept concept;

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyInt.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyInt.java
@@ -49,7 +49,9 @@ public class BeanPropertyInt extends ABeanUnitProperty<Long> {
 	
 	@Override
 	public Long getValue() throws NumberFormatException {
-		String stringValue = isSet() ? ti.getValue() : "";
-		return Long.parseLong(stringValue);
+		if (isSet()) {
+			return Long.parseLong(ti.getValue());
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
Closes #523

---
Task #523 If an IntProperty is not set, getValue() in a bean should
return null instead of exception