### PR TITLE
Fix NPE in ScrollRedirectListner if no scroallable parent exists

### DIFF
--- a/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/swt/forms/VirSatMouseWheelScrollRedirectListener.java
+++ b/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/swt/forms/VirSatMouseWheelScrollRedirectListener.java
@@ -44,7 +44,9 @@ public class VirSatMouseWheelScrollRedirectListener implements MouseWheelListene
 	 */
 	public void init() {
 		this.redirectScrolledForm = findNextParentScrolledForm(scrollable);
-		this.redirectScrollBar = redirectScrolledForm.getVerticalBar();
+		if (redirectScrolledForm != null) {
+			this.redirectScrollBar = redirectScrolledForm.getVerticalBar();
+		}
 	}
 	
 	@Override


### PR DESCRIPTION
- Fix a NPE if the scrollable form of which events are redirected does
not have a parent form that is scrollable

Closes #466 