### PR TITLE
Remove obsolete method in inheritance copier

### DIFF
--- a/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopierTest.java
+++ b/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopierTest.java
@@ -1264,7 +1264,7 @@ public class InheritanceCopierTest extends AInheritanceCopierTest {
 	
 	@Test
 	public void testCopyComposedPropertyInstance() {
-		seiEo1RwI.getSuperSeis().remove(seiEcRwI);
+		
 		// Create a category coontaining a composed property having as type a category
 		// that is not applicable for anything
 		

--- a/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopierTest.java
+++ b/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopierTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.junit.Test;
 
 import de.dlr.sc.virsat.model.dvlm.calculation.AExpression;
@@ -1238,47 +1239,39 @@ public class InheritanceCopierTest extends AInheritanceCopierTest {
 	}
 	
 	@Test
-	public void testCleanRootTis() {
+	public void testInheritDeleteRootCaInDiamondInheritance() {
+		// Build a diamond shaped inheritance formation
+		CategoryAssignment rootIfe = attachInterfaceEnd(seiEdRw, "IfeRoot");
+		
+		assertTrue("Initially, there is no attached CA", seiEo1RwI.getCategoryAssignments().isEmpty());
 		
 		InheritanceCopier ic = new InheritanceCopier();
-		CategoryAssignment ife = attachInterfaceEnd(seiEo1RwI, "Ife");
-		CategoryAssignment ifeSuper1 = attachInterfaceEnd(seiEcRwI, "IfeSuper1");
 		
-		ife.getSuperTis().add(ifeSuper1);
+		// Update the seis relevant to this test case
+		ic.updateStep(seiEcRwI);
+		ic.updateStep(seiErRwA);
+		ic.updateStep(seiEo1RwI);
 		
-		ic.cleanRootTis(seiEo1RwI);
-		assertThat("Super TI with unique root not touched", seiEo1RwI.getCategoryAssignments(), hasItems(ife));
+		assertEquals("Element has correct number of CAs", 1, seiEo1RwI.getCategoryAssignments().size());
+		CategoryAssignment inheritedCa = seiEo1RwI.getCategoryAssignments().get(0);
+		Set<IInheritanceLink> rootTis = InheritanceCopier.getRootSuperTypeInstance(inheritedCa);
+		assertThat("Element has correct root CA", rootTis, hasItem(rootIfe));
+		assertEquals("Element has only one root CA", 1, rootTis.size());
 		
-		CategoryAssignment ifeSuper2 = attachInterfaceEnd(seiErRwA, "IfeSuper2");
-		ife.getSuperTis().add(ifeSuper2);
+		// Delete the root CA
+		EcoreUtil.delete(rootIfe);
 		
-		ic.cleanRootTis(seiEo1RwI);
-		assertTrue("Super TIs with multiple root TIs cleaned", seiEo1RwI.getCategoryAssignments().isEmpty());
-	}
-	
-	@Test
-	public void testCleanRootTisValid() {
-		CategoryAssignment ife = attachInterfaceEnd(seiEo1RwI, "Ife");
-		CategoryAssignment superIfe1 = attachInterfaceEnd(seiEcRwI, "IfeSuper1");
-		CategoryAssignment superIfe2 = attachInterfaceEnd(seiErRwA, "IfeSuper2");
-		CategoryAssignment superSuperIfe = attachInterfaceEnd(seiEdRw, "IfeSuperSuper");
+		// Update the seis relevant to this test case
+		ic.updateStep(seiEcRwI);
+		ic.updateStep(seiErRwA);
+		ic.updateStep(seiEo1RwI);
 		
-		ife.getSuperTis().add(superIfe1);
-		ife.getSuperTis().add(superIfe2);
-		superIfe1.getSuperTis().add(superSuperIfe);
-		superIfe2.getSuperTis().add(superSuperIfe);
-		
-		assertThat("Element has correct CA", seiEo1RwI.getCategoryAssignments(), hasItems(ife));
-		
-		InheritanceCopier ic = new InheritanceCopier();
-		ic.cleanRootTis(seiEo1RwI);
-
-		assertThat("Element still has correct CA", seiEo1RwI.getCategoryAssignments(), hasItems(ife));
+		assertTrue("The now invalid CA has been correctly removed", seiEo1RwI.getCategoryAssignments().isEmpty());
 	}
 	
 	@Test
 	public void testCopyComposedPropertyInstance() {
-		
+		seiEo1RwI.getSuperSeis().remove(seiEcRwI);
 		// Create a category coontaining a composed property having as type a category
 		// that is not applicable for anything
 		

--- a/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopierTest.java
+++ b/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopierTest.java
@@ -1038,7 +1038,6 @@ public class InheritanceCopierTest extends AInheritanceCopierTest {
 		assertFalse("Update is not needed since the Configuration is not the last inherited", ic.needsUpdateInOrder(seiEo1RwI));
 	}
 	
-	
 	@Test
 	public void testUpdateWithAssignedDisciplines() {
 		final String TEST_VAL_1 = "1234";
@@ -1128,6 +1127,29 @@ public class InheritanceCopierTest extends AInheritanceCopierTest {
 		assertFalse("Update is done", ic.needsUpdateStep(seiEo2RwI));
 		
 		assertFalse("Update was done before, now all superSeis are updated, but no additional information was transferred with this", ic.needsUpdateInOrder(seiEo1RwI));
+	}
+	
+	@Test
+	public void testUpdateDeleteRootCaInDiamondInheritance() {
+		// Build a diamond shaped inheritance formation
+		CategoryAssignment rootIfe = attachInterfaceEnd(seiEdRw, "IfeRoot");
+		
+		assertTrue("Initially, there is no attached CA", seiEo1RwI.getCategoryAssignments().isEmpty());
+		
+		InheritanceCopier ic = new InheritanceCopier();
+		ic.updateAllInOrder(repo, new NullProgressMonitor());
+		
+		assertEquals("Element has correct number of CAs", 1, seiEo1RwI.getCategoryAssignments().size());
+		CategoryAssignment inheritedCa = seiEo1RwI.getCategoryAssignments().get(0);
+		Set<IInheritanceLink> rootTis = InheritanceCopier.getRootSuperTypeInstance(inheritedCa);
+		assertThat("Element has correct root CA", rootTis, hasItem(rootIfe));
+		assertEquals("Element has only one root CA", 1, rootTis.size());
+		
+		// Delete the root CA
+		EcoreUtil.delete(rootIfe);
+		ic.updateAllInOrder(repo, new NullProgressMonitor());
+		
+		assertTrue("The now invalid CA has been correctly removed", seiEo1RwI.getCategoryAssignments().isEmpty());
 	}
 	
 	/**
@@ -1236,37 +1258,6 @@ public class InheritanceCopierTest extends AInheritanceCopierTest {
 		
 		assertFalse("Not Inherited IFE doesnt have inheritance flag set", seiEo1RwI.getCategoryAssignments().get(0).isIsInherited());
 		assertTrue("Inherited IFE has inheritance flag set", seiEo1RwI.getCategoryAssignments().get(1).isIsInherited());
-	}
-	
-	@Test
-	public void testInheritDeleteRootCaInDiamondInheritance() {
-		// Build a diamond shaped inheritance formation
-		CategoryAssignment rootIfe = attachInterfaceEnd(seiEdRw, "IfeRoot");
-		
-		assertTrue("Initially, there is no attached CA", seiEo1RwI.getCategoryAssignments().isEmpty());
-		
-		InheritanceCopier ic = new InheritanceCopier();
-		
-		// Update the seis relevant to this test case
-		ic.updateStep(seiEcRwI);
-		ic.updateStep(seiErRwA);
-		ic.updateStep(seiEo1RwI);
-		
-		assertEquals("Element has correct number of CAs", 1, seiEo1RwI.getCategoryAssignments().size());
-		CategoryAssignment inheritedCa = seiEo1RwI.getCategoryAssignments().get(0);
-		Set<IInheritanceLink> rootTis = InheritanceCopier.getRootSuperTypeInstance(inheritedCa);
-		assertThat("Element has correct root CA", rootTis, hasItem(rootIfe));
-		assertEquals("Element has only one root CA", 1, rootTis.size());
-		
-		// Delete the root CA
-		EcoreUtil.delete(rootIfe);
-		
-		// Update the seis relevant to this test case
-		ic.updateStep(seiEcRwI);
-		ic.updateStep(seiErRwA);
-		ic.updateStep(seiEo1RwI);
-		
-		assertTrue("The now invalid CA has been correctly removed", seiEo1RwI.getCategoryAssignments().isEmpty());
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopierTest.java
+++ b/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopierTest.java
@@ -1131,7 +1131,7 @@ public class InheritanceCopierTest extends AInheritanceCopierTest {
 	
 	@Test
 	public void testUpdateDeleteRootCaInDiamondInheritance() {
-		// Build a diamond shaped inheritance formation
+		// Attach a CA to the root of a diamond shaped inheritance formation
 		CategoryAssignment rootIfe = attachInterfaceEnd(seiEdRw, "IfeRoot");
 		
 		assertTrue("Initially, there is no attached CA", seiEo1RwI.getCategoryAssignments().isEmpty());
@@ -1140,6 +1140,8 @@ public class InheritanceCopierTest extends AInheritanceCopierTest {
 		ic.updateAllInOrder(repo, new NullProgressMonitor());
 		
 		assertEquals("Element has correct number of CAs", 1, seiEo1RwI.getCategoryAssignments().size());
+		
+		// Verify that the newly inherited CA is linked correctly
 		CategoryAssignment inheritedCa = seiEo1RwI.getCategoryAssignments().get(0);
 		Set<IInheritanceLink> rootTis = InheritanceCopier.getRootSuperTypeInstance(inheritedCa);
 		assertThat("Element has correct root CA", rootTis, hasItem(rootIfe));

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopier.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopier.java
@@ -190,7 +190,6 @@ public class InheritanceCopier implements IInheritanceCopier {
 			// Clean old super Tis that may no longer have valid links
 			cleanSuperTis(subSei);
 			cleanCas(subSei);
-			cleanRootTis(subSei);
 			
 			// Do the Pre-loading here. Pre-loading means that we have to load all necessary
 			// copied objects from the current tree, that might be referenced.
@@ -817,22 +816,5 @@ public class InheritanceCopier implements IInheritanceCopier {
 		for (IInheritanceLink childTi : childTypeInstances) {
 			childTi.getSuperTis().retainAll(allSuperTis);
 		}
-	}
-	
-	/**
-	 * If there is a Type Instance contained in the SEI it will be deleted 
-	 * and there will be build new once by the Inheritance Builder according to the root Tis  
-	 * @param sei The Sei to be checked
-	 */
-	public void cleanRootTis(StructuralElementInstance sei) {
-		List<CategoryAssignment> cas = new ArrayList<>(sei.getCategoryAssignments());
-		
-		for (CategoryAssignment ca : cas) {
-			Set<IInheritanceLink> rootSuperTis = getRootSuperTypeInstance(ca);
-			if (rootSuperTis.size() > 1) {
-				EcoreUtil.delete(ca);
-			}
-		}
-		
 	}
 }


### PR DESCRIPTION
- Removed cleanRootTis method.  The correct cleaning of instances, whose super tis have been deleted, is handled in the cleanSuperTis method.
- Added a more integration like test case to verify that the cleanSuperTis method is indeed enough to handle cleanup of invalidated instances in the case of a diamond shaped inheritance case