### PR TITLE
Sortable columns in QUDV Editor

### DIFF
--- a/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/navigator/commonSorter/LabelColumnSorter.java
+++ b/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/navigator/commonSorter/LabelColumnSorter.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2020 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.project.ui.navigator.commonSorter;
+
+import org.eclipse.jface.viewers.ITableLabelProvider;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerComparator;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.TableColumn;
+
+public class LabelColumnSorter extends ViewerComparator {
+	
+	private TableViewer tableViewer;
+	private ITableLabelProvider labelProvider;
+	
+	private int lastSelectedColumnIndex;
+	private boolean isAscending;
+
+	public LabelColumnSorter(TableViewer tableViewer) {
+		this.tableViewer = tableViewer;
+	}
+	
+	public void setLabelProvider(ITableLabelProvider labelProvider) {
+		this.labelProvider = labelProvider;
+	}
+
+	@Override
+	public int compare(Viewer viewer, Object o1, Object o2) {
+		String text1 = labelProvider.getColumnText(o1, lastSelectedColumnIndex);
+		String text2 = labelProvider.getColumnText(o2, lastSelectedColumnIndex);
+		
+		if (isAscending) {
+			return text1.compareTo(text2);
+		} else {
+			return text2.compareTo(text1);
+		}
+	}
+
+	/**
+	 * React to the selection of a column
+	 * @param column the the selected column
+	 * @param columnIndex the index of the selected column
+	 */
+	public void onSelectColumn(TableColumn column, int columnIndex) {
+		if (columnIndex == lastSelectedColumnIndex) {
+			// We selected the same column again, so we now change the sorting order
+			isAscending = !isAscending;
+		} else {
+			// We selected a new column, so now we sort according to that one
+			lastSelectedColumnIndex = columnIndex;
+			isAscending = true;
+		}
+		
+		tableViewer.getTable().setSortColumn(column);
+		tableViewer.getTable().setSortDirection(isAscending ? SWT.UP : SWT.DOWN);
+		
+		// The comparator requires the label provider, so if that is not set yet, we must not refresh
+		if (labelProvider != null) {
+			// We only want to update the order (and not the labels) so we turn label update off
+			tableViewer.refresh(false);
+		}
+	}
+}

--- a/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/navigator/commonSorter/LabelColumnSorter.java
+++ b/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/navigator/commonSorter/LabelColumnSorter.java
@@ -16,6 +16,12 @@ import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.TableColumn;
 
+/**
+ * This class provides capabilties to sort table columns according to
+ * the text given by a label provider and a sorting direction (ascending, descending).
+ *
+ */
+
 public class LabelColumnSorter extends ViewerComparator {
 	
 	private TableViewer tableViewer;
@@ -62,7 +68,7 @@ public class LabelColumnSorter extends ViewerComparator {
 		tableViewer.getTable().setSortColumn(column);
 		tableViewer.getTable().setSortDirection(isAscending ? SWT.UP : SWT.DOWN);
 		
-		// The comparator requires the label provider, so if that is not set yet, we must not refresh
+		// The comparator requires the label provider, so if that is not set at this point, we must not refresh
 		if (labelProvider != null) {
 			// We only want to update the order (and not the labels) so we turn label update off
 			tableViewer.refresh(false);

--- a/de.dlr.sc.virsat.qudv.ui/src/de/dlr/sc/virsat/qudv/ui/editor/snippets/UiSnippetUnitManagement.java
+++ b/de.dlr.sc.virsat.qudv.ui/src/de/dlr/sc/virsat/qudv/ui/editor/snippets/UiSnippetUnitManagement.java
@@ -17,14 +17,18 @@ import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.jface.viewers.IContentProvider;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.ITableLabelProvider;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.jface.viewers.TableViewerColumn;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Table;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.forms.widgets.FormToolkit;
+
 import de.dlr.sc.virsat.model.dvlm.qudv.AConversionBasedUnit;
 import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
 import de.dlr.sc.virsat.model.dvlm.qudv.DerivedUnit;
@@ -35,6 +39,7 @@ import de.dlr.sc.virsat.model.dvlm.units.UnitsPackage;
 import de.dlr.sc.virsat.project.resources.VirSatResourceSet;
 import de.dlr.sc.virsat.project.ui.contentProvider.VirSatFilteredWrappedTreeContentProvider;
 import de.dlr.sc.virsat.project.ui.labelProvider.VirSatTransactionalAdapterFactoryLabelProvider;
+import de.dlr.sc.virsat.project.ui.navigator.commonSorter.LabelColumnSorter;
 import de.dlr.sc.virsat.qudv.ui.wizards.ConversionBasedUnitWizard;
 import de.dlr.sc.virsat.qudv.ui.wizards.DerivedUnitWizard;
 import de.dlr.sc.virsat.qudv.ui.wizards.PrefixedUnitWizard;
@@ -55,6 +60,9 @@ public class UiSnippetUnitManagement extends AUiSnippetEStructuralFeatureTable i
 	private Button buttonAdd;
 	private Button buttonRemove;
 	private Button buttonEdit;
+
+	private ITableLabelProvider labelProvider;
+	private LabelColumnSorter labelColumnSorter;
 	
 	private static final String BUTTON_ADD_TEXT = "Add Unit";
 	private static final String BUTTON_REMOVE_TEXT = "Remove Unit";
@@ -88,8 +96,6 @@ public class UiSnippetUnitManagement extends AUiSnippetEStructuralFeatureTable i
 	
 	@Override
 	protected ITableLabelProvider getTableLabelProvider() {
-		VirSatTransactionalAdapterFactoryLabelProvider labelProvider;
-		
 		labelProvider = new VirSatTransactionalAdapterFactoryLabelProvider(adapterFactory) {
 			@Override
 			public String getColumnText(Object object, int columnIndex) {
@@ -112,20 +118,41 @@ public class UiSnippetUnitManagement extends AUiSnippetEStructuralFeatureTable i
 			}
 		};
 		
+		labelColumnSorter.setLabelProvider(labelProvider);
 		return labelProvider;		
 	}
 	
 	@Override
-	protected void createTableColumns(EditingDomain editingDomain) {
-	    // Column Unit Name
-		createDefaultColumn(tableViewer, COLUMN_TEXT_UNIT_NAME);
+	protected void setUpTableViewer(EditingDomain editingDomain, Table table) {
+		super.setUpTableViewer(editingDomain, table);
+		
+		labelColumnSorter = new LabelColumnSorter(tableViewer);
+		tableViewer.setComparator(labelColumnSorter);
+	}
 	
+	@Override
+	protected void createTableColumns(EditingDomain editingDomain) {
+		// Column Unit Name
+		TableViewerColumn nameColumn = createDefaultColumn(tableViewer, COLUMN_TEXT_UNIT_NAME);
+		labelColumnSorter.onSelectColumn(nameColumn.getColumn(), 0);
+		
 		// Column Symbol
 		createDefaultColumn(tableViewer, COLUMN_TEXT_SYMBOL);
-		//	colSymbol.setEditingSupport(PropertyInstanceEditingSupportFactory.INSTANCE.createEditingSupportFor(editingDomain, tableViewer, property));
-
+		
 		//Column QuantityKind
 		createDefaultColumn(tableViewer, COLUMN_TEXT_QK);
+	}
+	
+	@Override
+	protected TableViewerColumn createDefaultColumn(TableViewer tableViewer, String columnText) {
+		TableViewerColumn column = super.createDefaultColumn(tableViewer, columnText);
+		// Columns dont have a get index method so we need to grab the information from the table
+		int columnIndex = tableViewer.getTable().getColumnCount() - 1;
+		column.getColumn().addSelectionListener(SelectionListener.widgetSelectedAdapter(
+			event -> labelColumnSorter.onSelectColumn(column.getColumn(), columnIndex)
+		));
+		
+		return column;
 	}
 	
 	@Override
@@ -224,5 +251,4 @@ public class UiSnippetUnitManagement extends AUiSnippetEStructuralFeatureTable i
 		}
 		return null;
 	}
-
 }

--- a/de.dlr.sc.virsat.qudv.ui/src/de/dlr/sc/virsat/qudv/ui/editor/snippets/UiSnippetUnitManagement.java
+++ b/de.dlr.sc.virsat.qudv.ui/src/de/dlr/sc/virsat/qudv/ui/editor/snippets/UiSnippetUnitManagement.java
@@ -123,8 +123,8 @@ public class UiSnippetUnitManagement extends AUiSnippetEStructuralFeatureTable i
 	}
 	
 	@Override
-	protected void setUpTableViewer(EditingDomain editingDomain, Table table) {
-		super.setUpTableViewer(editingDomain, table);
+	protected void createTableViewer(Table table) {
+		super.createTableViewer(table);
 		
 		labelColumnSorter = new LabelColumnSorter(tableViewer);
 		tableViewer.setComparator(labelColumnSorter);

--- a/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/editor/snippets/AUiSnippetEStructuralFeatureTable.java
+++ b/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/editor/snippets/AUiSnippetEStructuralFeatureTable.java
@@ -152,16 +152,24 @@ public abstract class AUiSnippetEStructuralFeatureTable extends AUiEStructuralFe
 	 * @param table The Table which should be set in the TableViewer
 	 */
 	protected void setUpTableViewer(EditingDomain editingDomain, Table table) {
-		tableViewer = new TableViewer(table);
-		tableViewer.setContentProvider(getTableContentProvider());
-		
+		createTableViewer(table);
 		createTableColumns(editingDomain);
 		
-		if (getTableLabelProvider() != null) {
-			tableViewer.setLabelProvider(getTableLabelProvider());
+		ITableLabelProvider labelProvider = getTableLabelProvider();
+		if (labelProvider != null) {
+			tableViewer.setLabelProvider(labelProvider);
 		}
-	
+		
 		setTableViewerInput(editingDomain);
+	}
+	
+	/**
+	 * Creates the actual table viewer
+	 * @param table The Table which should be set in the TableViewer
+	 */
+	protected void createTableViewer(Table table) {
+		tableViewer = new TableViewer(table);
+		tableViewer.setContentProvider(getTableContentProvider());
 	}
 	
 	/**


### PR DESCRIPTION
Implemented new LabelColumnSorter that provides generic functionality to sort a table according to 
* a selected column by the user,
* a sort direction (ascending, descending),
* and the label of the objects.

Small refactoring in generic snippets to exract creation process of a table viewer to make it easier to override just that logic instead of the entire setup process of the table viewer

Have some funny picture:

![sorting](https://user-images.githubusercontent.com/48356419/83634196-6a01a880-a5a2-11ea-9527-263b99d9115e.png)

By default the tables are sorted ascending by Unit Name and Quantitiy Kind Name.

Apparantly you cant customize the placement of the sorting indicator (the arrow thing), as that seems to be somehow determined by the operating system.

Closes #30 