### PR TITLE
convertFromSourceToTarget now throws IllegalArgumentException for mismatching QKs

### DIFF
--- a/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelperTest.java
+++ b/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelperTest.java
@@ -80,8 +80,8 @@ public class QudvUnitHelperTest {
 		String uuid2 = simpleUnit2.getUuid().toString();
 		
 		assertNotSame(uuid1, uuid2);
-	
 	}
+	
 	@Test
 	public void createPrefixedUnitTest() {
 		
@@ -111,7 +111,6 @@ public class QudvUnitHelperTest {
 		String uuid2 = prefixedUnit2.getUuid().toString();
 		
 		assertNotSame(uuid1, uuid2);
-	
 	}
 	
 	@Test
@@ -145,7 +144,6 @@ public class QudvUnitHelperTest {
 		String uuid2 = affineConversionUnit2.getUuid().toString();
 		
 		assertNotSame(uuid1, uuid2);
-	
 	}
 	
 	@Test
@@ -177,7 +175,6 @@ public class QudvUnitHelperTest {
 		String uuid2 = linearConversionUnit2.getUuid().toString();
 		
 		assertNotSame(uuid1, uuid2);
-	
 	}
 	
 	@Test
@@ -202,9 +199,7 @@ public class QudvUnitHelperTest {
 		String uuid2 = simpleQuantityKind2.getUuid().toString();
 		
 		assertNotSame(uuid1, uuid2);
-	
 	}
-	
 	
 	@Test
 	public void qudvImportExportTest() throws IOException {
@@ -289,10 +284,8 @@ public class QudvUnitHelperTest {
 		assertEquals("Retrieved quantitiy kinds has 1 item", retrivedQuantityKinds.size(), 1);
 	}
 
-
 	@Test
-	public void convertToTargetUnitTest() {
-	
+	public void convertFromSourceToTargetUnitTest() {
 		//we simply use the the library to set up the systemOfUnits in the background 
 		SystemOfUnits sou1 = QudvUnitHelper.getInstance().initializeSystemOfUnits("SystemOfUnits", "SoU", "This is the system of units for this study", "N/A");
 		
@@ -313,7 +306,17 @@ public class QudvUnitHelperTest {
 		final double THIRTY_SIX = 36.0;
 		convertedValue = QudvUnitHelper.getInstance().convertFromSourceToTargetUnit(meterPerSecond, TEN, kilometerPerHour);
 		assertEquals(THIRTY_SIX, convertedValue, TEST_EPSILON);
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void convertFromSourceToTargetUnitIncompatibleQuantityKindsTest() {
+		//we simply use the the library to set up the systemOfUnits in the background 
+		SystemOfUnits sou1 = QudvUnitHelper.getInstance().initializeSystemOfUnits("SystemOfUnits", "SoU", "This is the system of units for this study", "N/A");
 		
+		// grab two units with incompatible quantity kinds
+		AUnit percentUnit = QudvUnitHelper.getInstance().getUnitByName(sou1, "Percent");
+		AUnit meterPerSecond = QudvUnitHelper.getInstance().getUnitByName(sou1, "Meter Per Second");
+		QudvUnitHelper.getInstance().convertFromSourceToTargetUnit(percentUnit, 0, meterPerSecond);
 	}
 	
 	@Test
@@ -442,7 +445,6 @@ public class QudvUnitHelperTest {
 		//if both are not set, it should return false as well
 		pound = qudvHelper.createSimpleUnit("pound", "pd", "pound of coffee", "http://pound.virsat.dlr.de", null);
 		assertFalse(qudvHelper.haveSameQuantityKind(g, pound));
-
 	}
 	
 	@Test
@@ -488,7 +490,6 @@ public class QudvUnitHelperTest {
 		map2.put(length, 2.0);
 		assertFalse(qudvHelper.haveSameQuantityKind(map1, map2));
 		assertFalse(qudvHelper.haveSameQuantityKind(map2, map1));
-		
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelper.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/qudv/util/QudvUnitHelper.java
@@ -1159,12 +1159,11 @@ public class QudvUnitHelper {
 	 * @param targetUnit the target unit in which you want your unit to be converted in
 	 * @return the converted value
 	 */
-	public double convertFromSourceToTargetUnit(AUnit sourceUnit, double sourceValue, AUnit targetUnit) {
+	public double convertFromSourceToTargetUnit(AUnit sourceUnit, double sourceValue, AUnit targetUnit) throws IllegalArgumentException {
 		double convertedValue = 0.0;
 		if (!haveSameQuantityKind(sourceUnit, targetUnit)) {
-			//conversion is not possible so we return the unconverted value!
-			//pipe a message to the Logger!
-			return sourceValue;
+			throw new IllegalArgumentException("Cannot convert from " + sourceUnit.getName() + " to " + targetUnit.getName() 
+			+ " as they have different quantitiy kinds!");
 		}
 		
 		//we convert the source Unit to the basUnits and then to the given target unit


### PR DESCRIPTION
- Throwing an exception when the method convertFromSourceToTarget is called for units that have mismatching QKs (previous behavior was silently saying ok and just passing back the original value)
- Added a test case to verify that the exception is correctly thrown.
- Removed some unnecessary whitespaces

Though, apparantly nobody is actually even calling this function...?!

Closes #89

---
Task #89: Unit conversion Qudv is returning undesired value