### PR TITLE
Replaced force delete with quiet delete - (Task #629)

### DIFF
--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/dataaccess/VirSatGitAccessTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/dataaccess/VirSatGitAccessTest.java
@@ -65,9 +65,9 @@ public class VirSatGitAccessTest {
 	@After
 	public void tearDown() throws Exception {
 		gitUpstream.close();
-		FileUtils.forceDelete(absolutePathToTempUpstreamRepository);
-		FileUtils.forceDelete(makeAbsolute(relativePathToTempLocalRepository1));
-		FileUtils.forceDelete(makeAbsolute(relativePathToTempLocalRepository2));
+		FileUtils.deleteQuietly(absolutePathToTempUpstreamRepository);
+		FileUtils.deleteQuietly(makeAbsolute(relativePathToTempLocalRepository1));
+		FileUtils.deleteQuietly(makeAbsolute(relativePathToTempLocalRepository2));
 	}
 
 	@Test


### PR DESCRIPTION
- [x] Done

The issue seems to be that git is cleaning up some files while the apache code for deleting the directory is being executed. So he fails to delete the directory because he cant delete a file in it which has has already been deleted.

Replaced the forceDelete call by a quietDelete call. According to the API quietDelete should behave as forceDelete except that it doesnt throw any exceptions. I dont think there is a point for introducing some elaborate exception handling scheme in the tear down which should simply just delete a directory......

Closes #629 

---
Task #629: Server test case sometimes fails due to locked file