### PR TITLE
Changed handling of nested categories in set functions - (Task #635)

### DIFF
--- a/de.dlr.sc.virsat.model.calculation.test/src/de/dlr/sc/virsat/model/calculation/compute/ExpressionHelperTest.java
+++ b/de.dlr.sc.virsat.model.calculation.test/src/de/dlr/sc/virsat/model/calculation/compute/ExpressionHelperTest.java
@@ -971,7 +971,7 @@ public class ExpressionHelperTest extends AEquationTest {
 		// root
 		//	-- CA: State
 		//	-- PI: totalValue
-		//	-- Eq: Power.value = summary{Power.value}
+		//	-- Eq: totalValue = summary{Power.value}
 		//	---- CA: Power
 		//	------ PI: value
 		StructuralElementInstance seiRoot = createStructuralElementInstance("System", se);

--- a/de.dlr.sc.virsat.model.calculation.test/src/de/dlr/sc/virsat/model/calculation/compute/ExpressionHelperTest.java
+++ b/de.dlr.sc.virsat.model.calculation.test/src/de/dlr/sc/virsat/model/calculation/compute/ExpressionHelperTest.java
@@ -874,7 +874,7 @@ public class ExpressionHelperTest extends AEquationTest {
 	}
 	
 	@Test
-	public void testNestedSetFunction() {
+	public void testNestedSeisSetFunction() {
 		// Create a common root category
 		Category cat = createCategory("Mass");
 		IntProperty value = PropertydefinitionsFactory.eINSTANCE.createIntProperty();
@@ -934,6 +934,54 @@ public class ExpressionHelperTest extends AEquationTest {
 		
 		NumberLiteralResult resultExpression1 = (NumberLiteralResult) exprHelper.evaluate(caRoot.getEquationSection().getEquations().get(0).getExpression());
 		assertEquals("Summary correct", 1, Double.valueOf(resultExpression1.getNumberLiteral().getValue()), EPSILON);
+	}
+	
+	@Test
+	public void testNestedCasSetFunction() {
+		// Create a contained category
+		Category catPower = createCategory("Power");
+		IntProperty value = PropertydefinitionsFactory.eINSTANCE.createIntProperty();
+		value.setName("value");
+		value.setDefaultValue("1");
+		catPower.getProperties().add(value);
+		
+		// Create a container caetgory
+		Category catState = createCategory("State");
+		IntProperty totalValue = PropertydefinitionsFactory.eINSTANCE.createIntProperty();
+		ComposedProperty powerProperty = PropertydefinitionsFactory.eINSTANCE.createComposedProperty();
+		powerProperty.setType(catPower);
+		totalValue.setName("totalValue");
+		catState.getProperties().add(totalValue);
+		catState.getProperties().add(powerProperty);
+		
+		// Setup a summary equation in the category
+		EquationDefinition eqDef = CalculationFactory.eINSTANCE.createEquationDefinition();
+		TypeDefinitionResult tdResult = CalculationFactory.eINSTANCE.createTypeDefinitionResult();
+		tdResult.setReference(value);
+		
+		SetFunction summary = CalculationFactory.eINSTANCE.createSetFunction();
+		summary.setOperator("summary");
+		summary.setTypeDefinition(value);
+		
+		eqDef.setResult(tdResult);
+		eqDef.setExpression(summary);
+		catState.getEquationDefinitions().add(eqDef);
+		
+		// Setup the data model:
+		// root
+		//	-- CA: State
+		//  -- PI: totalValue
+		//	-- Eq: Power.value = summary{Power.value}
+		//	---- CA: Power
+		//	------ PI: value
+		StructuralElementInstance seiRoot = createStructuralElementInstance("System", se);
+		CategoryAssignment caRoot = new CategoryInstantiator().generateInstance(catState, "power");
+		seiRoot.getCategoryAssignments().add(caRoot);
+		
+		createResources();
+		
+		NumberLiteralResult resultExpression = (NumberLiteralResult) exprHelper.evaluate(caRoot.getEquationSection().getEquations().get(0).getExpression());
+		assertEquals("Summary correct", 1, Double.valueOf(resultExpression.getNumberLiteral().getValue()), EPSILON);
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.model.calculation.test/src/de/dlr/sc/virsat/model/calculation/compute/ExpressionHelperTest.java
+++ b/de.dlr.sc.virsat.model.calculation.test/src/de/dlr/sc/virsat/model/calculation/compute/ExpressionHelperTest.java
@@ -970,7 +970,7 @@ public class ExpressionHelperTest extends AEquationTest {
 		// Setup the data model:
 		// root
 		//	-- CA: State
-		//  -- PI: totalValue
+		//	-- PI: totalValue
 		//	-- Eq: Power.value = summary{Power.value}
 		//	---- CA: Power
 		//	------ PI: value

--- a/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/compute/ExpressionHelper.java
+++ b/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/compute/ExpressionHelper.java
@@ -322,9 +322,11 @@ public class ExpressionHelper {
 				// Get all nested TypeInstances to the current treeSei and see if one
 				// is matching to the definition of what is referenced by the SET function
 				List<CategoryAssignment> currentCas = new LinkedList<>(treeSei.getCategoryAssignments());
-				currentCas.remove(currentCa);
+			
 				Collection<ATypeInstance> typeInstances = VirSatEcoreUtil.getAllContentsOfType(currentCas, ATypeInstance.class, true);
 				typeInstances.addAll(currentCas);
+				typeInstances.remove(currentCa);
+				typeInstances.removeAll(currentCa.getPropertyInstances());
 				
 				// Loop over all identified ATypeInstances
 				for (ATypeInstance aTypeInstance : typeInstances) {

--- a/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/compute/ExpressionHelper.java
+++ b/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/compute/ExpressionHelper.java
@@ -325,6 +325,10 @@ public class ExpressionHelper {
 			
 				Collection<ATypeInstance> typeInstances = VirSatEcoreUtil.getAllContentsOfType(currentCas, ATypeInstance.class, true);
 				typeInstances.addAll(currentCas);
+				
+				// Remove the local type instances. This prevents the creation of cyclic input for the set function
+				// i.e. it prevents that expressions such as mass = summary{mass} create a cycle by including the local
+				// mass property in the inputs of the summary set function
 				typeInstances.remove(currentCa);
 				typeInstances.removeAll(currentCa.getPropertyInstances());
 				


### PR DESCRIPTION
Old approach: Removed entire category assignment and all contained
typeinstances from the inputs of set functions. This prevented the
creation of cycles. But also is responsible for the bug #635 since now
the PowerState category assignments in a PowerEquipment are disregarded
for the questions. Therefore, no update occurs.

New approach: Remove only the ca itself and the local property instances
from the inputs. Nestedely contained type instances are still considered
as potential inputs.

Also added a new test case modeling the situation of the power budget
concept.

Closes #635

---
Task #635: Equations for Power Concept do not update