### PR TITLE
Added test cases for validation

### DIFF
--- a/de.dlr.sc.virsat.build.ui/src/de/dlr/sc/virsat/build/marker/ui/MarkerImageProvider.java
+++ b/de.dlr.sc.virsat.build.ui/src/de/dlr/sc/virsat/build/marker/ui/MarkerImageProvider.java
@@ -133,7 +133,7 @@ public class MarkerImageProvider {
 	 * @param severity 
 	 * @return if severity is IMarker.SEVERITY or IMarker.SEVERITY_WARNING or IMarker.SEVERITY_INFO returns corresponding image, otherwise returns null
 	 */
-	protected Image getProblemImageForSeverity(int severity) {
+	public Image getProblemImageForSeverity(int severity) {
 		if (severity == IMarker.SEVERITY_ERROR) {
 			return imageError;
 		}

--- a/de.dlr.sc.virsat.build/src/de/dlr/sc/virsat/build/validator/core/DvlmNamingConventionValidator.java
+++ b/de.dlr.sc.virsat.build/src/de/dlr/sc/virsat/build/validator/core/DvlmNamingConventionValidator.java
@@ -34,6 +34,10 @@ public class DvlmNamingConventionValidator extends ADvlmCoreValidator implements
 
 	//includes capital and small letters, numbers and underline "_" but no spaces and especially no dots
 	public static final String CAMELCASE_PATTERN_ARBITRARY = "^[a-zA-z]+\\w*";
+	public static final String WARNING_PREFIX = "The name of \'";
+	public static final String WARNING_EMPTY_NAME_SUFFIX = "\' is not set.";
+	public static final String WARNING_DOTS_SUFFIX = "\' contains dots.";
+	public static final String WARNING_CAMEL_CASE_SUFFIX = "\' does not match the camelCase convention.";
 	
 	@Override
 	public boolean validate(StructuralElementInstance sei) {
@@ -62,14 +66,14 @@ public class DvlmNamingConventionValidator extends ADvlmCoreValidator implements
 			String fqn = iInstance.getFullQualifiedInstanceName();
 			boolean isCamelCase = name != null && name.matches(CAMELCASE_PATTERN_ARBITRARY);
 			if (name == null || name.isEmpty()) {
-				vvmHelper.createEMFValidationMarker(IMarker.SEVERITY_WARNING, "The name of \'" + fqn + "\' is not set.", iUuid, GeneralPackage.Literals.INAME__NAME);
+				vvmHelper.createEMFValidationMarker(IMarker.SEVERITY_WARNING, WARNING_PREFIX + fqn + WARNING_EMPTY_NAME_SUFFIX, iUuid, GeneralPackage.Literals.INAME__NAME);
 				validationSuccessful = false;
 			} else if (!isCamelCase) {
 				if (name.contains(".")) {
-					vvmHelper.createEMFValidationMarker(IMarker.SEVERITY_ERROR, "The name of \'" + fqn + "\' contains dots.", iUuid, GeneralPackage.Literals.INAME__NAME);
+					vvmHelper.createEMFValidationMarker(IMarker.SEVERITY_ERROR, WARNING_PREFIX + fqn + WARNING_DOTS_SUFFIX, iUuid, GeneralPackage.Literals.INAME__NAME);
 					validationSuccessful = false;
 				} else {
-					vvmHelper.createEMFValidationMarker(IMarker.SEVERITY_WARNING, "The name of \'" + fqn + "\' does not match the camelCase convention.", iUuid, GeneralPackage.Literals.INAME__NAME);
+					vvmHelper.createEMFValidationMarker(IMarker.SEVERITY_WARNING, WARNING_PREFIX + fqn + WARNING_CAMEL_CASE_SUFFIX, iUuid, GeneralPackage.Literals.INAME__NAME);
 					validationSuccessful = false;
 				}
 			}

--- a/de.dlr.sc.virsat.project.ui/META-INF/MANIFEST.MF
+++ b/de.dlr.sc.virsat.project.ui/META-INF/MANIFEST.MF
@@ -36,6 +36,7 @@ Export-Package: de.dlr.sc.virsat.project.ui,
  de.dlr.sc.virsat.project.ui.navigator.handler,
  de.dlr.sc.virsat.project.ui.navigator.labelProvider,
  de.dlr.sc.virsat.project.ui.navigator.util,
+ de.dlr.sc.virsat.project.ui.perspective,
  de.dlr.sc.virsat.project.ui.transactional.handler,
  de.dlr.sc.virsat.project.ui.wizard
 Automatic-Module-Name: de.dlr.sc.virsat.project.ui

--- a/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/perspective/CorePerspective.java
+++ b/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/perspective/CorePerspective.java
@@ -27,6 +27,12 @@ public class CorePerspective implements IPerspectiveFactory {
 	public static final String ID_BOTTOM_RIGHT_FOLDER = "de.dlr.sc.virsat.perspective.core.BOTTOMRIGHT";
 	public static final String ID_LEFT_MID_FOLDER = "de.dlr.sc.virsat.perspective.core.LEFT_MID";
 	
+	public static final String ID_PROPERTY_SHEET = "org.eclipse.ui.views.PropertySheet";
+	public static final String ID_PROBLEM_VIEW = "org.eclipse.ui.views.ProblemView";
+	public static final String ID_CONTENT_OUTLINE = "org.eclipse.ui.views.ContentOutline";
+	public static final String ID_UI_ENGINE_PALETTE = "de.dlr.sc.virsat.uiengine.ui.palette";
+	public static final String ID_NAVIGATOR_VIEW = "de.dlr.sc.virsat.project.ui.navigator.view";
+	public static final String ID_PROJECT_EXPLORER = "org.eclipse.ui.navigator.ProjectExplorer";
 	
 	@Override
 	public void createInitialLayout(IPageLayout layout) {
@@ -37,21 +43,21 @@ public class CorePerspective implements IPerspectiveFactory {
 		
 		// Create a folder to bottom left and Add the problem view to the left bottom side		
 		IFolderLayout bottomrightFolder = layout.createFolder(ID_BOTTOM_RIGHT_FOLDER, IPageLayout.BOTTOM, TWOTHIRDS, editorArea);
-		bottomrightFolder.addView("org.eclipse.ui.views.PropertySheet");
-		bottomrightFolder.addView("org.eclipse.ui.views.ProblemView");
+		bottomrightFolder.addView(ID_PROPERTY_SHEET);
+		bottomrightFolder.addView(ID_PROBLEM_VIEW);
 
 		// Create a folder to the bottom right and add the outline view to it
 		IFolderLayout bottomleftFolder = layout.createFolder(ID_BOTTOM_LEFT_FOLDER, IPageLayout.LEFT, QUARTER, ID_BOTTOM_RIGHT_FOLDER);
-		bottomleftFolder.addView("org.eclipse.ui.views.ContentOutline");
+		bottomleftFolder.addView(ID_CONTENT_OUTLINE);
 
 		// Create a right folder to hold the widget gallery
 		IFolderLayout rightFolder = layout.createFolder(ID_RIGHT_FOLDER, IPageLayout.RIGHT, 1 - QUARTER, editorArea);
-		rightFolder.addView("de.dlr.sc.virsat.uiengine.ui.palette");
+		rightFolder.addView(ID_UI_ENGINE_PALETTE);
 		
 		// Create a folder to left and Add the navigator to the left side
 		IFolderLayout leftFolder = layout.createFolder(ID_LEFT_FOLDER, IPageLayout.LEFT, QUARTER, editorArea);
 		
-		leftFolder.addView("de.dlr.sc.virsat.project.ui.navigator.view");
-		leftFolder.addView("org.eclipse.ui.navigator.ProjectExplorer");
+		leftFolder.addView(ID_NAVIGATOR_VIEW);
+		leftFolder.addView(ID_PROJECT_EXPLORER);
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ASwtBotTestCase.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ASwtBotTestCase.java
@@ -437,7 +437,6 @@ public class ASwtBotTestCase {
 	 */
 	protected void createProject(String projectName) {
 		bot.viewById("de.dlr.sc.virsat.project.ui.navigator.view").toolbarButton("New VirSat Project").click();
-		waitForEditingDomainAndUiThread();
 		bot.textWithLabel("Project name:").setText(projectName);
 		bot.button("Finish").click();
 		waitForEditingDomainAndUiThread();

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ASwtBotTestCase.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ASwtBotTestCase.java
@@ -40,6 +40,7 @@ import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.forms.widgets.Hyperlink;
 import org.eclipse.ui.forms.widgets.Section;
 import org.hamcrest.Matcher;
 import org.hamcrest.core.StringStartsWith;
@@ -50,6 +51,7 @@ import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestName;
 import org.junit.rules.TestWatcher;
 import org.junit.rules.Timeout;
+
 import de.dlr.sc.virsat.concept.unittest.util.ConceptXmiLoader;
 import de.dlr.sc.virsat.model.dvlm.Repository;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
@@ -63,6 +65,7 @@ import de.dlr.sc.virsat.project.editingDomain.VirSatTransactionalEditingDomain;
 import de.dlr.sc.virsat.project.editingDomain.commands.VirSatEditingDomainClipBoard;
 import de.dlr.sc.virsat.project.resources.VirSatResourceSet;
 import de.dlr.sc.virsat.swtbot.util.SwtBotDebugHelper;
+import de.dlr.sc.virsat.swtbot.util.SwtBotHyperlink;
 import de.dlr.sc.virsat.swtbot.util.SwtBotSection;
 import de.dlr.sc.virsat.swtbot.util.SwtThreadWatcher;
 
@@ -224,6 +227,18 @@ public class ASwtBotTestCase {
 		waitForEditor(item);
 		waitForEditingDomainAndUiThread();
 		return newItem;
+	}
+	
+	/**
+	 * Opens a view
+	 * @param viewId the id of the view
+	 * @return the opened view
+	 */
+	protected SWTBotView openView(String viewId) {
+		SWTBotView view = bot.viewById(viewId);
+		view.show();
+		waitForEditingDomainAndUiThread();
+		return view;
 	}
 	
 	/**
@@ -662,6 +677,13 @@ public class ASwtBotTestCase {
 		Matcher<Section> matcher = allOf(widgetOfType(Section.class), withMnemonic(sectionName));
 		SwtBotSection composite = new SwtBotSection(bot.widget(matcher, 0), matcher);
 		return composite;
+	}	
+	
+	protected SwtBotHyperlink getSWTBotHyperlink(String text) {
+		@SuppressWarnings("unchecked")
+		Matcher<Hyperlink> matcher = allOf(widgetOfType(Hyperlink.class), withMnemonic(text));
+		SwtBotHyperlink swtBotHyperlink = new SwtBotHyperlink(bot.widget(matcher, 0), matcher);
+		return swtBotHyperlink;
 	}	
 	
 	/**

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ASwtBotTestCase.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ASwtBotTestCase.java
@@ -437,6 +437,7 @@ public class ASwtBotTestCase {
 	 */
 	protected void createProject(String projectName) {
 		bot.viewById("de.dlr.sc.virsat.project.ui.navigator.view").toolbarButton("New VirSat Project").click();
+		waitForEditingDomainAndUiThread();
 		bot.textWithLabel("Project name:").setText(projectName);
 		bot.button("Finish").click();
 		waitForEditingDomainAndUiThread();

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ProjectUiAllTests.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ProjectUiAllTests.java
@@ -21,13 +21,14 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 
 @Suite.SuiteClasses({
-	FuncElectricalDiagramTest.class,
-	EditorTest.class,
-	NewProjectWizardTest.class,
-	CutCopyDeleteUndoTest.class,
-	InheritanceTest.class, 
-	CalculationTest.class,   
-	ProductStructureTest.class
+//	FuncElectricalDiagramTest.class,
+//	EditorTest.class,
+//	NewProjectWizardTest.class,
+//	CutCopyDeleteUndoTest.class,
+//	InheritanceTest.class, 
+//	CalculationTest.class,   
+//	ProductStructureTest.class,
+	ValidatorTest.class
 	})
 
 public class ProjectUiAllTests {

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ProjectUiAllTests.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ProjectUiAllTests.java
@@ -21,13 +21,13 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 
 @Suite.SuiteClasses({
-//	FuncElectricalDiagramTest.class,
-//	EditorTest.class,
-//	NewProjectWizardTest.class,
-//	CutCopyDeleteUndoTest.class,
-//	InheritanceTest.class, 
-//	CalculationTest.class,   
-//	ProductStructureTest.class,
+	FuncElectricalDiagramTest.class,
+	EditorTest.class,
+	NewProjectWizardTest.class,
+	CutCopyDeleteUndoTest.class,
+	InheritanceTest.class, 
+	CalculationTest.class,   
+	ProductStructureTest.class,
 	ValidatorTest.class
 	})
 

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
@@ -182,7 +182,7 @@ public class ValidatorTest extends ASwtBotTestCase {
 		
 		// Check that clicking the header link collapses all sections which have no warning (i.e. all except the name section)
 		SwtBotHyperlink swtBotHyperlink = getSWTBotHyperlink(EMPTY_NAME_WARNING);
-		swtBotHyperlink.click();
+		buildCounter.executeInterlocked(() -> swtBotHyperlink.click());
 		
 		List<SwtBotSection> expandedSwtBotSections = getExpandedSections();
 		assertEquals(1, expandedSwtBotSections.size());
@@ -224,7 +224,7 @@ public class ValidatorTest extends ASwtBotTestCase {
 				+ ConfigurationTree.class.getSimpleName() + ".ec.."
 				+ DvlmNamingConventionValidator.WARNING_DOTS_SUFFIX;
 		SwtBotHyperlink swtBotHyperlink = getSWTBotHyperlink(EXPEDTED_ERROR);
-		swtBotHyperlink.click();
+		buildCounter.executeInterlocked(() -> swtBotHyperlink.click());
 		
 		List<SwtBotSection> expandedSwtBotSections = getExpandedSections();
 		assertEquals(1, expandedSwtBotSections.size());

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,7 +27,7 @@ import org.eclipse.core.resources.IMarker;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
-import org.eclipse.swtbot.swt.finder.results.BoolResult;
+import org.eclipse.swtbot.swt.finder.results.Result;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotLabel;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTableItem;
@@ -279,13 +278,11 @@ public class ValidatorTest extends ASwtBotTestCase {
 	 * @return the image of the table item
 	 */
 	private Image getImageForTableItem(SWTBotTableItem swtBotTableItem) {
-		List<Image> image = new ArrayList<>();
-		syncExec(new BoolResult() {
-			public Boolean run() {
-				image.add(swtBotTableItem.widget.getImage());
-				return true;
+		return syncExec(new Result<Image>() {
+			@Override
+			public Image run() {
+				return swtBotTableItem.widget.getImage();
 			}
 		});
-		return image.get(0);
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
@@ -195,6 +195,8 @@ public class ValidatorTest extends ASwtBotTestCase {
 		// Check that the header label has the right tooltip text
 		String tooltip = swtBotHyperlink.getToolTipText();
 		assertEquals(EMPTY_NAME_WARNING, tooltip);
+		
+		bot.resetWorkbench();
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
@@ -28,7 +28,6 @@ import org.eclipse.core.resources.IMarker;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
-import org.eclipse.swtbot.swt.finder.keyboard.Keystrokes;
 import org.eclipse.swtbot.swt.finder.results.BoolResult;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotLabel;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable;
@@ -221,7 +220,7 @@ public class ValidatorTest extends ASwtBotTestCase {
 		assertEquals(expectedIcon, actualIcon);
 		
 		// Unexpand the document section
-		//documentSection.click();
+		documentSection.click();
 		
 		// Check that clicking the header link collapses all sections which have no error (i.e. all except the document section)
 		// and expands those with an error (i.e. the document section)
@@ -229,12 +228,8 @@ public class ValidatorTest extends ASwtBotTestCase {
 				+ ConfigurationTree.class.getSimpleName() + "."
 				+ ElementConfiguration.class.getSimpleName() + ".."
 				+ DvlmNamingConventionValidator.WARNING_DOTS_SUFFIX;
-		SwtBotHyperlink swtBotHyperlink = getSWTBotHyperlink(EXPEDTED_ERROR);	
-		
-		// Clicking on hyperlinks that are not directly in view (which is the case here) has no effect
-		// Setting the widget into focus and then hitting enter as a workaround
-		swtBotHyperlink.setFocus();
-		swtBotHyperlink.pressShortcut(Keystrokes.CR);
+		SwtBotHyperlink swtBotHyperlink = getSWTBotHyperlink(EXPEDTED_ERROR);
+		swtBotHyperlink.click();
 		
 		List<SwtBotSection> expandedSwtBotSections = getExpandedSections();
 		assertEquals(1, expandedSwtBotSections.size());

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
@@ -56,6 +56,8 @@ public class ValidatorTest extends ASwtBotTestCase {
 	
 	@Before
 	public void before() throws Exception {
+		bot.resetWorkbench();
+		
 		super.before();
 		repositoryNavigatorItem = bot.tree().expandNode(SWTBOT_TEST_PROJECTNAME, "Repository");
 		problemView = openView(PROBLEM_VIEW_ID);
@@ -195,8 +197,6 @@ public class ValidatorTest extends ASwtBotTestCase {
 		// Check that the header label has the right tooltip text
 		String tooltip = swtBotHyperlink.getToolTipText();
 		assertEquals(EMPTY_NAME_WARNING, tooltip);
-		
-		bot.resetWorkbench();
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
@@ -182,7 +182,7 @@ public class ValidatorTest extends ASwtBotTestCase {
 		
 		// Check that clicking the header link collapses all sections which have no warning (i.e. all except the name section)
 		SwtBotHyperlink swtBotHyperlink = getSWTBotHyperlink(EMPTY_NAME_WARNING);
-		buildCounter.executeInterlocked(() -> swtBotHyperlink.click());
+		swtBotHyperlink.click();
 		
 		List<SwtBotSection> expandedSwtBotSections = getExpandedSections();
 		assertEquals(1, expandedSwtBotSections.size());
@@ -224,7 +224,7 @@ public class ValidatorTest extends ASwtBotTestCase {
 				+ ConfigurationTree.class.getSimpleName() + ".ec.."
 				+ DvlmNamingConventionValidator.WARNING_DOTS_SUFFIX;
 		SwtBotHyperlink swtBotHyperlink = getSWTBotHyperlink(EXPEDTED_ERROR);
-		buildCounter.executeInterlocked(() -> swtBotHyperlink.click());
+		swtBotHyperlink.click();
 		
 		List<SwtBotSection> expandedSwtBotSections = getExpandedSections();
 		assertEquals(1, expandedSwtBotSections.size());

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
@@ -180,7 +180,7 @@ public class ValidatorTest extends ASwtBotTestCase {
 		assertVisible(swtIcon);
 		assertEquals(expectedIcon, actualIcon);
 		
-		// Unexpand the name section
+		// Collapse the name section
 		nameSection.click();
 		
 		// Check that clicking the header link collapses all sections which have no warning (i.e. all except the name section)

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
@@ -42,13 +42,13 @@ import de.dlr.sc.virsat.build.validator.core.DvlmNamingConventionValidator;
 import de.dlr.sc.virsat.model.extension.ps.model.ConfigurationTree;
 import de.dlr.sc.virsat.model.extension.ps.model.Document;
 import de.dlr.sc.virsat.model.extension.ps.model.ElementConfiguration;
+import de.dlr.sc.virsat.project.ui.perspective.CorePerspective;
 import de.dlr.sc.virsat.swtbot.util.SwtBotHyperlink;
 import de.dlr.sc.virsat.swtbot.util.SwtBotSection;
 import de.dlr.sc.virsat.uiengine.ui.editor.snippets.general.UiSnippetIName;
 
 public class ValidatorTest extends ASwtBotTestCase {
 	
-	public static final String PROBLEM_VIEW_ID = "org.eclipse.ui.views.ProblemView";
 	public static final String EMPTY_NAME_WARNING = DvlmNamingConventionValidator.WARNING_PREFIX + DvlmNamingConventionValidator.WARNING_EMPTY_NAME_SUFFIX;		
 	
 	private SWTBotTreeItem repositoryNavigatorItem;
@@ -58,7 +58,7 @@ public class ValidatorTest extends ASwtBotTestCase {
 	public void before() throws Exception {
 		super.before();
 		repositoryNavigatorItem = bot.tree().expandNode(SWTBOT_TEST_PROJECTNAME, "Repository");
-		problemView = openView(PROBLEM_VIEW_ID);
+		problemView = openView(CorePerspective.ID_PROBLEM_VIEW);
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
@@ -219,7 +219,7 @@ public class ValidatorTest extends ASwtBotTestCase {
 		Image expectedIcon = new MarkerImageProvider(null).getProblemImageForSeverity(IMarker.SEVERITY_ERROR);
 		assertEquals(expectedIcon, actualIcon);
 		
-		// Unexpand the document section
+		// Collapse the document section
 		documentSection.click();
 		
 		// Check that clicking the header link collapses all sections which have no error (i.e. all except the document section)

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
@@ -159,7 +159,7 @@ public class ValidatorTest extends ASwtBotTestCase {
 		errors.getNode(EXPEDTED_ERROR).doubleClick();
 		assertText(ElementConfiguration.class.getSimpleName(), bot.textWithLabel(UiSnippetIName.NAME_FIELD));
 	}
-	
+
 	@Test
 	public void testWarningInGenericEditor() {
 		// Create sei with some warning
@@ -180,7 +180,11 @@ public class ValidatorTest extends ASwtBotTestCase {
 		assertVisible(swtIcon);
 		assertEquals(expectedIcon, actualIcon);
 		
+		// Unexpand the name section
+		nameSection.click();
+		
 		// Check that clicking the header link collapses all sections which have no warning (i.e. all except the name section)
+		// and expands those with a warning (i.e. the name section)
 		SwtBotHyperlink swtBotHyperlink = getSWTBotHyperlink(EMPTY_NAME_WARNING);
 		swtBotHyperlink.click();
 		
@@ -206,10 +210,6 @@ public class ValidatorTest extends ASwtBotTestCase {
 		bot.closeAllEditors();
 		openEditor(ec);
 		
-		// Make the name shorter to ensure that the error hyperlink is in view so that we can click on it
-		renameField(UiSnippetIName.NAME_FIELD, "ec");
-		buildCounter.executeInterlocked(() -> bot.saveAllEditors());
-		
 		// Check that there is an error icon in the document table
 		SwtBotSection documentSection = getSWTBotSection(Document.class);
 		SWTBotTable documentTable = documentSection.getSWTBotTable();
@@ -219,9 +219,14 @@ public class ValidatorTest extends ASwtBotTestCase {
 		Image expectedIcon = new MarkerImageProvider(null).getProblemImageForSeverity(IMarker.SEVERITY_ERROR);
 		assertEquals(expectedIcon, actualIcon);
 		
+		// Unexpand the document section
+		documentSection.click();
+		
 		// Check that clicking the header link collapses all sections which have no error (i.e. all except the document section)
+		// and expands those with an error (i.e. the document section)
 		final String EXPEDTED_ERROR = DvlmNamingConventionValidator.WARNING_PREFIX 
-				+ ConfigurationTree.class.getSimpleName() + ".ec.."
+				+ ConfigurationTree.class.getSimpleName() + "."
+				+ ElementConfiguration.class.getSimpleName() + ".."
 				+ DvlmNamingConventionValidator.WARNING_DOTS_SUFFIX;
 		SwtBotHyperlink swtBotHyperlink = getSWTBotHyperlink(EXPEDTED_ERROR);
 		swtBotHyperlink.click();

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IMarker;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
@@ -60,12 +59,6 @@ public class ValidatorTest extends ASwtBotTestCase {
 		super.before();
 		repositoryNavigatorItem = bot.tree().expandNode(SWTBOT_TEST_PROJECTNAME, "Repository");
 		problemView = openView(PROBLEM_VIEW_ID);
-	}
-	
-	@Override
-	public void tearDown() throws CoreException {
-		super.tearDown();
-		bot.resetWorkbench();
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
@@ -1,0 +1,255 @@
+/*******************************************************************************
+ * Copyright (c) 2020 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.swtbot.test;
+
+import static org.eclipse.swtbot.swt.finder.SWTBotAssert.assertSameWidget;
+import static org.eclipse.swtbot.swt.finder.SWTBotAssert.assertText;
+import static org.eclipse.swtbot.swt.finder.SWTBotAssert.assertVisible;
+import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.widgetOfType;
+import static org.eclipse.swtbot.swt.finder.matchers.WidgetMatcherFactory.withTooltip;
+import static org.hamcrest.Matchers.allOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotLabel;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.eclipse.ui.forms.widgets.Section;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.dlr.sc.virsat.build.marker.ui.MarkerImageProvider;
+import de.dlr.sc.virsat.build.validator.core.DvlmNamingConventionValidator;
+import de.dlr.sc.virsat.model.extension.ps.model.ConfigurationTree;
+import de.dlr.sc.virsat.model.extension.ps.model.Document;
+import de.dlr.sc.virsat.model.extension.ps.model.ElementConfiguration;
+import de.dlr.sc.virsat.swtbot.util.SwtBotHyperlink;
+import de.dlr.sc.virsat.swtbot.util.SwtBotSection;
+import de.dlr.sc.virsat.uiengine.ui.editor.snippets.general.UiSnippetIName;
+
+public class ValidatorTest extends ASwtBotTestCase {
+	
+	public static final String PROBLEM_VIEW_ID = "org.eclipse.ui.views.ProblemView";
+	public static final String EMPTY_NAME_WARNING = DvlmNamingConventionValidator.WARNING_PREFIX + DvlmNamingConventionValidator.WARNING_EMPTY_NAME_SUFFIX;		
+	
+	private SWTBotTreeItem repositoryNavigatorItem;
+	private SWTBotView problemView;
+	
+	@Before
+	public void before() throws Exception {
+		super.before();
+		repositoryNavigatorItem = bot.tree().expandNode(SWTBOT_TEST_PROJECTNAME, "Repository");
+	}
+	
+	@Test
+	public void testValidateSeiName() {
+		// Initially there are no warnings
+		problemView = openView(PROBLEM_VIEW_ID);
+		assertFalse(problemView.bot().tree().hasItems());
+		
+		// Create seis with incorrect names and then close the editors
+		// Create relevant problematic seis in one test case to keep overhead time in swtbot low
+		SWTBotTreeItem emptyNameSei = addElement(ConfigurationTree.class, conceptPs, repositoryNavigatorItem);
+		openEditor(emptyNameSei);
+		renameField(UiSnippetIName.NAME_FIELD, "");
+		
+		SWTBotTreeItem dotSei = addElement(ConfigurationTree.class, conceptPs, repositoryNavigatorItem);
+		openEditor(dotSei);
+		renameField(UiSnippetIName.NAME_FIELD, ".");
+		
+		SWTBotTreeItem noCamelCaseSei = addElement(ConfigurationTree.class, conceptPs, repositoryNavigatorItem);
+		openEditor(noCamelCaseSei);
+		renameField(UiSnippetIName.NAME_FIELD, "12");
+		
+		SWTBotTreeItem duplicateNameSei1 = addElement(ConfigurationTree.class, conceptPs, repositoryNavigatorItem);
+		openEditor(duplicateNameSei1);
+		renameField(UiSnippetIName.NAME_FIELD, "duplicateName");
+		
+		SWTBotTreeItem duplicateNameSei2 = addElement(ConfigurationTree.class, conceptPs, repositoryNavigatorItem);
+		openEditor(duplicateNameSei2);
+		renameField(UiSnippetIName.NAME_FIELD, "duplicateName");
+		
+		buildCounter.executeInterlocked(() -> bot.saveAllEditors());
+		bot.closeAllEditors();
+		
+		// There should now exist a warning for every incorrect validation, except for
+		// the no dots rule violation which is an error
+		final int COUNT_EXPECTED_WARNINGS = 4;
+		SWTBotTreeItem warnings = getWarnings(COUNT_EXPECTED_WARNINGS);
+		assertNotNull(warnings);
+		
+		final int COUNT_EXPECTED_ERRORS = 1;
+		SWTBotTreeItem errors = getErrors(COUNT_EXPECTED_ERRORS);
+		assertNotNull(errors);
+		
+		// Double clicking on a warning should open the editor of the correct sei which is checked via the name field
+		warnings.expand();
+		warnings.getNode(EMPTY_NAME_WARNING).doubleClick();
+		assertText("", bot.textWithLabel(UiSnippetIName.NAME_FIELD));
+	}
+	
+	@Test
+	public void testValidateCaName() {
+		// Initially there are no warnings
+		problemView = openView(PROBLEM_VIEW_ID);
+		assertFalse(problemView.bot().tree().hasItems());
+		
+		// Create seis with incorrect names and then close the editors
+		SWTBotTreeItem ct = addElement(ConfigurationTree.class, conceptPs, repositoryNavigatorItem);
+		SWTBotTreeItem ec = addElement(ElementConfiguration.class, conceptPs, ct);
+		
+		// Create relevant problematic cas in one test case to keep overhead time in swtbot low
+		SWTBotTreeItem emptyCa = addElement(Document.class, conceptPs, ec);
+		openEditor(emptyCa);
+		renameField(UiSnippetIName.NAME_FIELD, "");
+		
+		SWTBotTreeItem dotCa = addElement(Document.class, conceptPs, ec);
+		openEditor(dotCa);
+		renameField(UiSnippetIName.NAME_FIELD, ".");
+		
+		SWTBotTreeItem noCamelCaseCa = addElement(Document.class, conceptPs, ec);
+		openEditor(noCamelCaseCa);
+		renameField(UiSnippetIName.NAME_FIELD, "12");
+		
+		SWTBotTreeItem duplicateNameCa1 = addElement(Document.class, conceptPs, ec);
+		openEditor(duplicateNameCa1);
+		renameField(UiSnippetIName.NAME_FIELD, "duplicateName");
+		
+		SWTBotTreeItem duplicateNameCa2 = addElement(Document.class, conceptPs, ec);
+		openEditor(duplicateNameCa2);
+		renameField(UiSnippetIName.NAME_FIELD, "duplicateName");
+		
+		buildCounter.executeInterlocked(() -> bot.saveAllEditors());
+		bot.closeAllEditors();
+		
+		// There should now exist a warning for every incorrect validation, except for
+		// the no dots rule violation which is an error
+		final int COUNT_EXPECTED_WARNINGS = 4;
+		SWTBotTreeItem warnings = getWarnings(COUNT_EXPECTED_WARNINGS);
+		assertNotNull(warnings);
+		
+		final int COUNT_EXPECTED_ERRORS = 1;
+		SWTBotTreeItem errors = getErrors(COUNT_EXPECTED_ERRORS);
+		assertNotNull(errors);
+		
+		// Double clicking on an error should open the editor of the containing sei
+		errors.expand();
+		final String EXPEDTED_ERROR = DvlmNamingConventionValidator.WARNING_PREFIX 
+				+ ConfigurationTree.class.getSimpleName() + "."
+				+ ElementConfiguration.class.getSimpleName() + ".."
+				+ DvlmNamingConventionValidator.WARNING_DOTS_SUFFIX;
+		errors.getNode(EXPEDTED_ERROR).doubleClick();
+		assertText(ElementConfiguration.class.getSimpleName(), bot.textWithLabel(UiSnippetIName.NAME_FIELD));
+	}
+	
+	@Test
+	public void testWarningInGenericEditor() {
+		// Create sei with some warning
+		SWTBotTreeItem emptyNameSei = addElement(ConfigurationTree.class, conceptPs, repositoryNavigatorItem);
+		openEditor(emptyNameSei);
+		renameField(UiSnippetIName.NAME_FIELD, "");
+		buildCounter.executeInterlocked(() -> bot.saveAllEditors());
+		
+		// Check that clicking the header link collapses all sections which have no warning (i.e. all except the name section)
+		SwtBotHyperlink swtBotHyperlink = getSWTBotHyperlink(EMPTY_NAME_WARNING);
+		buildCounter.executeInterlocked(() -> swtBotHyperlink.click());
+		
+		List<SwtBotSection> expandedSwtBotSections = getExpandedSections();
+		SwtBotSection nameSection = getSWTBotSection(UiSnippetIName.SECTION_HEADING);
+		
+		assertEquals(1, expandedSwtBotSections.size());
+		assertSameWidget(nameSection.widget, expandedSwtBotSections.get(0).widget);
+		
+		// Check that the header label has the right tooltip text
+		String tooltip = swtBotHyperlink.getToolTipText();
+		assertEquals(EMPTY_NAME_WARNING, tooltip);
+		
+		// Check that there is a warning icon with the correct tooltip in the name section
+		// Note that icons are implemented via label with image
+		List<Label> iconLabels = bot.getFinder()
+				.findControls(nameSection.widget, allOf(widgetOfType(Label.class), withTooltip(EMPTY_NAME_WARNING)), true);
+		SWTBotLabel swtIcon = new SWTBotLabel(iconLabels.get(0));
+		Image actualIcon = swtIcon.image();
+		Image expectedIcon = new MarkerImageProvider(null).getProblemImageForSeverity(IMarker.SEVERITY_WARNING);
+		
+		assertVisible(swtIcon);
+		assertEquals(expectedIcon, actualIcon);
+	}
+	
+	@Test
+	public void testErrorInGenericEditor() {
+		// Create sei with an error in a contained sei
+		SWTBotTreeItem ct = addElement(ConfigurationTree.class, conceptPs, repositoryNavigatorItem);
+		SWTBotTreeItem ec = addElement(ElementConfiguration.class, conceptPs, ct);
+		SWTBotTreeItem dotCa = addElement(Document.class, conceptPs, ec);
+		openEditor(dotCa);
+		renameField(UiSnippetIName.NAME_FIELD, ".");
+		buildCounter.executeInterlocked(() -> bot.saveAllEditors());
+		openEditor(ec);
+		
+		// Check that clicking the header link collapses all sections which have no error (i.e. all except the document section)
+		final String EXPEDTED_ERROR = DvlmNamingConventionValidator.WARNING_PREFIX 
+				+ ConfigurationTree.class.getSimpleName() + "."
+				+ ElementConfiguration.class.getSimpleName() + ".."
+				+ DvlmNamingConventionValidator.WARNING_DOTS_SUFFIX;
+		SwtBotHyperlink swtBotHyperlink = getSWTBotHyperlink(EXPEDTED_ERROR);		
+		buildCounter.executeInterlocked(() -> swtBotHyperlink.click());
+		
+		List<SwtBotSection> expandedSwtBotSections = getExpandedSections();
+		SwtBotSection documentSection = getSWTBotSection(Document.class);
+		
+		assertEquals(1, expandedSwtBotSections.size());
+		assertSameWidget(documentSection.widget, expandedSwtBotSections.get(0).widget);
+		
+		// Check that the header label has the right tooltip text
+		String tooltip = swtBotHyperlink.getToolTipText();
+		assertEquals(EXPEDTED_ERROR, tooltip);
+	}
+	
+	/**
+	 * Gets the currently expanded sections
+	 * @return a list containing only expanded sections
+	 */
+	private List<SwtBotSection> getExpandedSections() {
+		List<? extends Section> sections = bot.getFinder().findControls(widgetOfType(Section.class));
+		List<SwtBotSection> expandedSwtBotSections = sections.stream()
+				.map(SwtBotSection::new)
+				.filter(SwtBotSection::isExpanded)
+				.collect(Collectors.toList());
+		return expandedSwtBotSections;
+	}
+	
+	/**
+	 * Gets the warnings entry from the problem view
+	 * @param countExpectedWarnings the expected number of warnings
+	 * @return the warning entry
+	 */
+	private SWTBotTreeItem getWarnings(int countExpectedWarnings) {
+		String plural = (countExpectedWarnings > 1) ? "s" : "";
+		return problemView.bot().tree().getTreeItem("Warnings (" + countExpectedWarnings + " item" + plural + ")");
+	}
+	
+	/**
+	 * Gets the error entry from the problem view
+	 * @param countExpectedErrors the expected number of errors
+	 * @return the warning entry
+	 */
+	private SWTBotTreeItem getErrors(int countExpectedErrors) {
+		String plural = (countExpectedErrors > 1) ? "s" : "";
+		return problemView.bot().tree().getTreeItem("Errors (" + countExpectedErrors + " item" + plural + ")");
+	}
+}

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
@@ -159,7 +159,7 @@ public class ValidatorTest extends ASwtBotTestCase {
 		errors.getNode(EXPEDTED_ERROR).doubleClick();
 		assertText(ElementConfiguration.class.getSimpleName(), bot.textWithLabel(UiSnippetIName.NAME_FIELD));
 	}
-
+	
 	@Test
 	public void testWarningInGenericEditor() {
 		// Create sei with some warning
@@ -180,11 +180,7 @@ public class ValidatorTest extends ASwtBotTestCase {
 		assertVisible(swtIcon);
 		assertEquals(expectedIcon, actualIcon);
 		
-		// Unexpand the name section
-		nameSection.click();
-		
 		// Check that clicking the header link collapses all sections which have no warning (i.e. all except the name section)
-		// and expands those with a warning (i.e. the name section)
 		SwtBotHyperlink swtBotHyperlink = getSWTBotHyperlink(EMPTY_NAME_WARNING);
 		swtBotHyperlink.click();
 		
@@ -210,6 +206,10 @@ public class ValidatorTest extends ASwtBotTestCase {
 		bot.closeAllEditors();
 		openEditor(ec);
 		
+		// Make the name shorter to ensure that the error hyperlink is in view so that we can click on it
+		renameField(UiSnippetIName.NAME_FIELD, "ec");
+		buildCounter.executeInterlocked(() -> bot.saveAllEditors());
+		
 		// Check that there is an error icon in the document table
 		SwtBotSection documentSection = getSWTBotSection(Document.class);
 		SWTBotTable documentTable = documentSection.getSWTBotTable();
@@ -219,14 +219,9 @@ public class ValidatorTest extends ASwtBotTestCase {
 		Image expectedIcon = new MarkerImageProvider(null).getProblemImageForSeverity(IMarker.SEVERITY_ERROR);
 		assertEquals(expectedIcon, actualIcon);
 		
-		// Unexpand the document section
-		documentSection.click();
-		
 		// Check that clicking the header link collapses all sections which have no error (i.e. all except the document section)
-		// and expands those with an error (i.e. the document section)
 		final String EXPEDTED_ERROR = DvlmNamingConventionValidator.WARNING_PREFIX 
-				+ ConfigurationTree.class.getSimpleName() + "."
-				+ ElementConfiguration.class.getSimpleName() + ".."
+				+ ConfigurationTree.class.getSimpleName() + ".ec.."
 				+ DvlmNamingConventionValidator.WARNING_DOTS_SUFFIX;
 		SwtBotHyperlink swtBotHyperlink = getSWTBotHyperlink(EXPEDTED_ERROR);
 		swtBotHyperlink.click();

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ValidatorTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
@@ -56,11 +57,15 @@ public class ValidatorTest extends ASwtBotTestCase {
 	
 	@Before
 	public void before() throws Exception {
-		bot.resetWorkbench();
-		
 		super.before();
 		repositoryNavigatorItem = bot.tree().expandNode(SWTBOT_TEST_PROJECTNAME, "Repository");
 		problemView = openView(PROBLEM_VIEW_ID);
+	}
+	
+	@Override
+	public void tearDown() throws CoreException {
+		super.tearDown();
+		bot.resetWorkbench();
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -9,7 +9,6 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.swtbot.util;
 
-import org.eclipse.swt.SWT;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBotControl;
@@ -24,6 +23,7 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	
 	@Override
 	public AbstractSWTBot<Hyperlink> click() {
-		return pressShortcut(SWT.NONE, '\r');
+		setFocus();
+		return click(true);
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -26,7 +26,7 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	
 	@Override
 	public AbstractSWTBot<Hyperlink> click() {
-		// The click funcion doesnt cause any reactions on linux systems
+		// The click function doesnt cause any reactions on linux systems
 		// so directly triggering the hyperlink by injecting an enter press on it
 		syncExec(new VoidResult() {
 			public void run() {

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -27,7 +27,7 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	@Override
 	public AbstractSWTBot<Hyperlink> click() {
 		// The click function doesnt cause any reactions on linux systems
-		// so directly triggering the hyperlink by injecting an enter press on it
+		// so directly triggering the hyperlink by injecting an enter (carriage return) press on it
 		syncExec(new VoidResult() {
 			public void run() {
 				Event event = createEvent();

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2020 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.swtbot.util;
+
+import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
+import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot;
+import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBotControl;
+import org.eclipse.ui.forms.widgets.Hyperlink;
+import org.hamcrest.Matcher;
+
+public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
+
+	public SwtBotHyperlink(Hyperlink hyperlink, Matcher<Hyperlink> matcher) throws WidgetNotFoundException {
+		super(hyperlink, matcher);
+	}
+	
+	@Override
+	public AbstractSWTBot<Hyperlink> click() {
+		// Increase invisible of inherited method and 
+		// redirect to standard implementation doing a center click
+		return super.click(true);
+	}
+}

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -9,6 +9,7 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.swtbot.util;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBotControl;
@@ -23,6 +24,6 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	
 	@Override
 	public AbstractSWTBot<Hyperlink> click() {
-		return click(true);
+		return pressShortcut(SWT.NONE, '\r');
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -9,6 +9,7 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.swtbot.util;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBotControl;
@@ -24,6 +25,7 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	@Override
 	public AbstractSWTBot<Hyperlink> click() {
 		setFocus();
-		return click(true);
+		click(true);
+		return pressShortcut(SWT.NONE, '\r');
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -10,7 +10,6 @@
 package de.dlr.sc.virsat.swtbot.util;
 
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
-import org.eclipse.swtbot.swt.finder.keyboard.Keystrokes;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBotControl;
 import org.eclipse.ui.forms.widgets.Hyperlink;
@@ -26,7 +25,7 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	public AbstractSWTBot<Hyperlink> click() {
 		// Clicking on hyperlinks that are not directly in view (which is the case here) has no effect
 		// Setting the widget into focus and then hitting enter as a workaround
-		setFocus();
-		return pressShortcut(Keystrokes.CR);
+		//setFocus();
+		return click(true);
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -24,7 +24,7 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	@Override
 	public AbstractSWTBot<Hyperlink> click() {
 		setFocus();
-		click(true);
-		return click(false);
+		keyboard().typeCharacter('\r');
+		return this;
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -25,14 +25,6 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	public AbstractSWTBot<Hyperlink> click() {
 		setFocus();
 		click(true);
-		
-		try {
-			final int TIME = 5000;
-			Thread.sleep(TIME);
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		}
-		
-		return click(true);
+		return click(false);
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -9,8 +9,8 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.swtbot.util;
 
+import org.eclipse.swt.SWT;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
-import org.eclipse.swtbot.swt.finder.keyboard.Keystrokes;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBotControl;
 import org.eclipse.ui.forms.widgets.Hyperlink;
@@ -27,6 +27,6 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 		// Clicking on hyperlinks that are not directly in view (which is the case here) has no effect
 		// Setting the widget into focus and then hitting enter as a workaround
 		setFocus();
-		return pressShortcut(Keystrokes.CR, Keystrokes.LF);
+		return pressShortcut(SWT.CR, SWT.LF);
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -26,9 +26,8 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	public AbstractSWTBot<Hyperlink> click() {
 		// Clicking on hyperlinks that are not directly in view (which is the case here) has no effect
 		// Setting the widget into focus and then hitting enter as a workaround
-		this.click(true);
 		setFocus();
-		pressShortcut(Keystrokes.CR);
+		//pressShortcut(Keystrokes.CR);
 		pressShortcut(Keystrokes.LF);
 		return pressShortcut(Keystrokes.ESC);
 	}

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -26,10 +26,12 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	
 	@Override
 	public AbstractSWTBot<Hyperlink> click() {
+		// The click funcion doesnt cause any reactions on linux systems
+		// so directly triggering the hyperlink by injecting an enter press on it
 		syncExec(new VoidResult() {
 			public void run() {
 				Event event = createEvent();
-				event.character = '\r';
+				event.character = SWT.CR;
 				widget.notifyListeners(SWT.KeyDown, event);
 			}
 		});

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -26,8 +26,10 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	public AbstractSWTBot<Hyperlink> click() {
 		// Clicking on hyperlinks that are not directly in view (which is the case here) has no effect
 		// Setting the widget into focus and then hitting enter as a workaround
+		this.click(true);
 		setFocus();
 		pressShortcut(Keystrokes.CR);
-		return pressShortcut(Keystrokes.LF);
+		pressShortcut(Keystrokes.LF);
+		return pressShortcut(Keystrokes.ESC);
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -10,7 +10,6 @@
 package de.dlr.sc.virsat.swtbot.util;
 
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
-import org.eclipse.swtbot.swt.finder.keyboard.Keystrokes;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBotControl;
 import org.eclipse.ui.forms.widgets.Hyperlink;
@@ -24,11 +23,6 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	
 	@Override
 	public AbstractSWTBot<Hyperlink> click() {
-		// Clicking on hyperlinks that are not directly in view (which is the case here) has no effect
-		// Setting the widget into focus and then hitting enter as a workaround
-		setFocus();
-		//pressShortcut(Keystrokes.CR);
-		pressShortcut(Keystrokes.LF);
-		return pressShortcut(Keystrokes.ESC);
+		return click(true);
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -9,8 +9,8 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.swtbot.util;
 
-import org.eclipse.swt.SWT;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
+import org.eclipse.swtbot.swt.finder.keyboard.Keystrokes;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBotControl;
 import org.eclipse.ui.forms.widgets.Hyperlink;
@@ -27,6 +27,7 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 		// Clicking on hyperlinks that are not directly in view (which is the case here) has no effect
 		// Setting the widget into focus and then hitting enter as a workaround
 		setFocus();
-		return pressShortcut(SWT.CR, SWT.LF);
+		pressShortcut(Keystrokes.CR);
+		return pressShortcut(Keystrokes.LF);
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -10,6 +10,7 @@
 package de.dlr.sc.virsat.swtbot.util;
 
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
+import org.eclipse.swtbot.swt.finder.keyboard.Keystrokes;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBotControl;
 import org.eclipse.ui.forms.widgets.Hyperlink;
@@ -25,7 +26,7 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	public AbstractSWTBot<Hyperlink> click() {
 		// Clicking on hyperlinks that are not directly in view (which is the case here) has no effect
 		// Setting the widget into focus and then hitting enter as a workaround
-		//setFocus();
-		return click(true);
+		setFocus();
+		return pressShortcut(Keystrokes.CR, Keystrokes.LF);
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -9,7 +9,10 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.swtbot.util;
 
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Event;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
+import org.eclipse.swtbot.swt.finder.results.VoidResult;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBotControl;
 import org.eclipse.ui.forms.widgets.Hyperlink;
@@ -23,15 +26,13 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	
 	@Override
 	public AbstractSWTBot<Hyperlink> click() {
-		setFocus();
-		keyboard().typeCharacter('\r');
-		
-		try {
-			final int TIME = 5000;
-			Thread.sleep(TIME);
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		}
+		syncExec(new VoidResult() {
+			public void run() {
+				Event event = createEvent();
+				event.character = '\r';
+				widget.notifyListeners(SWT.KeyDown, event);
+			}
+		});
 		
 		return this;
 	}

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -9,7 +9,6 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.swtbot.util;
 
-import org.eclipse.swt.SWT;
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBotControl;
@@ -26,6 +25,12 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	public AbstractSWTBot<Hyperlink> click() {
 		setFocus();
 		click(true);
-		return pressShortcut(SWT.NONE, '\r');
+		click(true);
+		click(true);
+		click(true);
+		click(true);
+		click(true);
+		click(true);
+		return click(true);
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -10,6 +10,7 @@
 package de.dlr.sc.virsat.swtbot.util;
 
 import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
+import org.eclipse.swtbot.swt.finder.keyboard.Keystrokes;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBot;
 import org.eclipse.swtbot.swt.finder.widgets.AbstractSWTBotControl;
 import org.eclipse.ui.forms.widgets.Hyperlink;
@@ -23,8 +24,9 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	
 	@Override
 	public AbstractSWTBot<Hyperlink> click() {
-		// Increase invisible of inherited method and 
-		// redirect to standard implementation doing a center click
-		return super.click(true);
+		// Clicking on hyperlinks that are not directly in view (which is the case here) has no effect
+		// Setting the widget into focus and then hitting enter as a workaround
+		setFocus();
+		return pressShortcut(Keystrokes.CR);
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -25,12 +25,14 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	public AbstractSWTBot<Hyperlink> click() {
 		setFocus();
 		click(true);
-		click(true);
-		click(true);
-		click(true);
-		click(true);
-		click(true);
-		click(true);
+		
+		try {
+			final int TIME = 5000;
+			Thread.sleep(TIME);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+		
 		return click(true);
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/util/SwtBotHyperlink.java
@@ -25,6 +25,14 @@ public class SwtBotHyperlink extends AbstractSWTBotControl<Hyperlink> {
 	public AbstractSWTBot<Hyperlink> click() {
 		setFocus();
 		keyboard().typeCharacter('\r');
+		
+		try {
+			final int TIME = 5000;
+			Thread.sleep(TIME);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+		
 		return this;
 	}
 }

--- a/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/editor/snippets/general/UiSnippetIName.java
+++ b/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/editor/snippets/general/UiSnippetIName.java
@@ -40,7 +40,9 @@ import de.dlr.sc.virsat.uiengine.ui.editor.snippets.IUiSnippet;
  */
 public class UiSnippetIName extends AUiEStructuralFeatureSectionSnippet implements IUiSnippet {
 
-	private static final String SECTION_HEADING = "Name Section";
+	public static final String SECTION_HEADING = "Name Section";
+	public static final String NAME_FIELD = "Name";
+	
 	private static final int UI_LAYOUT_NR_COLUMNS =  2;	
 	
 	private EsfMarkerImageProvider emip;

--- a/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/editor/snippets/general/UiSnippetIName.java
+++ b/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/editor/snippets/general/UiSnippetIName.java
@@ -70,11 +70,11 @@ public class UiSnippetIName extends AUiEStructuralFeatureSectionSnippet implemen
 		labelWithIcon.setLayout(new GridLayout(2, false));
 		
 		labelPropertyIcon = toolkit.createLabel(labelWithIcon, "");
-		Label label = toolkit.createLabel(labelWithIcon, "Name");
+		Label labelName = toolkit.createLabel(labelWithIcon, NAME_FIELD);
 		textName = toolkit.createText(sectionBody, "");
 		
 		setUpIcon();
-		setUpLabel(label);		
+		setUpLabel(labelName);		
 		setUpText(editingDomain);
 	    
 		checkWriteAccess(textName);


### PR DESCRIPTION
- Testing name validation of Seis and Cas
- Testing linking between problem markers and editors (if you double click on a marker, the correct editor is opened)
- Testing existance of correct warning and error icons in GenericEditor
- Testing correct tooltips
- Testing focused expansion on all sections with warnings/errors
- Created SwtBotHyperlink class because SwtBot only supports Links natively which are somehow different from Hyperlinks in SWT. The text link used to focus expand only sections with warnings/errors uses Hyperlinks.

The tests are structured into 4 cases:
- Testing of Sei name validation
- Testing of Ca name validation
- Testing of warnings in generic editor
- Testing of errors in generic editor

More combinations would be possible this should cover most cases without leading to too much SWTBot testing time.

Closes #639