### PR TITLE
Exchanged write access checks in snippet for equation section

### DIFF
--- a/de.dlr.sc.virsat.model.calculation.ui/src/de/dlr/sc/virsat/model/calculation/ui/editor/snippet/UiSnippetEquations.java
+++ b/de.dlr.sc.virsat.model.calculation.ui/src/de/dlr/sc/virsat/model/calculation/ui/editor/snippet/UiSnippetEquations.java
@@ -192,7 +192,7 @@ public class UiSnippetEquations extends AUiSnippetEStructuralFeatureTable implem
 
 		checkWriteAccess(buttonAdd);
 		checkWriteAccess(buttonRemove);
-		checkWriteAccess(buttonEdit);
+		checkWriteAccess(buttonUpdate);
 		
 		return compositeButtons;
 	}


### PR DESCRIPTION
- The Equation section edit button is no longer checked for rights
management
- The perform update button is now checked for rights management

Closes #374

---
Task #374: Add ability to see equations of not owned elements