### PR TITLE
Test cases for checking values after reference change in a bean

### DIFF
--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyReference.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyReference.java
@@ -40,7 +40,7 @@ public class BeanPropertyReference<BEAN_TYPE extends IBeanObject<? extends AType
 		setTypeInstance(rpi);
 	}
 	
-	private ATypeInstance saveGetTypeInstance(BEAN_TYPE value) {
+	private ATypeInstance safeGetTypeInstance(BEAN_TYPE value) {
 		if (value == null) {
 			return null;
 		} else {
@@ -50,13 +50,13 @@ public class BeanPropertyReference<BEAN_TYPE extends IBeanObject<? extends AType
 	
 	@Override
 	public void setValue(BEAN_TYPE value) {
-		ATypeInstance reference = saveGetTypeInstance(value);
+		ATypeInstance reference = safeGetTypeInstance(value);
 		ti.setReference(reference);
 	}
 	
 	@Override
 	public Command setValue(EditingDomain ed, BEAN_TYPE value) {
-		ATypeInstance reference = saveGetTypeInstance(value);
+		ATypeInstance reference = safeGetTypeInstance(value);
 		
 		return SetCommand.create(ed, ti, PropertyinstancesPackage.Literals.REFERENCE_PROPERTY_INSTANCE__REFERENCE, reference);
 	}

--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/concept/list/ArrayUpdateTest.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/concept/list/ArrayUpdateTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2008-2019 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.list;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.extension.tests.model.AConceptTestCase;
+import de.dlr.sc.virsat.model.extension.tests.model.TestCategoryAllProperty;
+import de.dlr.sc.virsat.model.extension.tests.model.TestCategoryBase;
+import de.dlr.sc.virsat.model.extension.tests.model.TestCategoryReferenceArray;
+
+public class ArrayUpdateTest extends AConceptTestCase {
+
+	Concept concept;
+	
+	@Before
+	public void setup() {
+		concept = loadConceptFromPlugin();
+	}
+
+	@Test
+	public void testReferencedArrayUpdatesAfterChange() {
+		TestCategoryBase root = new TestCategoryBase(concept);
+
+		TestCategoryBase empty = new TestCategoryBase(concept);
+		assertTrue(empty.getTestArray().isEmpty());
+		
+		TestCategoryBase nonEmpty = new TestCategoryBase(concept);
+		nonEmpty.getTestArray().add(new TestCategoryBase(concept));
+		assertFalse(nonEmpty.getTestArray().isEmpty());
+		
+		root.setTestReference(empty);
+		assertTrue("Reference points to an object with empty array", root.getTestReference().getTestArray().isEmpty());
+		
+		root.setTestReference(nonEmpty);
+		assertFalse("Referenced points to an object with non-empty array", root.getTestReference().getTestArray().isEmpty());
+	}
+	
+	@Test
+	public void testReferencedPropertyInReferenceArrayUpdatesAfterChange() {
+		TestCategoryReferenceArray root = new TestCategoryReferenceArray(concept);
+		
+		TestCategoryAllProperty property = new TestCategoryAllProperty(concept);
+		assertFalse(property.getTestBool());
+		
+		TestCategoryAllProperty propertyChanged = new TestCategoryAllProperty(concept);
+		propertyChanged.setTestBool(true);
+		assertTrue(propertyChanged.getTestBool());
+		
+		root.getTestCategoryReferenceArrayDynamic().add(property);
+		assertEquals("Array contains one element", 1, root.getTestCategoryReferenceArrayDynamic().size());
+		assertFalse("Reference points to an object with false boolean", 
+			root.getTestCategoryReferenceArrayDynamic()
+				.get(0)
+				.getTestBool());
+		
+		root.getTestCategoryReferenceArrayDynamic().set(0, propertyChanged);
+		assertTrue("Reference points to an object with true boolean", 
+				root.getTestCategoryReferenceArrayDynamic()
+					.get(0)
+					.getTestBool());
+	}
+}

--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/concept/types/property/ReferenceUpdateTest.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/concept/types/property/ReferenceUpdateTest.java
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package de.dlr.sc.virsat.model.concept.list;
+package de.dlr.sc.virsat.model.concept.types.property;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -20,9 +20,10 @@ import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
 import de.dlr.sc.virsat.model.extension.tests.model.AConceptTestCase;
 import de.dlr.sc.virsat.model.extension.tests.model.TestCategoryAllProperty;
 import de.dlr.sc.virsat.model.extension.tests.model.TestCategoryBase;
+import de.dlr.sc.virsat.model.extension.tests.model.TestCategoryReference;
 import de.dlr.sc.virsat.model.extension.tests.model.TestCategoryReferenceArray;
 
-public class ArrayUpdateTest extends AConceptTestCase {
+public class ReferenceUpdateTest extends AConceptTestCase {
 
 	Concept concept;
 	
@@ -32,7 +33,27 @@ public class ArrayUpdateTest extends AConceptTestCase {
 	}
 
 	@Test
-	public void testReferencedArrayUpdatesAfterChange() {
+	public void testRereferencing() {
+		final int FIRST_VALUE = 1;
+		final int SECOND_VALUE = 2;
+		
+		TestCategoryReference root = new TestCategoryReference(concept);
+
+		TestCategoryAllProperty firstReference = new TestCategoryAllProperty(concept);
+		firstReference.setTestInt(FIRST_VALUE);
+		
+		TestCategoryAllProperty secondReference = new TestCategoryAllProperty(concept);
+		secondReference.setTestInt(SECOND_VALUE);
+		
+		root.setTestRefCategory(firstReference);
+		assertEquals("First value is correctly set", FIRST_VALUE, root.getTestRefCategory().getTestInt());
+		
+		root.setTestRefCategory(secondReference);
+		assertEquals("Value is changed after rereferencing", SECOND_VALUE, root.getTestRefCategory().getTestInt());
+	}
+	
+	@Test
+	public void testRereferencingArray() {
 		TestCategoryBase root = new TestCategoryBase(concept);
 
 		TestCategoryBase empty = new TestCategoryBase(concept);

--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/test/AllTests.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/test/AllTests.java
@@ -17,10 +17,10 @@ import de.dlr.sc.virsat.apps.api.external.ModelAPITest;
 import de.dlr.sc.virsat.build.validator.core.DvlmLatestConceptValidatorTest;
 import de.dlr.sc.virsat.build.validator.core.RepoValidatorsInstantiatorTest;
 import de.dlr.sc.virsat.model.concept.list.ArrayInstanceListIteratorTest;
-import de.dlr.sc.virsat.model.concept.list.ArrayUpdateTest;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanCategoryAssignmentFactoryTest;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanStructuralElementInstanceFactoryTest;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyReferenceTest;
+import de.dlr.sc.virsat.model.concept.types.property.ReferenceUpdateTest;
 import de.dlr.sc.virsat.model.concept.types.structural.level.HierarchyLevelCheckerTest;
 import de.dlr.sc.virsat.model.concept.types.structural.tree.BeanStructuralTreeTraverserTest;
 import de.dlr.sc.virsat.model.concept.types.util.BeanCategoryAssignmentHelperTest;
@@ -79,7 +79,7 @@ import junit.framework.JUnit4TestAdapter;
 				MatImporterTest.class,
 				MatExporterTest.class,
 				BeanPropertyReferenceTest.class,
-				ArrayUpdateTest.class
+				ReferenceUpdateTest.class
 				})
 
 /**

--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/test/AllTests.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/test/AllTests.java
@@ -17,6 +17,7 @@ import de.dlr.sc.virsat.apps.api.external.ModelAPITest;
 import de.dlr.sc.virsat.build.validator.core.DvlmLatestConceptValidatorTest;
 import de.dlr.sc.virsat.build.validator.core.RepoValidatorsInstantiatorTest;
 import de.dlr.sc.virsat.model.concept.list.ArrayInstanceListIteratorTest;
+import de.dlr.sc.virsat.model.concept.list.ArrayUpdateTest;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanCategoryAssignmentFactoryTest;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanStructuralElementInstanceFactoryTest;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyReferenceTest;
@@ -77,7 +78,8 @@ import junit.framework.JUnit4TestAdapter;
 				RepoValidatorsInstantiatorTest.class,
 				MatImporterTest.class,
 				MatExporterTest.class,
-				BeanPropertyReferenceTest.class
+				BeanPropertyReferenceTest.class,
+				ArrayUpdateTest.class
 				})
 
 /**

--- a/de.dlr.sc.virsat.model.extension.tests/src-gen/de/dlr/sc/virsat/model/extension/tests/model/ATestCategoryBase.java
+++ b/de.dlr.sc.virsat.model.extension.tests/src-gen/de/dlr/sc/virsat/model/extension/tests/model/ATestCategoryBase.java
@@ -144,13 +144,11 @@ public abstract class ATestCategoryBase extends GenericCategory implements IBean
 		ReferencePropertyInstance propertyInstance = (ReferencePropertyInstance) helper.getPropertyInstance("testReference");
 		CategoryAssignment ca = (CategoryAssignment) propertyInstance.getReference();
 		
-		if (ca != null) {
-			if (testReference == null) {
-				createTestReference(ca);
-			}
-			testReference.setTypeInstance(ca);
-		} else {
+		// Temporary manual fix before all generated code is updated
+		if (ca == null) {
 			testReference = null;
+		} else if (testReference == null || !testReference.getTypeInstance().equals(ca)) {
+			createTestReference(ca);
 		}
 	}
 	

--- a/de.dlr.sc.virsat.model.extension.tests/src-gen/de/dlr/sc/virsat/model/extension/tests/model/ATestCategoryReference.java
+++ b/de.dlr.sc.virsat.model.extension.tests/src-gen/de/dlr/sc/virsat/model/extension/tests/model/ATestCategoryReference.java
@@ -87,13 +87,11 @@ public abstract class ATestCategoryReference extends GenericCategory implements 
 		ReferencePropertyInstance propertyInstance = (ReferencePropertyInstance) helper.getPropertyInstance("testRefCategory");
 		CategoryAssignment ca = (CategoryAssignment) propertyInstance.getReference();
 		
-		if (ca != null) {
-			if (testRefCategory == null) {
-				createTestRefCategory(ca);
-			}
-			testRefCategory.setTypeInstance(ca);
-		} else {
+		// Temporary manual fix before all generated code is updated
+		if (ca == null) {
 			testRefCategory = null;
+		} else if (testRefCategory == null || !testRefCategory.getTypeInstance().equals(ca)) {
+			createTestRefCategory(ca);
 		}
 	}
 	


### PR DESCRIPTION
The bug with re-referencing #486 is not reproducing with the new reference bean.
So this request just adds a couple of test cases to test this functionality.