### PR TITLE
Feature/task 684 enable filtering of available objects in reference selection dialog

### DIFF
--- a/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/AFilteredContentProvider.java
+++ b/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/AFilteredContentProvider.java
@@ -11,6 +11,7 @@ package de.dlr.sc.virsat.project.ui.contentProvider;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * Abstract class for filtering content.
@@ -20,6 +21,7 @@ public abstract class AFilteredContentProvider {
 
 	protected Set<String> filterElementCategoryIds;
 	protected Set<String> filterElementStructuralElementIds;
+	protected Set<Function<Object, Boolean>> filterElementFunctions;
 
 	/**
 	 * Filters the objects for the desired ids
@@ -41,6 +43,7 @@ public abstract class AFilteredContentProvider {
 		filterElementClasses = new HashSet<>();
 		filterElementCategoryIds = new HashSet<>();
 		filterElementStructuralElementIds = new HashSet<>();
+		filterElementFunctions = new HashSet<>();
 	}
 
 	/**
@@ -71,6 +74,44 @@ public abstract class AFilteredContentProvider {
 	public AFilteredContentProvider addStructuralElementIdFilterToGetElement(String filterId) {
 		filterElementStructuralElementIds.add(filterId);
 		return (this);
+	}
+
+	/**
+	 * Use this method to add a filtering function
+	 * @param filter function that the object that should be returned by the GetElement method should satisfy
+	 * @return returns the current instance to easily concatenate various filters.
+	 */
+	public AFilteredContentProvider addFunctionFilterToGetElement(Function<Object, Boolean> filter) {
+		filterElementFunctions.add(filter);
+		return (this);
+	}
+
+	/**
+	 * Use this method to filter objects for a list of filtering functions
+	 * Only objects that satisfy the specified filters will be returned
+	 * @param objects Array of input objects
+	 * @param filterFunctions A set of filtering functions. all objects will be returned if list is empty 
+	 * @return the objects that passed the filter (that have been selected by the filter)
+	 */
+	protected Object[] filterFunctions(Object[] objects, Set<Function<Object, Boolean>> filterFunctions) {
+		Set<Object> filteredObjects = new HashSet<>();
+		// In case there are no filters specified we return all objects
+		if (filterFunctions.isEmpty()) {
+			return objects;
+		}
+		
+		// Now filter the
+		for (Object object : objects) {
+			for (Function<Object, Boolean> filter : filterFunctions) {
+				if (filter.apply(object)) {
+					filteredObjects.add(object);
+					// Object is accepted therefore go to the next
+					// evaluate the next object
+					break;
+				}
+			}
+		}
+		return filteredObjects.toArray();
 	}
 
 	/**

--- a/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/AFilteredContentProvider.java
+++ b/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/AFilteredContentProvider.java
@@ -63,7 +63,7 @@ public abstract class AFilteredContentProvider {
 	 */
 	public AFilteredContentProvider addCategoryIdFilterToGetElement(String filterId) {
 		filterElementCategoryIds.add(filterId);
-		return (this);
+		return this;
 	}
 	
 	/**
@@ -73,7 +73,7 @@ public abstract class AFilteredContentProvider {
 	 */
 	public AFilteredContentProvider addStructuralElementIdFilterToGetElement(String filterId) {
 		filterElementStructuralElementIds.add(filterId);
-		return (this);
+		return this;
 	}
 
 	/**
@@ -83,7 +83,7 @@ public abstract class AFilteredContentProvider {
 	 */
 	public AFilteredContentProvider addFunctionFilterToGetElement(Function<Object, Boolean> filter) {
 		filterElementFunctions.add(filter);
-		return (this);
+		return this;
 	}
 
 	/**

--- a/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/AFilteredContentProvider.java
+++ b/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/AFilteredContentProvider.java
@@ -88,25 +88,21 @@ public abstract class AFilteredContentProvider {
 
 	/**
 	 * Use this method to filter objects for a list of filtering functions
-	 * Only objects that satisfy the specified filters will be returned
+	 * Only objects that satisfy at least one of the specified filters will be returned
 	 * @param objects Array of input objects
 	 * @param filterFunctions A set of filtering functions. all objects will be returned if list is empty 
 	 * @return the objects that passed the filter (that have been selected by the filter)
 	 */
 	protected Object[] filterFunctions(Object[] objects, Set<Function<Object, Boolean>> filterFunctions) {
 		Set<Object> filteredObjects = new HashSet<>();
-		// In case there are no filters specified we return all objects
 		if (filterFunctions.isEmpty()) {
 			return objects;
 		}
 		
-		// Now filter the
 		for (Object object : objects) {
 			for (Function<Object, Boolean> filter : filterFunctions) {
 				if (filter.apply(object)) {
 					filteredObjects.add(object);
-					// Object is accepted therefore go to the next
-					// evaluate the next object
 					break;
 				}
 			}
@@ -123,18 +119,14 @@ public abstract class AFilteredContentProvider {
 	 */
 	protected Object[] filterClasses(Object[] objects, Set<Class<?>> classFilters) {
 		Set<Object> filteredObjects = new HashSet<>();
-		// In case there are no filters specified we return all objects
 		if (classFilters.isEmpty()) {
 			return objects;
 		}
 		
-		// Now filter the
 		for (Object object : objects) {
 			for (Class<?> clazz : classFilters) {
 				if (clazz.isAssignableFrom(object.getClass())) {
 					filteredObjects.add(object);
-					// Object is accepted therefore go to the next
-					// evaluate the next object
 					break;
 				}
 			}

--- a/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/VirSatFilteredListContentProvider.java
+++ b/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/VirSatFilteredListContentProvider.java
@@ -57,8 +57,9 @@ public class VirSatFilteredListContentProvider extends AFilteredContentProvider 
 			Object[] elements = objects.toArray();
 			Object[] filteredClasses = filterClasses(elements, filterElementClasses);
 			Object[] filteredIds = filterIds(filteredClasses, filterElementCategoryIds, filterElementStructuralElementIds);
+			Object[] filteredFunctions = filterFunctions(filteredIds, filterElementFunctions);
 			
-			return filteredIds;
+			return filteredFunctions;
 		} else if (inputElement instanceof Resource) {
 			List<Object> objects = new ArrayList<>();
 			for (EObject content : ((Resource) inputElement).getContents()) {

--- a/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/VirSatFilteredWrappedTreeContentProvider.java
+++ b/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/VirSatFilteredWrappedTreeContentProvider.java
@@ -127,6 +127,17 @@ public class VirSatFilteredWrappedTreeContentProvider extends AFilteredContentPr
 		addCategoryIdFilterToGetChildren(filterId);
 		return (this);
 	}
+
+	/**
+	 * Use this method to add an ID for a specific type id of the StructuralElement Concept
+	 * @param filterId the ID of the object that should be returned by the GetElement and GetChildren method
+	 * @return returns the current instance to easily concatenate various filters.
+	 */
+	public VirSatFilteredWrappedTreeContentProvider addStructuralElementIdFilter(String filterId) {
+		addStructuralElementIdFilterToGetElement(filterId);
+		addStructuralElementIdFilterToGetChildren(filterId);
+		return (this);
+	}
 	
 	/**
 	 * Use this method to add a custom filtering function

--- a/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/VirSatFilteredWrappedTreeContentProvider.java
+++ b/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/VirSatFilteredWrappedTreeContentProvider.java
@@ -49,6 +49,7 @@ public class VirSatFilteredWrappedTreeContentProvider extends AFilteredContentPr
 		filterChildrenClasses = new HashSet<>();
 		filterChildrenCategoryIds = new HashSet<>();
 		filterChildrenStructuralElementIds = new HashSet<>();
+		filterChildrenFunctions = new HashSet<>();
 	}
 
 	/**

--- a/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/VirSatFilteredWrappedTreeContentProvider.java
+++ b/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/VirSatFilteredWrappedTreeContentProvider.java
@@ -12,6 +12,7 @@ package de.dlr.sc.virsat.project.ui.contentProvider;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -63,6 +64,7 @@ public class VirSatFilteredWrappedTreeContentProvider extends AFilteredContentPr
 	private Set<String> filterChildrenCategoryIds;
 	private Set<String> filterChildrenStructuralElementIds;
 	private Set<Class<?>> filterChildrenClasses;
+	private Set<Function<Object, Boolean>> filterChildrenFunctions;
 
 	/**
 	 * This method adds a class filter to the GetChildren Method
@@ -106,6 +108,16 @@ public class VirSatFilteredWrappedTreeContentProvider extends AFilteredContentPr
 	}
 
 	/**
+	 * Use this method to add a custom filtering function
+	 * @param filter the filter that the objects returned by the GetChildren method should satisfy
+	 * @return returns the current instance to easily concatenate various filters.
+	 */
+	public VirSatFilteredWrappedTreeContentProvider addFunctionFilterToGetChildren(Function<Object, Boolean> filter) {
+		filterChildrenFunctions.add(filter);
+		return (this);
+	}
+
+	/**
 	 * Use this method to add an ID for a specific type id of the Category and Property Concept
 	 * @param filterId the ID of the object that should be returned by the GetElement and GetChildren method
 	 * @return returns the current instance to easily concatenate various filters.
@@ -117,13 +129,13 @@ public class VirSatFilteredWrappedTreeContentProvider extends AFilteredContentPr
 	}
 	
 	/**
-	 * Use this method to add an ID for a specific type id of the StructuralElement Concept
-	 * @param filterId the ID of the object that should be returned by the GetElement and GetChildren method
+	 * Use this method to add a custom filtering function
+	 * @param filter the filter that the objects returned by the GetElement and GetChildren methods should satisfy
 	 * @return returns the current instance to easily concatenate various filters.
 	 */
-	public VirSatFilteredWrappedTreeContentProvider addStructuralElementIdFilter(String filterId) {
-		addStructuralElementIdFilterToGetElement(filterId);
-		addStructuralElementIdFilterToGetChildren(filterId);
+	public VirSatFilteredWrappedTreeContentProvider addFunctionFilter(Function<Object, Boolean> filter) {
+		addFunctionFilterToGetElement(filter);
+		addFunctionFilterToGetChildren(filter);
 		return (this);
 	}
 	
@@ -148,7 +160,8 @@ public class VirSatFilteredWrappedTreeContentProvider extends AFilteredContentPr
 		Object[] allObjects = wrappedContentProvider.getElements(rootObject);
 		Object[] filteredClasses = filterClasses(allObjects, filterElementClasses);
 		Object[] filteredInstances = filterIds(filteredClasses, filterElementCategoryIds, filterElementStructuralElementIds);
-		return filteredInstances;
+		Object[] filteredFunctions = filterFunctions(filteredInstances, filterElementFunctions);
+		return filteredFunctions;
 	}
 	
 	@Override
@@ -156,7 +169,8 @@ public class VirSatFilteredWrappedTreeContentProvider extends AFilteredContentPr
 		Object[] allObjects = wrappedContentProvider.getChildren(parentObject);
 		Object[] filteredClasses = filterClasses(allObjects, filterChildrenClasses);
 		Object[] filteredInstances = filterIds(filteredClasses, filterChildrenCategoryIds, filterChildrenStructuralElementIds);
-		return filteredInstances;
+		Object[] filteredFunctions = filterFunctions(filteredInstances, filterChildrenFunctions);
+		return filteredFunctions;
 	}
 
 	@Override

--- a/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/cellEditor/aproperties/ReferencePropertyCellEditingSupport.java
+++ b/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/cellEditor/aproperties/ReferencePropertyCellEditingSupport.java
@@ -9,6 +9,10 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.uiengine.ui.cellEditor.aproperties;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.edit.command.SetCommand;
@@ -42,6 +46,7 @@ import de.dlr.sc.virsat.model.dvlm.provider.DVLMDVLMItemProviderAdapterFactory;
 import de.dlr.sc.virsat.model.dvlm.roles.provider.RolesItemProviderAdapterFactory;
 import de.dlr.sc.virsat.model.dvlm.structural.provider.DVLMStructuralItemProviderAdapterFactory;
 import de.dlr.sc.virsat.model.dvlm.units.provider.UnitsItemProviderAdapterFactory;
+import de.dlr.sc.virsat.project.ui.contentProvider.VirSatFilteredListContentProvider;
 import de.dlr.sc.virsat.uiengine.ui.dialog.ReferenceSelectionDialog;
 
 /**
@@ -93,6 +98,7 @@ public class ReferencePropertyCellEditingSupport extends APropertyCellEditingSup
 				dialog.setAllowMultiple(false);
 				dialog.setDoubleClickSelects(true);
 				setReferenceDialogInput(propertyInstance.eResource());
+				setFiltersForDialog();
 				dialog.setInitialSelection(toSelect);
 				if (dialog.open() == Dialog.OK) {
 					Object selection = dialog.getFirstResult();
@@ -118,6 +124,21 @@ public class ReferencePropertyCellEditingSupport extends APropertyCellEditingSup
 		};
 		return editor;
 	}
+	
+	protected void setFiltersForDialog() {
+		VirSatFilteredListContentProvider cp = (VirSatFilteredListContentProvider) ((ReferenceSelectionDialog) dialog).getContentProvider();
+		getResultFilters().forEach(cp::addFunctionFilterToGetElement);
+	}
+	
+	/**
+	 * An overridable method to filter the dialogs selectable objects
+	 * 
+	 * @return filter functions
+	 */
+	protected List<Function<Object, Boolean>> getResultFilters() {
+		return new ArrayList<>();
+	}
+
 	/**
 	 * An overridable method to set dialog input
 	 * @param input the input for the dialog

--- a/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/dialog/ReferenceSelectionDialog.java
+++ b/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/dialog/ReferenceSelectionDialog.java
@@ -420,4 +420,8 @@ public class ReferenceSelectionDialog extends ElementTreeSelectionDialog {
 		treeViewer.setComparator(new VirSatNavigatorSeiSorter());
 		return treeViewer;
 	}
+	
+	public IStructuredContentProvider getContentProvider() {
+		return contentProviderList;
+	}
 }


### PR DESCRIPTION
New pull request for the same issue. Based on your feedback for the first one.

Closes #684