### PR TITLE
Git and SVN backends now properly resolve merge conflicts and dialogs show backend errors

### DIFF
--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/versioningbackend/AVersioningBackendTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/versioningbackend/AVersioningBackendTest.java
@@ -115,9 +115,7 @@ public abstract class AVersioningBackendTest extends ASwtBotTestCase {
 		roleManagementNode.doubleClick();
 		
 		// Run the update in Virtual Satellite
-		buildCounter.executeInterlocked(() -> {
-			roleManagementNode.contextMenu("Update Project from Repository").click();
-		});
+		updateProject();
 		
 		// Assert that the node got correctly updated in the navigator
 		navigatorView.bot().tree().getTreeItem("SWTBotTestProject").getNode("Role Management").getNode("Discipline: SubSystem");
@@ -167,9 +165,7 @@ public abstract class AVersioningBackendTest extends ASwtBotTestCase {
 		assertTrue("The button is enabled", rmEditor.bot().button("Add Discipline").isEnabled());
 		
 		// Run the update in Virtual Satellite
-		buildCounter.executeInterlocked(() -> {
-			roleManagementNode.contextMenu("Update Project from Repository").click();
-		});
+		updateProject();
 		
 		// Open the editor and check if that the button is disabled
 		SWTBotEditor rmEditor2 = bot.editorByTitle("Role Management");
@@ -192,6 +188,17 @@ public abstract class AVersioningBackendTest extends ASwtBotTestCase {
 			projectNode.contextMenu("Commit Project to Repository").click();
 			bot.text().setText(SWTBOT_COMMIT_MESSAGE);
 			bot.button("OK").click();
+		});
+	}
+	
+	/**
+	 * Use the context menu to update the project.
+	 */
+	public void updateProject() {
+		buildCounter.executeInterlocked(() -> {
+			SWTBotTreeItem projectNode = bot.tree().getTreeItem("SWTBotTestProject");
+			projectNode.select();
+			projectNode.contextMenu("Update Project from Repository").click();
 		});
 	}
 }

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/versioningbackend/GitVersioningBackendTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/versioningbackend/GitVersioningBackendTest.java
@@ -188,4 +188,20 @@ public class GitVersioningBackendTest extends AVersioningBackendTest {
 		Git.wrap(remoteGitRepository)
 			.close();
 	}
+	
+	@Override
+	public void commitProject() {
+		super.commitProject();
+		
+		// Close the EGit window reporting the push result
+		bot.button("Close").click();
+	}
+	
+	@Override
+	public void updateProject() {
+		super.updateProject();
+		
+		// Close the EGit window reporting the pull result
+		bot.button("Close").click();
+	}
 }

--- a/de.dlr.sc.virsat.team.test/src/de/dlr/sc/virsat/team/svn/VirSatSvnVersionControlBackendTest.java
+++ b/de.dlr.sc.virsat.team.test/src/de/dlr/sc/virsat/team/svn/VirSatSvnVersionControlBackendTest.java
@@ -12,12 +12,16 @@ package de.dlr.sc.virsat.team.svn;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.team.svn.core.connector.SVNDepth;
+import org.eclipse.team.svn.core.operation.file.AddToSVNOperation;
 import org.eclipse.team.svn.core.operation.file.CheckoutAsOperation;
 import org.eclipse.team.svn.core.resource.IRepositoryResource;
+import org.eclipse.team.svn.core.utility.FileUtility;
 import org.eclipse.team.svn.core.utility.SVNUtility;
 import org.junit.Before;
 
@@ -60,5 +64,17 @@ public class VirSatSvnVersionControlBackendTest extends AVirSatVersionControlBac
 		super.setUp();
 
 		backend = new VirSatSvnVersionControlBackend();
+	}
+	
+	@Override
+	protected void ensureFileCanConflict(IFile file) {
+		// SVN requires files to be added or else it will not detect conflicts on the files
+		// Therefore we perform the add operation to ensure that SVN recognizes that local changes
+		// to a file can conflict with remote changes
+		
+		File workingFile = new File(FileUtility.getWorkingCopyPath(file));
+		File[] files = { workingFile };
+		AddToSVNOperation addToSVNOperation = new AddToSVNOperation(files, true);
+		addToSVNOperation.run(new NullProgressMonitor());
 	}
 }

--- a/de.dlr.sc.virsat.team.ui/src/de/dlr/sc/virsat/team/ui/handler/git/GitCommitHandler.java
+++ b/de.dlr.sc.virsat.team.ui/src/de/dlr/sc/virsat/team/ui/handler/git/GitCommitHandler.java
@@ -9,7 +9,16 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.team.ui.handler.git;
 
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.egit.core.op.PushOperationResult;
+import org.eclipse.egit.core.project.RepositoryMapping;
 import org.eclipse.egit.ui.internal.credentials.EGitCredentialsProvider;
+import org.eclipse.egit.ui.internal.push.PushMode;
+import org.eclipse.egit.ui.internal.push.ShowPushResultAction;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.transport.PushResult;
+import org.eclipse.swt.widgets.Display;
 
 import de.dlr.sc.virsat.team.IVirSatVersionControlBackend;
 import de.dlr.sc.virsat.team.git.VirSatGitVersionControlBackend;
@@ -25,5 +34,27 @@ public class GitCommitHandler extends AVersionControlCommitHandler {
 	protected IVirSatVersionControlBackend createVersionControlBackend() {
 		return new VirSatGitVersionControlBackend(new EGitCredentialsProvider());
 	}
-
+	
+	@Override
+	protected void doCommit(IProject project, String message, IProgressMonitor monitor) throws Exception {
+		super.doCommit(project, message, monitor);
+		
+		VirSatGitVersionControlBackend gitBackend = (VirSatGitVersionControlBackend) backend;
+		
+		// Create an interim push operation result object for passing on to egit
+		PushOperationResult pushOperationResult = new PushOperationResult();
+		Iterable<PushResult> lastPushResults = gitBackend.getLastPushResults();
+		for (PushResult pushResult : lastPushResults) {
+			pushOperationResult.addOperationResult(pushResult.getURI(), pushResult);
+		}
+		
+		// Create the actual egit dialog for showing push results
+		Repository gitRepository = RepositoryMapping.getMapping(project).getRepository();
+		String destination = lastPushResults.iterator().next().getURI().toString();
+		ShowPushResultAction showPushResultAction = 
+				new ShowPushResultAction(gitRepository, pushOperationResult, destination, false, PushMode.UPSTREAM);
+		
+		// Run it in the display thread since we will be showing UI
+		Display.getDefault().asyncExec(() -> showPushResultAction.run());
+	}
 }

--- a/de.dlr.sc.virsat.team.ui/src/de/dlr/sc/virsat/team/ui/handler/git/GitUpdateHandler.java
+++ b/de.dlr.sc.virsat.team.ui/src/de/dlr/sc/virsat/team/ui/handler/git/GitUpdateHandler.java
@@ -9,7 +9,14 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.team.ui.handler.git;
 
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.egit.core.project.RepositoryMapping;
 import org.eclipse.egit.ui.internal.credentials.EGitCredentialsProvider;
+import org.eclipse.egit.ui.internal.pull.PullResultDialog;
+import org.eclipse.jgit.api.PullResult;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.swt.widgets.Display;
 
 import de.dlr.sc.virsat.team.IVirSatVersionControlBackend;
 import de.dlr.sc.virsat.team.git.VirSatGitVersionControlBackend;
@@ -27,4 +34,20 @@ public class GitUpdateHandler extends AVersionControlUpdateHandler {
 		return new VirSatGitVersionControlBackend(new EGitCredentialsProvider());
 	}
 
+	@Override
+	protected void doUpdate(IProject project, IProgressMonitor monitor) throws Exception {
+		super.doUpdate(project, monitor);
+		
+		VirSatGitVersionControlBackend gitBackend = (VirSatGitVersionControlBackend) backend;
+		PullResult pullResult = gitBackend.getLastPullResult();
+		
+		Repository gitRepository = RepositoryMapping.getMapping(project).getRepository();
+
+		// Build the dialog in the UI thread
+		Display.getDefault().asyncExec(() -> {
+			PullResultDialog pullResultDialog = 
+					new PullResultDialog(Display.getDefault().getActiveShell(), gitRepository, pullResult);
+			pullResultDialog.open();
+		});
+	}
 }


### PR DESCRIPTION
- The simple THEIRS strategy for the git backend is replaced by the default strategy RECURSIVE + all conflicting files are replaced with the remote version. As a result, instead of discarding all local changes, only conflicting changes are discarded in a merge.
- SVN now calls resolve to replaced conflicted files with the remote version
- Added new test case to check that a.) conflict resolution is applied correctly in both backends (replace with remote in case of conflict) and b.) only conflicting files are affected by this.
- Added EGit dialogs that show the push and pull results for error feedback
- Adapted SWTBot test cases to close the new EGit dialogs

Closes #708