### PR TITLE
Initializing value of cell editor for reference properties  - (Task #86)

### DIFF
--- a/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/cellEditor/aproperties/ReferencePropertyCellEditingSupport.java
+++ b/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/cellEditor/aproperties/ReferencePropertyCellEditingSupport.java
@@ -24,6 +24,7 @@ import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.viewers.CellEditor;
 import org.eclipse.jface.viewers.ColumnViewer;
 import org.eclipse.jface.viewers.DialogCellEditor;
+import org.eclipse.jface.viewers.ViewerCell;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
@@ -152,6 +153,11 @@ public class ReferencePropertyCellEditingSupport extends APropertyCellEditingSup
 		APropertyInstance propertyInstance = getPropertyInstance(element);
 		ATypeInstance value = ((ReferencePropertyInstance) propertyInstance).getReference();
 		return value;
+	}
+	
+	@Override
+	protected void initializeCellEditorValue(CellEditor cellEditor, ViewerCell cell) {
+		cellEditor.setValue(cell.getText());
 	}
 	
 	@Override


### PR DESCRIPTION
- Setting initial value of cell editor for reference properties to the
same text as the cell label

Closes #86

---
Task #86: Reference property in table of containing SEI shows
toString()-Output when clicking into property table