### PR TITLE
Added check for int type in setter - (Task #700)

### DIFF
--- a/de.dlr.sc.virsat.model.calculation.test/src/de/dlr/sc/virsat/model/calculation/compute/EquationHelperTest.java
+++ b/de.dlr.sc.virsat.model.calculation.test/src/de/dlr/sc/virsat/model/calculation/compute/EquationHelperTest.java
@@ -34,6 +34,7 @@ import de.dlr.sc.virsat.model.dvlm.calculation.TypeDefinitionResult;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoriesFactory;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.FloatProperty;
 import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.IntProperty;
 import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.PropertydefinitionsFactory;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.UnitValuePropertyInstance;
@@ -72,7 +73,7 @@ public class EquationHelperTest extends AEquationTest {
 		cat.setIsApplicableForAll(true);
 		contents.add(cat);
 		
-		IntProperty value = PropertydefinitionsFactory.eINSTANCE.createIntProperty();
+		FloatProperty value = PropertydefinitionsFactory.eINSTANCE.createFloatProperty();
 		value.setName("value");
 		cat.getProperties().add(value);
 		

--- a/de.dlr.sc.virsat.model.calculation.test/src/de/dlr/sc/virsat/model/calculation/compute/NumberLiteralSetterTest.java
+++ b/de.dlr.sc.virsat.model.calculation.test/src/de/dlr/sc/virsat/model/calculation/compute/NumberLiteralSetterTest.java
@@ -16,10 +16,16 @@ import java.util.List;
 
 import org.junit.Test;
 
+import de.dlr.sc.virsat.model.calculation.compute.extensions.NumberLiteralResult;
 import de.dlr.sc.virsat.model.calculation.compute.extensions.NumberLiteralSetter;
 import de.dlr.sc.virsat.model.calculation.compute.extensions.UnresolvedExpressionResult;
 import de.dlr.sc.virsat.model.calculation.compute.problem.EvaluationProblem;
 import de.dlr.sc.virsat.model.calculation.compute.problem.UnknownExpressionProblem;
+import de.dlr.sc.virsat.model.dvlm.calculation.CalculationFactory;
+import de.dlr.sc.virsat.model.dvlm.calculation.NumberLiteral;
+import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.FloatProperty;
+import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.IntProperty;
+import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.PropertydefinitionsFactory;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.PropertyinstancesFactory;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyInstance;
 
@@ -30,6 +36,45 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyIns
  */
 
 public class NumberLiteralSetterTest {
+	
+	@Test
+	public void testSetDoubleExpressionResultOnFloatProperty() {
+		NumberLiteralSetter nls = new NumberLiteralSetter();
+		
+		final String VALUE = "1.5";
+		
+		NumberLiteral nl = CalculationFactory.eINSTANCE.createNumberLiteral();
+		nl.setValue(VALUE);
+		NumberLiteralResult nlr = new NumberLiteralResult(nl);
+		ValuePropertyInstance vpi = PropertyinstancesFactory.eINSTANCE.createValuePropertyInstance();
+		FloatProperty fp = PropertydefinitionsFactory.eINSTANCE.createFloatProperty();
+		vpi.setType(fp);
+		
+		List<EvaluationProblem> problems = nls.set(vpi, nlr);
+		
+		assertTrue("No problems occurred during the set operation", problems.isEmpty());
+		assertEquals("The value has been set correctly", VALUE, vpi.getValue());
+	}
+	
+	@Test
+	public void testSetDoubleExpressionResultOnIntProperty() {
+		NumberLiteralSetter nls = new NumberLiteralSetter();
+		
+		final String VALUE = "1.5";
+		final String EXPECTED_VALUE = "1";
+		
+		NumberLiteral nl = CalculationFactory.eINSTANCE.createNumberLiteral();
+		nl.setValue(VALUE);
+		NumberLiteralResult nlr = new NumberLiteralResult(nl);
+		ValuePropertyInstance vpi = PropertyinstancesFactory.eINSTANCE.createValuePropertyInstance();
+		IntProperty ip = PropertydefinitionsFactory.eINSTANCE.createIntProperty();
+		vpi.setType(ip);
+		
+		List<EvaluationProblem> problems = nls.set(vpi, nlr);
+		
+		assertTrue("No problems occurred during the set operation", problems.isEmpty());
+		assertEquals("The value has been set correctly", EXPECTED_VALUE, vpi.getValue());
+	}
 	
 	@Test
 	public void testSetUnknownExpressionResult() {

--- a/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/compute/extensions/NumberLiteralSetter.java
+++ b/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/compute/extensions/NumberLiteralSetter.java
@@ -22,7 +22,9 @@ import de.dlr.sc.virsat.model.calculation.compute.problem.IncompatibleQuantityKi
 import de.dlr.sc.virsat.model.calculation.compute.problem.UnknownExpressionProblem;
 import de.dlr.sc.virsat.model.dvlm.calculation.CalculationFactory;
 import de.dlr.sc.virsat.model.dvlm.calculation.NumberLiteral;
+import de.dlr.sc.virsat.model.dvlm.categories.ATypeDefinition;
 import de.dlr.sc.virsat.model.dvlm.categories.ATypeInstance;
+import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.IntProperty;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.UnitValuePropertyInstance;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyInstance;
 import de.dlr.sc.virsat.model.dvlm.qudv.AQuantityKind;
@@ -58,7 +60,7 @@ public class NumberLiteralSetter implements IResultSetter {
 		
 		// Now check if this is not just a ValuePropertyInstance but also
 		// a UnitValuePropertyInstance with an assigned unit. If so we need
-		// to convert the value
+		// to convert the value from the base unit to the unit of the instance
 		
 		if (instance instanceof UnitValuePropertyInstance) {
 			AUnit targetUnit = ((UnitValuePropertyInstance) instance).getUnit();
@@ -79,7 +81,17 @@ public class NumberLiteralSetter implements IResultSetter {
 			}
 		}
 		
-		instance.setValue(result.toString());
+		ATypeDefinition type = instance.getType();
+		if (type instanceof IntProperty) {
+			// Check if the target instance is a integer property and if so, cut off the fractionals
+			NumberLiteralHelper nlh = new NumberLiteralHelper(result.getNumberLiteral());
+			int integerValue = (int) nlh.getValue();
+			instance.setValue(String.valueOf(integerValue));
+		} else {
+			// Otherwise we can directly set the value
+			instance.setValue(result.toString());
+		}
+		
 		return setProblems;
 	}
 


### PR DESCRIPTION
- Checking if the target property is an int property. If so, the result
value is now cast to int before being set

Closes #700

---
Task #700: Calculation engine assigns double values to int properties