### PR TITLE
Refactored excel exporter constants - (Task #737)

### DIFF
--- a/de.dlr.sc.virsat.excel/src/de/dlr/sc/virsat/excel/AExcelIo.java
+++ b/de.dlr.sc.virsat.excel/src/de/dlr/sc/virsat/excel/AExcelIo.java
@@ -15,9 +15,9 @@ package de.dlr.sc.virsat.excel;
  */
 public abstract class AExcelIo {
 
-	public static final int HEADER_ROW_STRUCTURALELEMENTUUID = 4;
-	public static final int HEADER_ROW_STRUCTURALELEMENTNAME = 5;
-	public static final int HEADER_ROW_STRUCTURALELEMENTTYPE = 6;
+	public static final int HEADER_ROW_STRUCTURALELEMENT_UUID = 4;
+	public static final int HEADER_ROW_STRUCTURALELEMENT_NAME = 5;
+	public static final int HEADER_ROW_STRUCTURALELEMENT_TYPE = 6;
 	public static final int HEADER_ROW_USER = 7;
 	public static final int HEADER_ROW_DATE = 8;
 	public static final int HEADER_ROW_TIME = 9;
@@ -26,11 +26,6 @@ public abstract class AExcelIo {
 	public static final int COMMON_COLUMN_DELETE = 1;
 	public static final int COMMON_ROW_START_TABLE = 4;
 	public static final String COMMON_DELETEMARK_VALUE = "1.0";
-
-	public static final int INTERFACE_COLUMN_INTERFACE_TO = 4;
-
-	public static final int INTERFACEEND_COLUMN_INTERFACEEND_NAME = 2;
-	public static final int INTERFACEEND_COLUMN_INTERFACEEND_TYPE = 3;
 
 	public static final String TEMPLATE_SHEETNAME_HEADER = "Header";
 }

--- a/de.dlr.sc.virsat.excel/src/de/dlr/sc/virsat/excel/exporter/ExcelExportHelper.java
+++ b/de.dlr.sc.virsat.excel/src/de/dlr/sc/virsat/excel/exporter/ExcelExportHelper.java
@@ -108,13 +108,13 @@ public class ExcelExportHelper {
 		}
 
 		// Just write the values, the property names should be in the header already
-		Row row = headerSheet.getRow(AExcelIo.HEADER_ROW_STRUCTURALELEMENTUUID);
+		Row row = headerSheet.getRow(AExcelIo.HEADER_ROW_STRUCTURALELEMENT_UUID);
 		row.getCell(1).setCellValue(getCreationHelper().createRichTextString(exportSei.getUuid().toString()));
 
-		row = headerSheet.getRow(AExcelIo.HEADER_ROW_STRUCTURALELEMENTNAME);
+		row = headerSheet.getRow(AExcelIo.HEADER_ROW_STRUCTURALELEMENT_NAME);
 		row.getCell(datacell).setCellValue(getCreationHelper().createRichTextString(exportSei.getName()));
 
-		row = headerSheet.getRow(AExcelIo.HEADER_ROW_STRUCTURALELEMENTTYPE);
+		row = headerSheet.getRow(AExcelIo.HEADER_ROW_STRUCTURALELEMENT_TYPE);
 		row.getCell(datacell).setCellValue(getCreationHelper().createRichTextString(exportSei.getType().getName()));
 
 		row = headerSheet.getRow(AExcelIo.HEADER_ROW_USER);

--- a/de.dlr.sc.virsat.model.extension.funcelectrical/src/de/dlr/sc/virsat/model/extension/funcelectrical/excel/AExcelFuncIO.java
+++ b/de.dlr.sc.virsat.model.extension.funcelectrical/src/de/dlr/sc/virsat/model/extension/funcelectrical/excel/AExcelFuncIO.java
@@ -13,6 +13,11 @@ import de.dlr.sc.virsat.excel.AExcelIo;
 
 public abstract class AExcelFuncIO extends AExcelIo {
 
+	public static final int INTERFACE_COLUMN_INTERFACE_TO = 4;
+
+	public static final int INTERFACEEND_COLUMN_INTERFACEEND_NAME = 2;
+	public static final int INTERFACEEND_COLUMN_INTERFACEEND_TYPE = 3;
+	
 	public static final int INTERFACE_COLUMN_INTERFACE_NAME = 2;
 	public static final int INTERFACE_COLUMN_INTERFACE_FROM = 3;
 	public static final int INTERFACETYPES_COLUMN_INTERFACETYPE_NAME = 2;

--- a/de.dlr.sc.virsat.model.extension.funcelectrical/src/de/dlr/sc/virsat/model/extension/funcelectrical/excel/importer/ImportValidator.java
+++ b/de.dlr.sc.virsat.model.extension.funcelectrical/src/de/dlr/sc/virsat/model/extension/funcelectrical/excel/importer/ImportValidator.java
@@ -259,14 +259,14 @@ public class ImportValidator {
 		final int sheetIndex = wb.getSheetIndex(AExcelFuncIO.TEMPLATE_SHEETNAME_HEADER);
 
 		// Control if we are importing the correct Structural element by comparing UUIDs
-		String tempUUID = Objects.toString(sheet.getRow(AExcelFuncIO.HEADER_ROW_STRUCTURALELEMENTUUID).getCell(1), "");
+		String tempUUID = Objects.toString(sheet.getRow(AExcelFuncIO.HEADER_ROW_STRUCTURALELEMENT_UUID).getCell(1), "");
 		if (!(importSei.getUuid().toString().equals(tempUUID))) {
-			faultList.add(new Fault(FaultType.STRUCTURAL_ELEMENT_UUIDS_DO_NOT_MATCH, sheetIndex, AExcelFuncIO.HEADER_ROW_STRUCTURALELEMENTUUID));
+			faultList.add(new Fault(FaultType.STRUCTURAL_ELEMENT_UUIDS_DO_NOT_MATCH, sheetIndex, AExcelFuncIO.HEADER_ROW_STRUCTURALELEMENT_UUID));
 		}
 		// Control if we are importing the correct Structural element by comparing NAMEs
-		String tempName = Objects.toString(sheet.getRow(AExcelFuncIO.HEADER_ROW_STRUCTURALELEMENTNAME).getCell(1), "");
+		String tempName = Objects.toString(sheet.getRow(AExcelFuncIO.HEADER_ROW_STRUCTURALELEMENT_NAME).getCell(1), "");
 		if (!(importSei.getName().toString().equals(tempName))) {
-			faultList.add(new Fault(FaultType.STRUCTURAL_ELEMENT_NAMES_DO_NOT_MATCH, sheetIndex, AExcelFuncIO.HEADER_ROW_STRUCTURALELEMENTNAME));
+			faultList.add(new Fault(FaultType.STRUCTURAL_ELEMENT_NAMES_DO_NOT_MATCH, sheetIndex, AExcelFuncIO.HEADER_ROW_STRUCTURALELEMENT_NAME));
 		}
 	}
 }

--- a/de.dlr.sc.virsat.model.extension.statemachines/src/de/dlr/sc/virsat/model/extension/statemachines/excel/exporter/StateMachineExporter.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines/src/de/dlr/sc/virsat/model/extension/statemachines/excel/exporter/StateMachineExporter.java
@@ -117,13 +117,13 @@ public class StateMachineExporter implements IExport {
 		}
 		StateMachine stateMaschine = new StateMachine(exportCa);
 		IBeanList<State> states = stateMaschine.getStates();
-		helper.instantiateCells(sheet, states.size() + AExcelStatIO.COMMON_ROW_START_TABLE, AExcelStatIO.INTERFACEEND_COLUMN_INTERFACEEND_TYPE + 1);
+		helper.instantiateCells(sheet, states.size() + AExcelStatIO.COMMON_ROW_START_TABLE, AExcelStatIO.TRANSITION_COLUMN_TRANSITION_FROM + 1);
 		// for each interface end, fill out a row
 		int i = AExcelStatIO.COMMON_ROW_START_TABLE;
 		for (State state : states) {
 			Row row = sheet.getRow(i);
 			row.getCell(AExcelStatIO.COMMON_COLUMN_UUID).setCellValue(helper.getCreationHelper().createRichTextString(state.getTypeInstance().getUuid().toString()));
-			row.getCell(AExcelStatIO.INTERFACEEND_COLUMN_INTERFACEEND_NAME).setCellValue(helper.getCreationHelper().createRichTextString(state.getName()));
+			row.getCell(AExcelStatIO.TRANSITION_COLUMN_TRANSITION_NAME).setCellValue(helper.getCreationHelper().createRichTextString(state.getName()));
 			i++;
 		}
 	}
@@ -139,7 +139,7 @@ public class StateMachineExporter implements IExport {
 
 		StateMachine stateMaschine = new StateMachine(exportCa);
 		IBeanList<Transition> transitions = stateMaschine.getTransitions();
-		helper.instantiateCells(sheet, transitions.size() + AExcelStatIO.COMMON_ROW_START_TABLE, AExcelStatIO.INTERFACE_COLUMN_INTERFACE_TO + 1);
+		helper.instantiateCells(sheet, transitions.size() + AExcelStatIO.COMMON_ROW_START_TABLE, AExcelStatIO.TRANSITION_COLUMN_TRANSITION_TO + 1);
 		int i = AExcelStatIO.COMMON_ROW_START_TABLE;
 
 		for (Transition transition : transitions) {

--- a/de.dlr.sc.virsat.model.extension.statemachines/src/de/dlr/sc/virsat/model/extension/statemachines/excel/importer/ImportValidator.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines/src/de/dlr/sc/virsat/model/extension/statemachines/excel/importer/ImportValidator.java
@@ -168,14 +168,14 @@ public class ImportValidator {
 		final int sheetIndex = wb.getSheetIndex(AExcelStatIO.TEMPLATE_SHEETNAME_HEADER);
 
 		// Control if we are importing the correct Structural element by comparing UUIDs
-		String tempUUID = Objects.toString(sheet.getRow(AExcelStatIO.HEADER_ROW_STRUCTURALELEMENTUUID).getCell(1), "");
+		String tempUUID = Objects.toString(sheet.getRow(AExcelStatIO.HEADER_ROW_STRUCTURALELEMENT_UUID).getCell(1), "");
 		if (!(importSei.getUuid().toString().equals(tempUUID))) {
-			faultList.add(new Fault(FaultType.STRUCTURAL_ELEMENT_UUIDS_DO_NOT_MATCH, sheetIndex, AExcelStatIO.HEADER_ROW_STRUCTURALELEMENTUUID));
+			faultList.add(new Fault(FaultType.STRUCTURAL_ELEMENT_UUIDS_DO_NOT_MATCH, sheetIndex, AExcelStatIO.HEADER_ROW_STRUCTURALELEMENT_UUID));
 		}
 		// Control if we are importing the correct Structural element by comparing NAMEs
-		String tempName = Objects.toString(sheet.getRow(AExcelStatIO.HEADER_ROW_STRUCTURALELEMENTNAME).getCell(1), "");
+		String tempName = Objects.toString(sheet.getRow(AExcelStatIO.HEADER_ROW_STRUCTURALELEMENT_NAME).getCell(1), "");
 		if (!(importSei.getName().equals(tempName))) {
-			faultList.add(new Fault(FaultType.STRUCTURAL_ELEMENT_NAMES_DO_NOT_MATCH, sheetIndex, AExcelStatIO.HEADER_ROW_STRUCTURALELEMENTNAME));
+			faultList.add(new Fault(FaultType.STRUCTURAL_ELEMENT_NAMES_DO_NOT_MATCH, sheetIndex, AExcelStatIO.HEADER_ROW_STRUCTURALELEMENT_NAME));
 		}
 	}
 }


### PR DESCRIPTION
Minor cleanup of the excel exporter constants.

- Removed excess FEA constants in SM plugin
- Moved FEA constants from general excel plugin to FEA plugin
- Improved readability of some general excel exporter constant names

Closes #737 

---
Task #737: Refactor column constants in excel exporters to appropriate
classes