### PR TITLE
Added test cases for idempotency and dynamic lists for BeanCategoryAssignments unmarshalling

### DIFF
--- a/de.dlr.sc.virsat.model.extension.tests.test/resources/json/TestCategoryCompositionArray_Marshaling.json
+++ b/de.dlr.sc.virsat.model.extension.tests.test/resources/json/TestCategoryCompositionArray_Marshaling.json
@@ -2,7 +2,41 @@
    "type" : "testCategoryCompositionArray",
    "uuid" : "f5d016ac-65fa-4b9d-ae94-582d4f73138a",
    "name" : "TestCategoryCompositionArray",
-   "testCompositionArrayDynamicBean" : [ ],
+   "testCompositionArrayDynamicBean" : [ {
+      "uuid" : "25ed5be7-de0d-4672-95be-8ccce3a7e2e2",
+      "value" : {
+         "type" : "testCategoryAllProperty",
+         "uuid" : "f34d30b0-80f5-4c96-864f-29ab4d3ae9f4",
+         "name" : "TestCategoryAllProperty",
+         "testBoolBean" : {
+            "uuid" : "b9bfb08f-2778-4fe9-a774-3d8b0ad638d4",
+            "value" : false
+         },
+         "testEnumBean" : {
+            "uuid" : "ed62d73c-dbba-409c-b73c-f0d3d9f49394",
+            "unit" : "",
+            "value" : null
+         },
+         "testFloatBean" : {
+            "uuid" : "2870876e-4d6c-4128-801d-54fa109f3824",
+            "unit" : "",
+            "value" : null
+         },
+         "testIntBean" : {
+            "uuid" : "0f37aff6-ccc0-436f-a592-bd466f74bd84",
+            "unit" : "",
+            "value" : null
+         },
+         "testResourceBean" : {
+            "uuid" : "fa822159-51a5-4bf2-99cf-e565b67e0eb4",
+            "value" : null
+         },
+         "testStringBean" : {
+            "uuid" : "26edbae8-9f05-4ef5-8673-91e1af668aa4",
+            "value" : null
+         }
+      }
+   } ],
    "testCompositionArrayStaticBean" : [ {
       "uuid" : "45e18c9d-ef85-4ab8-ba2a-c5916697a0b0",
       "value" : {

--- a/de.dlr.sc.virsat.model.extension.tests.test/resources/json/TestCategoryReferenceArray_Marshaling.json
+++ b/de.dlr.sc.virsat.model.extension.tests.test/resources/json/TestCategoryReferenceArray_Marshaling.json
@@ -2,7 +2,10 @@
    "type" : "testCategoryReferenceArray",
    "uuid" : "f34d30b0-80f5-4c96-864f-29ab4d3ae9f2",
    "name" : "TestCategoryReferenceArray",
-   "testCategoryReferenceArrayDynamicBean" : [ ],
+   "testCategoryReferenceArrayDynamicBean" : [ {
+      "uuid" : "0544cfe4-ec11-4585-8f1b-e875e26ae33c",
+      "value" : "f34d30b0-80f5-4c96-864f-29ab4d3ae9f0"
+   } ],
    "testCategoryReferenceArrayStaticBean" : [ {
       "uuid" : "8872b433-968c-4f48-b9a3-d734c6e239a0",
       "value" : "f34d30b0-80f5-4c96-864f-29ab4d3ae9f0"
@@ -16,7 +19,10 @@
       "uuid" : "8872b433-968c-4f48-b9a3-d734c6e239a3",
       "value" : "f34d30b0-80f5-4c96-864f-29ab4d3ae9f0"
    } ],
-   "testPropertyReferenceArrayDynamicBean" : [ ],
+   "testPropertyReferenceArrayDynamicBean" : [ {
+      "uuid" : "f8932f09-71b7-40b6-bcbd-5d71c2b8d6d7",
+      "value" : "7256e7a2-9a1f-443c-85f8-7b766eac3f50"
+   } ],
    "testPropertyReferenceArrayStaticBean" : [ {
       "uuid" : "49177554-f1e4-4529-bf1b-3036abb1ee30",
       "value" : "7256e7a2-9a1f-443c-85f8-7b766eac3f50"

--- a/de.dlr.sc.virsat.model.extension.tests.test/resources/json/TestCategoryReferenceArray_Marshaling_ChangeReference.json
+++ b/de.dlr.sc.virsat.model.extension.tests.test/resources/json/TestCategoryReferenceArray_Marshaling_ChangeReference.json
@@ -5,7 +5,7 @@
    "testCategoryReferenceArrayDynamicBean" : [ ],
    "testCategoryReferenceArrayStaticBean" : [ {
       "uuid" : "8872b433-968c-4f48-b9a3-d734c6e239a0",
-      "value" : "f34d30b0-80f5-4c96-864f-29ab4d3ae9f0"
+      "value" : "134d30b0-80f5-4c96-864f-29ab4d3ae9f0"
    }, {
       "uuid" : "8872b433-968c-4f48-b9a3-d734c6e239a1",
       "value" : "f34d30b0-80f5-4c96-864f-29ab4d3ae9f0"

--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryAllPropertyTest.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryAllPropertyTest.java
@@ -110,6 +110,10 @@ public class TestCategoryAllPropertyTest extends AConceptTestCase {
 		
 		// The values are correctly overwritten
 		assertEqualsTestValues();
+		
+		// Unmarshall again to test idempotency
+		unmarshalWithResource(RESOURCE_WITH_VALUES);
+		assertEqualsTestValues();
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryBeanATest.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryBeanATest.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.util.Arrays;
 
-import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.transform.stream.StreamSource;
@@ -60,8 +59,12 @@ public class TestCategoryBeanATest extends AConceptTestCase {
 		
 		StreamSource inputSource = JsonTestHelper.getResourceAsStreamSource(RESOURCE);
 		
-		JAXBElement<TestCategoryBeanA> jaxbElement = jsonUnmarshaller.unmarshal(inputSource, TestCategoryBeanA.class);
-		TestCategoryBeanA createdBeanA = jaxbElement.getValue();
+		TestCategoryBeanA createdBeanA = jsonUnmarshaller.unmarshal(inputSource, TestCategoryBeanA.class).getValue();
+		assertEquals(tcBeanA, createdBeanA);
+		
+		// Unmarshall again to test idempotency
+		inputSource = JsonTestHelper.getResourceAsStreamSource(RESOURCE);
+		createdBeanA = jsonUnmarshaller.unmarshal(inputSource, TestCategoryBeanA.class).getValue();
 		assertEquals(tcBeanA, createdBeanA);
 	}
 	

--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryCompositionArrayTest.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryCompositionArrayTest.java
@@ -80,12 +80,18 @@ public class TestCategoryCompositionArrayTest extends AConceptTestCase {
 				tcCompositionArray.getATypeInstance()
 		));
 		
+		// TODO: test dynamic array
 		StreamSource inputSource = JsonTestHelper.getResourceAsStreamSource(RESOURCE);
 		
 		assertNull(tcCompositionArray.getTestCompositionArrayStatic().get(0).getTestStringBean().getValue());
 		
 		jsonUnmarshaller.unmarshal(inputSource, TestCategoryCompositionArray.class);
 		
+		assertEquals(JsonTestHelper.TEST_STRING, tcCompositionArray.getTestCompositionArrayStatic().get(0).getTestStringBean().getValue());
+		
+		// Unmarshall again to test idempotency
+		inputSource = JsonTestHelper.getResourceAsStreamSource(RESOURCE);
+		jsonUnmarshaller.unmarshal(inputSource, TestCategoryCompositionArray.class);
 		assertEquals(JsonTestHelper.TEST_STRING, tcCompositionArray.getTestCompositionArrayStatic().get(0).getTestStringBean().getValue());
 	}
 	

--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryCompositionArrayTest.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryCompositionArrayTest.java
@@ -26,6 +26,8 @@ import org.junit.Test;
 
 import de.dlr.sc.virsat.model.concept.list.IBeanList;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyComposed;
+import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ComposedPropertyInstance;
+import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.PropertyinstancesFactory;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
 import de.dlr.sc.virsat.model.dvlm.json.JAXBUtility;
 import de.dlr.sc.virsat.model.dvlm.types.impl.VirSatUuid;
@@ -38,6 +40,8 @@ public class TestCategoryCompositionArrayTest extends AConceptTestCase {
 	private TestCategoryCompositionArray tcCompositionArray;
 	private JAXBUtility jaxbUtility;
 	private Concept concept;
+	private TestCategoryAllProperty tcAllProperty;
+	private BeanPropertyComposed<TestCategoryAllProperty> composedBean;
 	private static final String RESOURCE = "/resources/json/TestCategoryCompositionArray_Marshaling.json";
 	private static final String RESOURCE_NULL_COMPOSITION = "/resources/json/TestCategoryCompositionArray_Marshaling_NullComposition.json";
 	private static final String RESOURCE_CHANGE_ELEMENT = "/resources/json/TestCategoryCompositionArray_Marshaling_ChangeElement.json";
@@ -64,12 +68,27 @@ public class TestCategoryCompositionArrayTest extends AConceptTestCase {
 			JsonTestHelper.setTestCategoryAllPropertyUuids(tcAllProperty, i);
 		}
 		
+		tcAllProperty = new TestCategoryAllProperty(concept);
+		// Prior numbers for UUIDs are already taken so we use the next free one here
+		JsonTestHelper.setTestCategoryAllPropertyUuids(tcAllProperty, staticArray.size());
+		
+		// For composed / reference beans the wrapping beans
+		// have to exist because else adding a new element to
+		// the dynamic list in the unmarshalling fails
+		ComposedPropertyInstance cpi = PropertyinstancesFactory.eINSTANCE.createComposedPropertyInstance();
+		composedBean = new BeanPropertyComposed<TestCategoryAllProperty>(cpi);
+		cpi.setUuid(new VirSatUuid("25ed5be7-de0d-4672-95be-8ccce3a7e2e2"));
+		// Can't set this via the bean
+		cpi.setTypeInstance(tcAllProperty.getTypeInstance());
+		
 		JsonTestHelper.createRepositoryWithUnitManagement(concept);	
 	}
 	
 	@Test
 	public void testJsonMarshalling() throws JAXBException, IOException {
 		tcCompositionArray.getTestCompositionArrayStatic().get(0).getTestStringBean().setValue(JsonTestHelper.TEST_STRING);
+		// Use the bean list here to force the wanted bean (to reuse the same resource as for unmarshalling)
+		tcCompositionArray.getTestCompositionArrayDynamicBean().add(composedBean);
 		
 		JsonTestHelper.assertMarshall(jaxbUtility, RESOURCE, tcCompositionArray);
 	}
@@ -77,22 +96,25 @@ public class TestCategoryCompositionArrayTest extends AConceptTestCase {
 	@Test
 	public void testJsonUnmarshalling() throws JAXBException, IOException {
 		Unmarshaller jsonUnmarshaller = JsonTestHelper.getUnmarshaller(jaxbUtility, Arrays.asList(
-				tcCompositionArray.getATypeInstance()
+				tcCompositionArray.getATypeInstance(),
+				composedBean.getATypeInstance(),
+				tcAllProperty.getATypeInstance()
 		));
 		
-		// TODO: test dynamic array
 		StreamSource inputSource = JsonTestHelper.getResourceAsStreamSource(RESOURCE);
 		
 		assertNull(tcCompositionArray.getTestCompositionArrayStatic().get(0).getTestStringBean().getValue());
+		assertEquals("Initial no dynamic element", 0, tcCompositionArray.getTestCompositionArrayDynamic().size());
 		
 		jsonUnmarshaller.unmarshal(inputSource, TestCategoryCompositionArray.class);
 		
 		assertEquals(JsonTestHelper.TEST_STRING, tcCompositionArray.getTestCompositionArrayStatic().get(0).getTestStringBean().getValue());
+		assertEquals("Element added successfully", 1, tcCompositionArray.getTestCompositionArrayDynamic().size());
 		
 		// Unmarshall again to test idempotency
 		inputSource = JsonTestHelper.getResourceAsStreamSource(RESOURCE);
 		jsonUnmarshaller.unmarshal(inputSource, TestCategoryCompositionArray.class);
-		assertEquals(JsonTestHelper.TEST_STRING, tcCompositionArray.getTestCompositionArrayStatic().get(0).getTestStringBean().getValue());
+		assertEquals("Same element not added again", 1, tcCompositionArray.getTestCompositionArrayDynamic().size());
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryCompositionTest.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryCompositionTest.java
@@ -76,6 +76,11 @@ public class TestCategoryCompositionTest extends AConceptTestCase {
 		jsonUnmarshaller.unmarshal(inputSource, TestCategoryComposition.class);
 		
 		assertEquals("Composed element changed", JsonTestHelper.TEST_STRING, tcComposition.getTestSubCategory().getTestString());
+		
+		// Unmarshall again to test idempotency
+		inputSource = JsonTestHelper.getResourceAsStreamSource(RESOURCE);
+		jsonUnmarshaller.unmarshal(inputSource, TestCategoryComposition.class);
+		assertEquals("Composed element is still the same", JsonTestHelper.TEST_STRING, tcComposition.getTestSubCategory().getTestString());
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryIntrinsicArrayTest.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryIntrinsicArrayTest.java
@@ -81,5 +81,11 @@ public class TestCategoryIntrinsicArrayTest extends ATestCategoryIntrinsicArrayT
 		jsonUnmarshaller.unmarshal(inputSource, TestCategoryIntrinsicArray.class);
 		assertEquals("Element in static element changed", JsonTestHelper.TEST_STRING, tcIntrinsicArray.getTestStringArrayStaticBean().get(0).getValue());
 		assertEquals("Successfully added an element", 1, tcIntrinsicArray.getTestStringArrayDynamicBean().size());
+		
+		// Unmarshall again to test idempotency
+		inputSource = JsonTestHelper.getResourceAsStreamSource(RESOURCE);
+		jsonUnmarshaller.unmarshal(inputSource, TestCategoryIntrinsicArray.class);
+		assertEquals("Element in static is still the same", JsonTestHelper.TEST_STRING, tcIntrinsicArray.getTestStringArrayStaticBean().get(0).getValue());
+		assertEquals("Still only one element is present", 1, tcIntrinsicArray.getTestStringArrayDynamicBean().size());
 	}
 }

--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryReferenceArrayTest.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryReferenceArrayTest.java
@@ -96,6 +96,7 @@ public class TestCategoryReferenceArrayTest extends AConceptTestCase {
 				bpString2.getATypeInstance()
 		));
 		
+		// TODO: test dynamic array
 		StreamSource inputSource = JsonTestHelper.getResourceAsStreamSource(RESOURCE_CHANGED_REFERENCE);
 		
 		assertEquals(bpString.getUuid(), tcReferenceArray.getTestPropertyReferenceArrayStatic().get(0).getUuid());
@@ -103,6 +104,11 @@ public class TestCategoryReferenceArrayTest extends AConceptTestCase {
 		jsonUnmarshaller.unmarshal(inputSource, TestCategoryReferenceArray.class);
 		
 		assertEquals("Referenced bean changed successfully", bpString2.getUuid(), tcReferenceArray.getTestPropertyReferenceArrayStatic().get(0).getUuid());
+		
+		// Unmarshall again to test idempotency
+		inputSource = JsonTestHelper.getResourceAsStreamSource(RESOURCE_CHANGED_REFERENCE);
+		jsonUnmarshaller.unmarshal(inputSource, TestCategoryReferenceArray.class);
+		assertEquals("Referenced bean is the same", bpString2.getUuid(), tcReferenceArray.getTestPropertyReferenceArrayStatic().get(0).getUuid());
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryReferenceTest.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/extension/tests/model/json/TestCategoryReferenceTest.java
@@ -96,6 +96,11 @@ public class TestCategoryReferenceTest extends AConceptTestCase {
 		jsonUnmarshaller.unmarshal(inputSource, TestCategoryReference.class);
 		
 		assertEquals("Referenced bean changed successfully", bpString2.getUuid(), tcReference.getTestRefProperty().getUuid());
+		
+		// Unmarshall again to test idempotency
+		inputSource = JsonTestHelper.getResourceAsStreamSource(RESOURCE_CHANGED_REFERENCE);
+		jsonUnmarshaller.unmarshal(inputSource, TestCategoryReference.class);
+		assertEquals("Referenced is still the same", bpString2.getUuid(), tcReference.getTestRefProperty().getUuid());
 	}
 	
 	@Test


### PR DESCRIPTION
- Added idempotency test cases
- Added test cases for reference and composed dynamic lists
  - Discovered that to add an element in these lists, the wrapping rpi/cpi
has to exist in the model.
  - Improved the reference test case to also change the referenced ca.

Closes https://github.com/virtualsatellite/VirtualSatellite4-Core/issues/734