### PR TITLE
Extended functionality to support connection colors - (Task #750)

### DIFF
--- a/de.dlr.sc.virsat.graphiti.ui/src/de/dlr/sc/virsat/graphiti/ui/diagram/feature/VirSatChangeColorFeature.java
+++ b/de.dlr.sc.virsat.graphiti.ui/src/de/dlr/sc/virsat/graphiti/ui/diagram/feature/VirSatChangeColorFeature.java
@@ -77,9 +77,9 @@ public class VirSatChangeColorFeature extends AbstractCustomFeature {
 			if (pes != null && pes.length == 1) {
 				for (PictogramElement pe : pes) {
 					if (pe instanceof Connection) {
-						changeColorConnection((Connection) pe, color);
+						changeConnectionColor((Connection) pe, color);
 					} else {
-						changeColorGenericPictorgramElement(pe, color);
+						changeGenericPictogramElementColor(pe, color);
 					}
 				}
 			}
@@ -91,7 +91,7 @@ public class VirSatChangeColorFeature extends AbstractCustomFeature {
 	 * @param pe the pictogram element
 	 * @param color the target color
 	 */
-	private void changeColorGenericPictorgramElement(PictogramElement pe, Color color) {
+	private void changeGenericPictogramElementColor(PictogramElement pe, Color color) {
 		GraphicsAlgorithm ga = pe.getGraphicsAlgorithm();
 		ga.setBackground(color);
 		for (GraphicsAlgorithm childGa : ga.getGraphicsAlgorithmChildren()) {
@@ -106,7 +106,7 @@ public class VirSatChangeColorFeature extends AbstractCustomFeature {
 	 * @param connection the connection
 	 * @param color the target color
 	 */
-	private void changeColorConnection(Connection connection, Color color) {
+	private void changeConnectionColor(Connection connection, Color color) {
 		GraphicsAlgorithm ga = connection.getGraphicsAlgorithm();
 		// Connections & connection decorators use the foreground color to determine their color
 		ga.setForeground(color);

--- a/de.dlr.sc.virsat.graphiti.ui/src/de/dlr/sc/virsat/graphiti/ui/diagram/feature/VirSatChangeColorFeature.java
+++ b/de.dlr.sc.virsat.graphiti.ui/src/de/dlr/sc/virsat/graphiti/ui/diagram/feature/VirSatChangeColorFeature.java
@@ -15,6 +15,10 @@ import org.eclipse.graphiti.features.custom.AbstractCustomFeature;
 import org.eclipse.graphiti.mm.algorithms.GraphicsAlgorithm;
 import org.eclipse.graphiti.mm.algorithms.Rectangle;
 import org.eclipse.graphiti.mm.algorithms.RoundedRectangle;
+import org.eclipse.graphiti.mm.algorithms.Text;
+import org.eclipse.graphiti.mm.algorithms.styles.Color;
+import org.eclipse.graphiti.mm.pictograms.Connection;
+import org.eclipse.graphiti.mm.pictograms.ConnectionDecorator;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.eclipse.graphiti.util.ColorConstant;
 import org.eclipse.graphiti.util.IColorConstant;
@@ -65,22 +69,53 @@ public class VirSatChangeColorFeature extends AbstractCustomFeature {
 		s.setLocation(context.getX(), context.getY());
 		ColorDialog colorDialog = new ColorDialog(s);
 		RGB rgbColor = colorDialog.open();
-		if (colorDialog != null && rgbColor != null) {
-			IColorConstant color =
+		if (rgbColor != null) {
+			IColorConstant colorConstant =
 					new ColorConstant(rgbColor.red, rgbColor.green, rgbColor.blue);
+			Color color = manageColor(colorConstant);
 			PictogramElement[] pes = context.getPictogramElements();
 			if (pes != null && pes.length == 1) {
 				for (PictogramElement pe : pes) {
-					GraphicsAlgorithm ga = pe.getGraphicsAlgorithm();
-					ga.setBackground(manageColor(color));
-					for (GraphicsAlgorithm childGa : ga.getGraphicsAlgorithmChildren()) {
-						if (childGa instanceof RoundedRectangle || childGa instanceof Rectangle) {
-							childGa.setBackground(manageColor(color));
-						}
+					if (pe instanceof Connection) {
+						changeColorConnection((Connection) pe, color);
+					} else {
+						changeColorGenericPictorgramElement(pe, color);
 					}
 				}
 			}
 		}	
+	}
+	
+	/**
+	 * Changes the color of a generic pictorgram element
+	 * @param pe the pictogram element
+	 * @param color the target color
+	 */
+	private void changeColorGenericPictorgramElement(PictogramElement pe, Color color) {
+		GraphicsAlgorithm ga = pe.getGraphicsAlgorithm();
+		ga.setBackground(color);
+		for (GraphicsAlgorithm childGa : ga.getGraphicsAlgorithmChildren()) {
+			if (childGa instanceof RoundedRectangle || childGa instanceof Rectangle) {
+				childGa.setBackground(color);
+			}
+		}
+	}
+	
+	/**
+	 * Changes the color of a connection
+	 * @param connection the connection
+	 * @param color the target color
+	 */
+	private void changeColorConnection(Connection connection, Color color) {
+		GraphicsAlgorithm ga = connection.getGraphicsAlgorithm();
+		// Connections & connection decorators use the foreground color to determine their color
+		ga.setForeground(color);
+		for (ConnectionDecorator connectionDecorator : connection.getConnectionDecorators()) {
+			GraphicsAlgorithm connectionDecoratorGa = connectionDecorator.getGraphicsAlgorithm();
+			if (!(connectionDecoratorGa instanceof Text)) {
+				connectionDecoratorGa.setForeground(color);
+			}
+		}
 	}
 }
 

--- a/de.dlr.sc.virsat.model.extension.funcelectrical.ui/src/de/dlr/sc/virsat/model/extension/funcelectrical/ui/diagram/features/InterfaceDiagramFeatureProvider.java
+++ b/de.dlr.sc.virsat.model.extension.funcelectrical.ui/src/de/dlr/sc/virsat/model/extension/funcelectrical/ui/diagram/features/InterfaceDiagramFeatureProvider.java
@@ -10,6 +10,9 @@
 package de.dlr.sc.virsat.model.extension.funcelectrical.ui.diagram.features;
 
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.graphiti.dt.IDiagramTypeProvider;
 import org.eclipse.graphiti.features.IAddFeature;
 import org.eclipse.graphiti.features.ICopyFeature;
@@ -53,6 +56,7 @@ import de.dlr.sc.virsat.graphiti.ui.diagram.feature.VirSatMoveConnectionDecorato
 import de.dlr.sc.virsat.graphiti.ui.diagram.feature.VirSatStructuralElementInstanceCopyFeature;
 import de.dlr.sc.virsat.graphiti.ui.diagram.feature.VirSatStructuralElementInstancePasteFeature;
 import de.dlr.sc.virsat.graphiti.ui.diagram.feature.VirsatCategoryAssignmentOpenEditorFeature;
+import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.structural.ABeanStructuralElementInstance;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
@@ -230,18 +234,22 @@ public class InterfaceDiagramFeatureProvider extends VirSatDiagramFeatureProvide
 	
 	@Override
 	public ICustomFeature[] getCustomFeatures(ICustomContext context) {
-	    
 	    PictogramElement[] pictogramElements = context.getPictogramElements();
 		Object object = getBusinessObjectForPictogramElement(pictogramElements[0]);
 		
-		if (object instanceof ABeanStructuralElementInstance) {
-			return new ICustomFeature[] {  new VirSatChangeColorFeature(this)};
-		}
+		List<ICustomFeature> customFeatures = new ArrayList<>();
 		
 		if (object instanceof InterfaceEnd) {
-			return new ICustomFeature[] { new VirsatCategoryAssignmentOpenEditorFeature(this), new InterfaceEndChangeColorFeature(this)};
+			customFeatures.add(new InterfaceEndChangeColorFeature(this));
+		} else {
+			customFeatures.add(new VirSatChangeColorFeature(this));
 		}
-		return super.getCustomFeatures(context);
+		
+		if (object instanceof IBeanCategoryAssignment) {
+			customFeatures.add(new VirsatCategoryAssignmentOpenEditorFeature(this));
+		}
+		
+		return customFeatures.toArray(new ICustomFeature[0]);
 	} 
 	
 	@Override

--- a/de.dlr.sc.virsat.model.extension.funcelectrical.ui/src/de/dlr/sc/virsat/model/extension/funcelectrical/ui/diagram/features/InterfaceDiagramFeatureProvider.java
+++ b/de.dlr.sc.virsat.model.extension.funcelectrical.ui/src/de/dlr/sc/virsat/model/extension/funcelectrical/ui/diagram/features/InterfaceDiagramFeatureProvider.java
@@ -11,6 +11,7 @@ package de.dlr.sc.virsat.model.extension.funcelectrical.ui.diagram.features;
 
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.graphiti.dt.IDiagramTypeProvider;
@@ -249,6 +250,7 @@ public class InterfaceDiagramFeatureProvider extends VirSatDiagramFeatureProvide
 			customFeatures.add(new VirsatCategoryAssignmentOpenEditorFeature(this));
 		}
 		
+		Collections.addAll(customFeatures, super.getCustomFeatures(context));
 		return customFeatures.toArray(new ICustomFeature[0]);
 	} 
 	


### PR DESCRIPTION
- Extended the VirSatChangeColorFeature to support changing the color of
connections
- Minor refactoring in the getCustomFeatures method of interface
diagrams to enable the generic features such as changing color and
opening editors as much as possible

Close #750

---
Task #750: Support color change of Interfaces / Connections