### PR TITLE
Increased test timeout value for SWTBot tests in pom - (Task #771)

### DIFF
--- a/de.dlr.sc.virsat.swtbot.test/pom.xml
+++ b/de.dlr.sc.virsat.swtbot.test/pom.xml
@@ -30,7 +30,7 @@ SPDX-License-Identifier: EPL-2.0
 				<configuration>
 					<!-- Let the tests run for 20 minutes max. If time is exceeded kill 
 						the process. Apparently something is wrong -->
-					<forkedProcessTimeoutInSeconds>1200</forkedProcessTimeoutInSeconds>
+					<forkedProcessTimeoutInSeconds>1800</forkedProcessTimeoutInSeconds>
 					<redirectTestOutputToFile>true</redirectTestOutputToFile>
 					<showEclipseLog>true</showEclipseLog>
 					<rerunFailingTestsCount>3</rerunFailingTestsCount>


### PR DESCRIPTION
Closes #771

---
Task #771: Increase test timeout for SWTBot test cases