### PR TITLE
Fixed app activation to stop producing warnings - (Task #733)

### DIFF
--- a/de.dlr.sc.virsat.apps.test/resources/expectedGeneratorContent/AppManifest.MF
+++ b/de.dlr.sc.virsat.apps.test/resources/expectedGeneratorContent/AppManifest.MF
@@ -5,3 +5,4 @@ Bundle-SymbolicName: de.dlr.virsat.app.analysis
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: de.dlr.sc.virsat.apps
+Automatic-Module-Name: de.dlr.virsat.app.analysis

--- a/de.dlr.sc.virsat.apps.test/src/de/dlr/sc/virsat/apps/initializer/ContentManifestMfTest.java
+++ b/de.dlr.sc.virsat.apps.test/src/de/dlr/sc/virsat/apps/initializer/ContentManifestMfTest.java
@@ -11,8 +11,6 @@ package de.dlr.sc.virsat.apps.initializer;
 
 import java.io.IOException;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import de.dlr.sc.virsat.apps.test.util.GeneratorJunitAssert;
@@ -23,14 +21,6 @@ import de.dlr.sc.virsat.apps.test.util.GeneratorJunitAssert;
  *
  */
 public class ContentManifestMfTest {
-
-	@Before
-	public void setUp() throws Exception {
-	}
-
-	@After
-	public void tearDown() throws Exception {
-	}
 
 	public static final String TEST_PROJECT_NAME = "de.dlr.virsat.app.analysis";
 	

--- a/de.dlr.sc.virsat.apps.test/src/de/dlr/sc/virsat/apps/initializer/VirsatAppsInititalizerTest.java
+++ b/de.dlr.sc.virsat.apps.test/src/de/dlr/sc/virsat/apps/initializer/VirsatAppsInititalizerTest.java
@@ -66,7 +66,18 @@ public class VirsatAppsInititalizerTest extends AProjectTestCase {
 		assertTrue("meta-inf folder now exists", testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_META_INF).exists());
 		assertTrue("manifest.mf now exists", testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_META_INF).getFile(VirsatAppsInitializer.FILE_NAME_MANIFEST_MF).exists());
 		assertTrue("build.properties now exists", testProject.getFile(VirsatAppsInitializer.FILE_NAME_BUILD_PROPERTIES).exists());
-
+		
 		assertEquals("There are not files in the target/classes folder", 0, testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_TARGET).getFolder(VirsatAppsInitializer.FOLDER_NAME_CLASSES).members().length);
+	
+		// Test that initializing apps in a project with existing folder structure or files is safe
+		
+		appsInitializer.initializeProject(testProject, repository, new NullProgressMonitor());
+		
+		assertTrue("target folder still exists", testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_TARGET).exists());
+		assertTrue("classes folder still exists", testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_TARGET).getFolder(VirsatAppsInitializer.FOLDER_NAME_CLASSES).exists());
+		assertTrue("scripts folder still exists", testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_APPS).exists());
+		assertTrue("meta-inf folder still exists", testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_META_INF).exists());
+		assertTrue("manifest.mf still exists", testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_META_INF).getFile(VirsatAppsInitializer.FILE_NAME_MANIFEST_MF).exists());
+		assertTrue("build.properties still exists", testProject.getFile(VirsatAppsInitializer.FILE_NAME_BUILD_PROPERTIES).exists());
 	}
 }

--- a/de.dlr.sc.virsat.apps.test/src/de/dlr/sc/virsat/apps/initializer/VirsatAppsInititalizerTest.java
+++ b/de.dlr.sc.virsat.apps.test/src/de/dlr/sc/virsat/apps/initializer/VirsatAppsInititalizerTest.java
@@ -60,12 +60,13 @@ public class VirsatAppsInititalizerTest extends AProjectTestCase {
 	public void testInitializeProject() throws InvocationTargetException, InterruptedException, CoreException {
 		appsInitializer.initializeProject(testProject, repository, new NullProgressMonitor());
 		
-		assertTrue("bin folder now exists", testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_BIN).exists());
+		assertTrue("target folder now exists", testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_TARGET).exists());
+		assertTrue("classes folder now exists", testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_TARGET).getFolder(VirsatAppsInitializer.FOLDER_NAME_CLASSES).exists());
 		assertTrue("scripts folder now exists", testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_APPS).exists());
 		assertTrue("meta-inf folder now exists", testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_META_INF).exists());
 		assertTrue("manifest.mf now exists", testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_META_INF).getFile(VirsatAppsInitializer.FILE_NAME_MANIFEST_MF).exists());
 		assertTrue("build.properties now exists", testProject.getFile(VirsatAppsInitializer.FILE_NAME_BUILD_PROPERTIES).exists());
 
-		assertEquals("There are not files in the bin folder", 0, testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_BIN).members().length);
+		assertEquals("There are not files in the target/classes folder", 0, testProject.getFolder(VirsatAppsInitializer.FOLDER_NAME_TARGET).getFolder(VirsatAppsInitializer.FOLDER_NAME_CLASSES).members().length);
 	}
 }

--- a/de.dlr.sc.virsat.apps/src/de/dlr/sc/virsat/apps/initializer/ContentManifestMf.xtend
+++ b/de.dlr.sc.virsat.apps/src/de/dlr/sc/virsat/apps/initializer/ContentManifestMf.xtend
@@ -19,5 +19,6 @@ class ContentManifestMf {
 	Bundle-Version: 1.0.0.qualifier
 	Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 	Require-Bundle: de.dlr.sc.virsat.apps
+	Automatic-Module-Name: «projectName»
 	'''
 }

--- a/de.dlr.sc.virsat.apps/src/de/dlr/sc/virsat/apps/initializer/VirsatAppsInitializer.java
+++ b/de.dlr.sc.virsat.apps/src/de/dlr/sc/virsat/apps/initializer/VirsatAppsInitializer.java
@@ -50,7 +50,8 @@ import java.util.jar.Manifest;
  */
 public class VirsatAppsInitializer {
 	
-	public static final String FOLDER_NAME_BIN = "bin";
+	public static final String FOLDER_NAME_TARGET = "target";
+	public static final String FOLDER_NAME_CLASSES = "classes";
 	public static final String FOLDER_NAME_APPS = "apps";
 	public static final String FOLDER_NAME_META_INF = "META-INF";
 	
@@ -60,7 +61,7 @@ public class VirsatAppsInitializer {
 	public static final String FILE_NAME_SCRIPT_EXAMPLE_PATTERN = "AppExample%d";
 	public static final String FILE_NAME_SCRIPT_EXAMPLE_EXTENSION = ".java";
 	
-	public static final int PROGRESS_WORK_TICKS = 7;
+	public static final int PROGRESS_WORK_TICKS = 8;
 	
 	private static final int MAX_NUMBER_TRIES = 100;
 	
@@ -116,10 +117,16 @@ public class VirsatAppsInitializer {
 						Activator.getDefault().getLog().log(new Status(Status.INFO, Activator.getPluginId(), Status.OK, "VirsatAppsInitializer: Successfully created folder " + FOLDER_NAME_APPS, null));				
 					}
 			
-					IFolder folderBin = project.getFolder(FOLDER_NAME_BIN);
-					if (!folderBin.exists()) {
-						folderBin.create(IResource.NONE, true, SubMonitor.convert(pm, 1));
-						Activator.getDefault().getLog().log(new Status(Status.INFO, Activator.getPluginId(), Status.OK, "VirsatAppsInitializer: Successfully created folder " + FOLDER_NAME_BIN, null));				
+					IFolder folderTarget = project.getFolder(FOLDER_NAME_TARGET);
+					if (!folderTarget.exists()) {
+						folderTarget.create(IResource.NONE, true, SubMonitor.convert(pm, 1));
+						Activator.getDefault().getLog().log(new Status(Status.INFO, Activator.getPluginId(), Status.OK, "VirsatAppsInitializer: Successfully created folder " + FOLDER_NAME_TARGET, null));				
+					}
+					
+					IFolder folderClasses = folderTarget.getFolder(FOLDER_NAME_CLASSES);
+					if (!folderClasses.exists()) {
+						folderClasses.create(IResource.NONE, true, SubMonitor.convert(pm, 1));
+						Activator.getDefault().getLog().log(new Status(Status.INFO, Activator.getPluginId(), Status.OK, "VirsatAppsInitializer: Successfully created folder " + FOLDER_NAME_CLASSES, null));				
 					}
 			
 					IFolder folderMetaInf = project.getFolder(FOLDER_NAME_META_INF);
@@ -182,7 +189,7 @@ public class VirsatAppsInitializer {
 					
 					IJavaProject javaProject = JavaCore.create(project);
 					javaProject.setRawClasspath(classpathEntries.toArray(new IClasspathEntry[0]), SubMonitor.convert(pm, 1));
-					javaProject.setOutputLocation(folderBin.getFullPath(), SubMonitor.convert(pm, 1));
+					javaProject.setOutputLocation(folderClasses.getFullPath(), SubMonitor.convert(pm, 1));
 	
 					Activator.getDefault().getLog().log(new Status(Status.INFO, Activator.getPluginId(), Status.OK, "VirsatAppsInitializer: Successfully created ClassPath File", null));
 					

--- a/de.dlr.sc.virsat.apps/src/de/dlr/sc/virsat/apps/initializer/VirsatAppsInitializer.java
+++ b/de.dlr.sc.virsat.apps/src/de/dlr/sc/virsat/apps/initializer/VirsatAppsInitializer.java
@@ -90,6 +90,13 @@ public class VirsatAppsInitializer {
 		}
 	}
 	
+	private void initializeFolder(IFolder folder, IProgressMonitor pm) throws CoreException {
+		if (!folder.exists()) {
+			folder.create(IResource.NONE, true, SubMonitor.convert(pm, 1));
+			Activator.getDefault().getLog().log(new Status(Status.INFO, Activator.getPluginId(), Status.OK, "VirsatAppsInitializer: Successfully created folder " + folder.getName(), null));				
+		}
+	}
+	
 	/**
 	 * Call this method to add the needed files to the project to activate
 	 * it as a java/plugin project
@@ -112,28 +119,16 @@ public class VirsatAppsInitializer {
 					 * Create folders and files
 					 */
 					IFolder folderApps = project.getFolder(FOLDER_NAME_APPS);
-					if (!folderApps.exists()) {
-						folderApps.create(IResource.NONE, true, SubMonitor.convert(pm, 1));
-						Activator.getDefault().getLog().log(new Status(Status.INFO, Activator.getPluginId(), Status.OK, "VirsatAppsInitializer: Successfully created folder " + FOLDER_NAME_APPS, null));				
-					}
+					initializeFolder(folderApps, pm);
 			
 					IFolder folderTarget = project.getFolder(FOLDER_NAME_TARGET);
-					if (!folderTarget.exists()) {
-						folderTarget.create(IResource.NONE, true, SubMonitor.convert(pm, 1));
-						Activator.getDefault().getLog().log(new Status(Status.INFO, Activator.getPluginId(), Status.OK, "VirsatAppsInitializer: Successfully created folder " + FOLDER_NAME_TARGET, null));				
-					}
+					initializeFolder(folderTarget, pm);
 					
 					IFolder folderClasses = folderTarget.getFolder(FOLDER_NAME_CLASSES);
-					if (!folderClasses.exists()) {
-						folderClasses.create(IResource.NONE, true, SubMonitor.convert(pm, 1));
-						Activator.getDefault().getLog().log(new Status(Status.INFO, Activator.getPluginId(), Status.OK, "VirsatAppsInitializer: Successfully created folder " + FOLDER_NAME_CLASSES, null));				
-					}
+					initializeFolder(folderClasses, pm);
 			
 					IFolder folderMetaInf = project.getFolder(FOLDER_NAME_META_INF);
-					if (!folderMetaInf.exists()) {
-						folderMetaInf.create(IResource.NONE, true, SubMonitor.convert(pm, 1));
-						Activator.getDefault().getLog().log(new Status(Status.INFO, Activator.getPluginId(), Status.OK, "VirsatAppsInitializer: Successfully created folder " + FOLDER_NAME_META_INF, null));				
-					}
+					initializeFolder(folderMetaInf, pm);
 			
 					IFile fileManifestMf = folderMetaInf.getFile(FILE_NAME_MANIFEST_MF);
 					if (!fileManifestMf.exists()) {

--- a/de.dlr.sc.virsat.apps/xtend-gen/de/dlr/sc/virsat/apps/initializer/ContentManifestMf.java
+++ b/de.dlr.sc.virsat.apps/xtend-gen/de/dlr/sc/virsat/apps/initializer/ContentManifestMf.java
@@ -31,6 +31,9 @@ public class ContentManifestMf {
     _builder.newLine();
     _builder.append("Require-Bundle: de.dlr.sc.virsat.apps");
     _builder.newLine();
+    _builder.append("Automatic-Module-Name: ");
+    _builder.append(projectName);
+    _builder.newLineIfNotEmpty();
     return _builder;
   }
 }


### PR DESCRIPTION
- Made the target folder consistent to target/classes
- Added automatic module name to initial manifest

Closes #733

---
Task #733: App activation should produce project setup without warnings