### PR TITLE
Fixed direct editing update behavior - (Task #337)

### DIFF
--- a/de.dlr.sc.virsat.graphiti.test/src/de/dlr/sc/virsat/graphiti/util/DiagramHelperTest.java
+++ b/de.dlr.sc.virsat.graphiti.test/src/de/dlr/sc/virsat/graphiti/util/DiagramHelperTest.java
@@ -30,6 +30,7 @@ import org.eclipse.graphiti.features.context.IPasteContext;
 import org.eclipse.graphiti.features.context.IUpdateContext;
 import org.eclipse.graphiti.features.impl.AbstractFeatureProvider;
 import org.eclipse.graphiti.features.impl.AbstractUpdateFeature;
+import org.eclipse.graphiti.features.impl.UpdateNoBoFeature;
 import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.Diagram;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
@@ -168,7 +169,8 @@ public class DiagramHelperTest extends AConceptProjectTestCase {
 	@Test
 	public void testGetUpdateableElement() {
 		ContainerShape peUpdateableParent = Graphiti.getPeCreateService().createContainerShape(null, true);
-		PictogramElement peNoUpate = Graphiti.getPeCreateService().createShape(peUpdateableParent, true);
+		ContainerShape peNoUpdateParent = Graphiti.getPeCreateService().createContainerShape(peUpdateableParent, true);
+		PictogramElement peNoUpate = Graphiti.getPeCreateService().createShape(peNoUpdateParent, true);
 		
 		// Create a dummy update feature that that will later only be applicable for the parent pe
 		IUpdateFeature mockUpdateFeature = new AbstractUpdateFeature(null) {
@@ -210,6 +212,10 @@ public class DiagramHelperTest extends AConceptProjectTestCase {
 			public IUpdateFeature getUpdateFeature(IUpdateContext context) {
 				if (context.getPictogramElement() == peUpdateableParent) {
 					return mockUpdateFeature;
+				}
+				
+				if (context.getPictogramElement() == peNoUpdateParent) {
+					return new UpdateNoBoFeature(this);
 				}
 				
 				return null;

--- a/de.dlr.sc.virsat.graphiti.ui/src/de/dlr/sc/virsat/graphiti/ui/diagram/feature/BeanDirectEditNameFeature.java
+++ b/de.dlr.sc.virsat.graphiti.ui/src/de/dlr/sc/virsat/graphiti/ui/diagram/feature/BeanDirectEditNameFeature.java
@@ -16,7 +16,6 @@ import org.eclipse.graphiti.features.context.IDirectEditingContext;
 import org.eclipse.graphiti.features.impl.AbstractDirectEditingFeature;
 import org.eclipse.graphiti.mm.algorithms.GraphicsAlgorithm;
 import org.eclipse.graphiti.mm.algorithms.Text;
-import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 
 import de.dlr.sc.virsat.graphiti.util.DiagramHelper;
@@ -71,8 +70,8 @@ public class BeanDirectEditNameFeature extends AbstractDirectEditingFeature {
 		Command setName = bean.setName(ed, value);
 		ed.getCommandStack().execute(setName);
 		
-		ContainerShape cs = DiagramHelper.getUpdateableContainer(getFeatureProvider(), pe);
-		updatePictogramElement(cs);
+		PictogramElement updateablePe = DiagramHelper.getUpdateableElement(getFeatureProvider(), pe);
+		updatePictogramElement(updateablePe);
 	}
 
 }

--- a/de.dlr.sc.virsat.graphiti.ui/src/de/dlr/sc/virsat/graphiti/ui/diagram/feature/BeanPropertyFloatDirectEditValueFeature.java
+++ b/de.dlr.sc.virsat.graphiti.ui/src/de/dlr/sc/virsat/graphiti/ui/diagram/feature/BeanPropertyFloatDirectEditValueFeature.java
@@ -14,7 +14,6 @@ import org.eclipse.graphiti.features.context.IDirectEditingContext;
 import org.eclipse.graphiti.features.impl.AbstractDirectEditingFeature;
 import org.eclipse.graphiti.mm.algorithms.GraphicsAlgorithm;
 import org.eclipse.graphiti.mm.algorithms.Text;
-import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 
 import de.dlr.sc.virsat.graphiti.util.DiagramHelper;
@@ -67,8 +66,7 @@ public class BeanPropertyFloatDirectEditValueFeature extends AbstractDirectEditi
 		
 		bean.setValue(Double.parseDouble(value));	
 		
-		ContainerShape cs = DiagramHelper.getUpdateableContainer(getFeatureProvider(), pe);
-		
-		updatePictogramElement(cs);
+		PictogramElement updateablePe = DiagramHelper.getUpdateableElement(getFeatureProvider(), pe);
+		updatePictogramElement(updateablePe);
 	}
 }

--- a/de.dlr.sc.virsat.graphiti/src/de/dlr/sc/virsat/graphiti/util/DiagramHelper.java
+++ b/de.dlr.sc.virsat.graphiti/src/de/dlr/sc/virsat/graphiti/util/DiagramHelper.java
@@ -29,10 +29,8 @@ import org.eclipse.graphiti.features.impl.UpdateNoBoFeature;
 import org.eclipse.graphiti.mm.GraphicsAlgorithmContainer;
 import org.eclipse.graphiti.mm.algorithms.Polyline;
 import org.eclipse.graphiti.mm.algorithms.styles.Color;
-import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.Diagram;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
-import org.eclipse.graphiti.mm.pictograms.Shape;
 import org.eclipse.graphiti.services.Graphiti;
 import org.eclipse.graphiti.services.IGaService;
 
@@ -212,21 +210,21 @@ public class DiagramHelper {
 	}
 	
 	/**
-	 * Use this method to get a container shape containing the passed pictogram element
+	 * Use this method to get an element containing the passed pictogram element
 	 * that knows how its contents should be updated
 	 * @param fp the feature provider for associating diagram elements with update features
 	 * @param pe the pictogram element that we want to update and need the updateable container for
 	 * @return an updateable container that contains the passed pictogram element
 	 */
-	public static ContainerShape getUpdateableContainer(IFeatureProvider fp, PictogramElement pe) {
-		ContainerShape cs = ((Shape) pe).getContainer();
-		IUpdateFeature updateFeature = fp.getUpdateFeature(new UpdateContext(cs));
+	public static PictogramElement getUpdateableElement(IFeatureProvider fp, PictogramElement pe) {
+		IUpdateFeature updateFeature = fp.getUpdateFeature(new UpdateContext(pe));
 		// Crawl upwards until we have a valid update feature to update this element
-		while (updateFeature == null || updateFeature instanceof UpdateNoBoFeature) {
-			cs = cs.getContainer();
-			updateFeature = fp.getUpdateFeature(new UpdateContext(cs));
+		while ((updateFeature == null || updateFeature instanceof UpdateNoBoFeature) 
+				&& (pe.eContainer() instanceof PictogramElement)) {
+			pe = (PictogramElement) pe.eContainer();
+			updateFeature = fp.getUpdateFeature(new UpdateContext(pe));
 		}
 		
-		return cs;
+		return pe;
 	}
 }

--- a/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/StateMachineDiagramFeatureProvider.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/StateMachineDiagramFeatureProvider.java
@@ -37,12 +37,11 @@ import org.eclipse.graphiti.mm.pictograms.Connection;
 import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.Diagram;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
-import org.eclipse.graphiti.ui.features.DefaultFeatureProvider;
 
-import de.dlr.sc.virsat.graphiti.diagram.BeanIndependenceSolver;
 import de.dlr.sc.virsat.graphiti.ui.diagram.feature.BeanDirectEditNameFeature;
 import de.dlr.sc.virsat.graphiti.ui.diagram.feature.VirSatCategoryAssingmentCopyFeature;
 import de.dlr.sc.virsat.graphiti.ui.diagram.feature.VirSatChangeColorFeature;
+import de.dlr.sc.virsat.graphiti.ui.diagram.feature.VirSatDiagramFeatureProvider;
 import de.dlr.sc.virsat.graphiti.ui.diagram.feature.VirsatCategoryAssignmentOpenEditorFeature;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.extension.statemachines.model.AConstraint;
@@ -70,23 +69,15 @@ import de.dlr.sc.virsat.model.extension.statemachines.ui.diagram.features.transi
 import de.dlr.sc.virsat.model.extension.statemachines.ui.diagram.features.transitions.TransitionReconnectionFeature;
 /**
  * The State Machine feature provider provides all features for State Machine diagrams.
- * @author bell_er
  *
  */
-public class StateMachineDiagramFeatureProvider extends DefaultFeatureProvider {
-	private BeanIndependenceSolver beanIndependenceSolver;
+public class StateMachineDiagramFeatureProvider extends VirSatDiagramFeatureProvider {
 
-	/**
-	 * Default constructor
-	 * @param dtp the diagram type provider
-	 */
-
+	
 	public StateMachineDiagramFeatureProvider(IDiagramTypeProvider dtp) {
 		super(dtp);
-		beanIndependenceSolver = new BeanIndependenceSolver(dtp);
-		setIndependenceSolver(beanIndependenceSolver);
 	}
-	
+
 	@Override
 	public IAddFeature getAddFeature(IAddContext context) {
 		Object newObject = context.getNewObject();
@@ -158,14 +149,18 @@ public class StateMachineDiagramFeatureProvider extends DefaultFeatureProvider {
 	@Override
 	public IUpdateFeature getUpdateFeature(IUpdateContext context) {
 		PictogramElement pictogramElement = context.getPictogramElement();
+		
+		// Updating the diagram should trigger the default update feature
+		// which triggers in return the update features of all elements in the diagram
 		if (pictogramElement instanceof Diagram) {
-			return null;
+			return super.getUpdateFeature(context);
 		}
 		
 		Object object = getBusinessObjectForPictogramElement(pictogramElement);
 		if ((object instanceof StateMachine || object == null) && pictogramElement instanceof ContainerShape) {
 			return new StateMachineUpdateFeature(this);
 		}
+		
 		return super.getUpdateFeature(context);
 	}
 	

--- a/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/stateMachines/StateMachineUpdateFeature.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/stateMachines/StateMachineUpdateFeature.java
@@ -64,13 +64,11 @@ public class StateMachineUpdateFeature extends VirSatUpdateFeature {
 			ContainerShape cs = (ContainerShape) pictogramElement;
 			// Look for the state machine Name
 			for (Shape shape : cs.getChildren()) {
-				if (shape.getGraphicsAlgorithm() instanceof Text) {
+				if (shape.getGraphicsAlgorithm() instanceof Text && getBusinessObjectForPictogramElement(shape) == stateMachine) {
 					Text text = (Text) shape.getGraphicsAlgorithm();
-					if (!text.getValue().contains("«")) {
-						pictogramName = text.getValue();
-						if (!pictogramName.equals(businessName)) {
-							return Reason.createTrueReason("StateMachine name is changed");
-						}
+					pictogramName = text.getValue();
+					if (!pictogramName.equals(businessName)) {
+						return Reason.createTrueReason("StateMachine name is changed");
 					}
 				}
 			}
@@ -327,12 +325,10 @@ public class StateMachineUpdateFeature extends VirSatUpdateFeature {
 		if (pictogramElement instanceof ContainerShape) {
 			ContainerShape cs = (ContainerShape) pictogramElement;
 			for (Shape shape : cs.getChildren()) {
-				if (shape.getGraphicsAlgorithm() instanceof Text) {
+				if (shape.getGraphicsAlgorithm() instanceof Text && getBusinessObjectForPictogramElement(shape) == stateMachine) {
 					Text text = (Text) shape.getGraphicsAlgorithm();
-					if (!text.getValue().contains("«")) {
-						text.setValue(businessName);
-						changeDuringUpdate = true;
-					}
+					text.setValue(businessName);
+					changeDuringUpdate = true;
 				}
 			}
 


### PR DESCRIPTION
- Generalized update direct editing update feature to better work with
connection objects
- Fixed bad if check using some corrupted character
- Fixed diagram update not doing anything instead of updating all
elements in the diagram

Closes #337

---
Task #337: Name changes to transitions in state machine diagrams are not
updated in the model