### PR TITLE
Fixed abstract BeanProperty classes inconsistency

### DIFF
--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanProperty.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanProperty.java
@@ -10,18 +10,21 @@
 package de.dlr.sc.virsat.model.concept.types.property;
 
 import de.dlr.sc.virsat.model.concept.types.ABeanObject;
-import de.dlr.sc.virsat.model.dvlm.categories.ATypeInstance;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.APropertyInstance;
 
+/**
+ * Core functionality for a Property Bean and abstract implementation to the interface
+ *
+ * @param <P_TYPE> The property bean type
+ * @param <V_TYPE> The value type of the bean
+ */
 public abstract class ABeanProperty<P_TYPE extends APropertyInstance, V_TYPE> extends ABeanObject<P_TYPE> implements IBeanProperty<P_TYPE, V_TYPE> {
 
-	@SuppressWarnings("unchecked")
-	public ABeanProperty(ATypeInstance ti) {
-		this.ti = (P_TYPE) ti;
-	}
-	
 	public ABeanProperty() {
 		super();
 	}
 	
+	public ABeanProperty(APropertyInstance ti) {
+		super(ti);
+	}
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanProperty.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanProperty.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2020 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.property;
+
+import de.dlr.sc.virsat.model.concept.types.ABeanObject;
+import de.dlr.sc.virsat.model.dvlm.categories.ATypeInstance;
+import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.APropertyInstance;
+
+public abstract class ABeanProperty<P_TYPE extends APropertyInstance, V_TYPE> extends ABeanObject<P_TYPE> implements IBeanProperty<P_TYPE, V_TYPE> {
+
+	@SuppressWarnings("unchecked")
+	public ABeanProperty(ATypeInstance ti) {
+		this.ti = (P_TYPE) ti;
+	}
+	
+	public ABeanProperty() {
+		super();
+	}
+	
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanUnitValueProperty.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanUnitValueProperty.java
@@ -20,13 +20,15 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.UnitValuePropert
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.util.PropertyInstanceHelper;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.util.PropertyInstanceValueSwitch;
 
+// TODO: update
 /**
  * Abstract implementation to the interface dealing with Attributes with QUDV unit
  * @author fisc_ph
  *
  * @param <V_TYPE> The value type of this bean
  */
-public abstract class ABeanUnitProperty<V_TYPE> extends ABeanObject<UnitValuePropertyInstance> implements IBeanProperty<UnitValuePropertyInstance, V_TYPE>, IBeanUnitProperty {	
+// TODO: ABeanValueProperty
+public abstract class ABeanUnitValueProperty<V_TYPE> extends ABeanObject<UnitValuePropertyInstance> implements IBeanProperty<UnitValuePropertyInstance, V_TYPE>, IBeanUnitProperty {	
 	
 	@Override
 	public boolean isSet() {
@@ -79,7 +81,7 @@ public abstract class ABeanUnitProperty<V_TYPE> extends ABeanObject<UnitValuePro
 	 * @param other another bean of the same type
 	 * @return a command to set value + unit to the value + unit of the other bean
 	 */
-	public Command setValueWithUnit(EditingDomain ed, ABeanUnitProperty<V_TYPE> other) {
+	public Command setValueWithUnit(EditingDomain ed, ABeanUnitValueProperty<V_TYPE> other) {
 		CompoundCommand cmdSetValueAndUnit = new CompoundCommand();
 		Command cmdSetValue = setValue(ed, other.getValue());
 		Command cmdSetUnit = setUnit(ed, other.getUnit());
@@ -94,7 +96,7 @@ public abstract class ABeanUnitProperty<V_TYPE> extends ABeanObject<UnitValuePro
 	 * Sets the value and unit of this bean to the value and unit of the other bean
 	 * @param other another bean of the same type
 	 */
-	public void setValueWithUnit(ABeanUnitProperty<V_TYPE> other) {
+	public void setValueWithUnit(ABeanUnitValueProperty<V_TYPE> other) {
 		setValue(other.getValue());
 		setUnit(other.getUnit());
 	}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanUnitValueProperty.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanUnitValueProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008-2019 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ * Copyright (c) 2020 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -27,8 +27,8 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.util.PropertyIns
  *
  * @param <V_TYPE> The value type of this bean
  */
-// TODO: ABeanValueProperty
-public abstract class ABeanUnitValueProperty<V_TYPE> extends ABeanObject<UnitValuePropertyInstance> implements IBeanProperty<UnitValuePropertyInstance, V_TYPE>, IBeanUnitProperty {	
+// TODO: can we extend ABeanValueProperty?
+public abstract class ABeanUnitValueProperty<V_TYPE> extends ABeanProperty<UnitValuePropertyInstance, V_TYPE> implements IBeanProperty<UnitValuePropertyInstance, V_TYPE>, IBeanUnitProperty {	
 	
 	@Override
 	public boolean isSet() {

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanUnitValueProperty.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanUnitValueProperty.java
@@ -15,29 +15,33 @@ import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.CompoundCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 
-import de.dlr.sc.virsat.model.concept.types.ABeanObject;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.UnitValuePropertyInstance;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.util.PropertyInstanceHelper;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.util.PropertyInstanceValueSwitch;
 
-// TODO: update
 /**
  * Abstract implementation to the interface dealing with Attributes with QUDV unit
- * @author fisc_ph
  *
  * @param <V_TYPE> The value type of this bean
  */
-// TODO: can we extend ABeanValueProperty?
-public abstract class ABeanUnitValueProperty<V_TYPE> extends ABeanProperty<UnitValuePropertyInstance, V_TYPE> implements IBeanProperty<UnitValuePropertyInstance, V_TYPE>, IBeanUnitProperty {	
+public abstract class ABeanUnitValueProperty<V_TYPE> extends ABeanValueProperty<UnitValuePropertyInstance, V_TYPE> implements IBeanUnitProperty {	
+	
+	public ABeanUnitValueProperty() {
+		super();
+	}
+	
+	public ABeanUnitValueProperty(UnitValuePropertyInstance uvpi) {
+		super(uvpi);
+	}
 	
 	@Override
 	public boolean isSet() {
-		return ti.getValue() != null && !ti.getValue().equals("");
+		return super.isSet() && !ti.getValue().equals("");
 	}
 	
 	@Override
 	public void unset() {
-		ti.setValue(null);
+		super.unset();
 	}
 	
 	/**

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanValueProperty.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanValueProperty.java
@@ -11,15 +11,22 @@ package de.dlr.sc.virsat.model.concept.types.property;
 
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyInstance;
 
-//TODO: update
 /**
  * Abstract implementation to the interface dealing with Attributes without QUDV unit
- * @author fisc_ph
  * 
+ * @param <P_TYPE> The property bean type
  * @param <V_TYPE> Value type of the Bean
  *
  */
-public abstract class ABeanValueProperty<V_TYPE> extends ABeanProperty<ValuePropertyInstance, V_TYPE> implements IBeanProperty<ValuePropertyInstance, V_TYPE> {
+public abstract class ABeanValueProperty<P_TYPE extends ValuePropertyInstance, V_TYPE> extends ABeanProperty<P_TYPE, V_TYPE> {
+	
+	public ABeanValueProperty() {
+		super();
+	}
+	
+	public ABeanValueProperty(P_TYPE vpi) {
+		super(vpi);
+	}
 	
 	@Override
 	public boolean isSet() {

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanValueProperty.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanValueProperty.java
@@ -12,6 +12,7 @@ package de.dlr.sc.virsat.model.concept.types.property;
 import de.dlr.sc.virsat.model.concept.types.ABeanObject;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyInstance;
 
+//TODO: update
 /**
  * Abstract implementation to the interface dealing with Attributes without QUDV unit
  * @author fisc_ph
@@ -19,7 +20,7 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyIns
  * @param <V_TYPE> Value type of the Bean
  *
  */
-public abstract class ABeanProperty<V_TYPE> extends ABeanObject<ValuePropertyInstance> implements IBeanProperty<ValuePropertyInstance, V_TYPE> {
+public abstract class ABeanValueProperty<V_TYPE> extends ABeanObject<ValuePropertyInstance> implements IBeanProperty<ValuePropertyInstance, V_TYPE> {
 	
 	@Override
 	public boolean isSet() {

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanValueProperty.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanValueProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008-2019 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ * Copyright (c) 2020 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -9,7 +9,6 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.model.concept.types.property;
 
-import de.dlr.sc.virsat.model.concept.types.ABeanObject;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyInstance;
 
 //TODO: update
@@ -20,7 +19,7 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyIns
  * @param <V_TYPE> Value type of the Bean
  *
  */
-public abstract class ABeanValueProperty<V_TYPE> extends ABeanObject<ValuePropertyInstance> implements IBeanProperty<ValuePropertyInstance, V_TYPE> {
+public abstract class ABeanValueProperty<V_TYPE> extends ABeanProperty<ValuePropertyInstance, V_TYPE> implements IBeanProperty<ValuePropertyInstance, V_TYPE> {
 	
 	@Override
 	public boolean isSet() {

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyBoolean.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyBoolean.java
@@ -23,7 +23,7 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyIns
  * @author fisc_ph
  *
  */
-public class BeanPropertyBoolean extends ABeanProperty<Boolean> {
+public class BeanPropertyBoolean extends ABeanValueProperty<Boolean> {
 
 	/**
 	 * Standard Constructor

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyBoolean.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyBoolean.java
@@ -20,10 +20,9 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyIns
 
 /**
  * Class to wrap BooleanPropertyInstances
- * @author fisc_ph
  *
  */
-public class BeanPropertyBoolean extends ABeanValueProperty<Boolean> {
+public class BeanPropertyBoolean extends ABeanValueProperty<ValuePropertyInstance, Boolean> {
 
 	/**
 	 * Standard Constructor
@@ -36,7 +35,7 @@ public class BeanPropertyBoolean extends ABeanValueProperty<Boolean> {
 	 * @param vpi the type instance to be used
 	 */
 	public BeanPropertyBoolean(ValuePropertyInstance vpi) {
-		setTypeInstance(vpi);
+		super(vpi);
 	}
 	
 	@Override

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyComposed.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyComposed.java
@@ -21,6 +21,7 @@ import de.dlr.sc.virsat.model.concept.types.ABeanObject;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanCategoryAssignmentFactory;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.APropertyInstance;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ComposedPropertyInstance;
 import de.dlr.sc.virsat.model.dvlm.json.AnyTypeAdapter;
 
@@ -28,7 +29,7 @@ import de.dlr.sc.virsat.model.dvlm.json.AnyTypeAdapter;
  * Class to wrap a ComposedPropertyInstance that doesn't support to set values.
  * @param <BEAN_TYPE> the reference type
  */
-public class BeanPropertyComposed<BEAN_TYPE extends IBeanCategoryAssignment> extends ABeanObject<ComposedPropertyInstance> implements IBeanProperty<ComposedPropertyInstance, BEAN_TYPE> {
+public class BeanPropertyComposed<BEAN_TYPE extends IBeanCategoryAssignment> extends ABeanProperty<ComposedPropertyInstance, BEAN_TYPE>  implements IBeanProperty<ComposedPropertyInstance, BEAN_TYPE> {
 
 	public BeanPropertyComposed() { }
 	

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyComposed.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyComposed.java
@@ -17,11 +17,9 @@ import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 
-import de.dlr.sc.virsat.model.concept.types.ABeanObject;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanCategoryAssignmentFactory;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
-import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.APropertyInstance;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ComposedPropertyInstance;
 import de.dlr.sc.virsat.model.dvlm.json.AnyTypeAdapter;
 
@@ -29,7 +27,7 @@ import de.dlr.sc.virsat.model.dvlm.json.AnyTypeAdapter;
  * Class to wrap a ComposedPropertyInstance that doesn't support to set values.
  * @param <BEAN_TYPE> the reference type
  */
-public class BeanPropertyComposed<BEAN_TYPE extends IBeanCategoryAssignment> extends ABeanProperty<ComposedPropertyInstance, BEAN_TYPE>  implements IBeanProperty<ComposedPropertyInstance, BEAN_TYPE> {
+public class BeanPropertyComposed<BEAN_TYPE extends IBeanCategoryAssignment> extends ABeanProperty<ComposedPropertyInstance, BEAN_TYPE> {
 
 	public BeanPropertyComposed() { }
 	
@@ -38,7 +36,7 @@ public class BeanPropertyComposed<BEAN_TYPE extends IBeanCategoryAssignment> ext
 	 * @param cpi the type instance to be used
 	 */
 	public BeanPropertyComposed(ComposedPropertyInstance cpi) {
-		setTypeInstance(cpi);
+		super(cpi);
 	}
 	
 	@Override

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyEReference.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyEReference.java
@@ -22,7 +22,7 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.Propertyinstance
  * Bean class to warp EObject values of EReferencePropertyInstances. Supports getting and setting values via command.
  * @param <Type> the reference type
  */
-public class BeanPropertyEReference<Type extends EObject> extends ABeanObject<EReferencePropertyInstance> implements IBeanProperty<EReferencePropertyInstance, Type> {
+public class BeanPropertyEReference<Type extends EObject> extends ABeanProperty<EReferencePropertyInstance, Type> implements IBeanProperty<EReferencePropertyInstance, Type> {
 
 	/**
 	 * Standard Constructor

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyEReference.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyEReference.java
@@ -14,7 +14,6 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 
-import de.dlr.sc.virsat.model.concept.types.ABeanObject;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.EReferencePropertyInstance;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.PropertyinstancesPackage;
 
@@ -22,7 +21,7 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.Propertyinstance
  * Bean class to warp EObject values of EReferencePropertyInstances. Supports getting and setting values via command.
  * @param <Type> the reference type
  */
-public class BeanPropertyEReference<Type extends EObject> extends ABeanProperty<EReferencePropertyInstance, Type> implements IBeanProperty<EReferencePropertyInstance, Type> {
+public class BeanPropertyEReference<Type extends EObject> extends ABeanProperty<EReferencePropertyInstance, Type> {
 
 	/**
 	 * Standard Constructor

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyEnum.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyEnum.java
@@ -30,7 +30,7 @@ import de.dlr.sc.virsat.model.dvlm.qudv.util.QudvUnitHelper;
  * @author fisc_ph
  *
  */
-public class BeanPropertyEnum extends ABeanObject<EnumUnitPropertyInstance> implements IBeanProperty<EnumUnitPropertyInstance, String>, IBeanUnitProperty {
+public class BeanPropertyEnum extends ABeanProperty<EnumUnitPropertyInstance, String> implements IBeanProperty<EnumUnitPropertyInstance, String>, IBeanUnitProperty {
 
 	/**
 	 * standard Constructor

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyEnum.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyEnum.java
@@ -15,7 +15,6 @@ import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 
-import de.dlr.sc.virsat.model.concept.types.ABeanObject;
 import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.EnumProperty;
 import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.EnumPropertyHelper;
 import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.EnumValueDefinition;
@@ -26,11 +25,10 @@ import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
 import de.dlr.sc.virsat.model.dvlm.qudv.util.QudvUnitHelper;
 
 /**
- * Class to wrap FloatPropertyInstances
- * @author fisc_ph
+ * Class to wrap EnumPropertyInstances
  *
  */
-public class BeanPropertyEnum extends ABeanProperty<EnumUnitPropertyInstance, String> implements IBeanProperty<EnumUnitPropertyInstance, String>, IBeanUnitProperty {
+public class BeanPropertyEnum extends ABeanProperty<EnumUnitPropertyInstance, String> implements IBeanUnitProperty {
 
 	/**
 	 * standard Constructor
@@ -43,7 +41,7 @@ public class BeanPropertyEnum extends ABeanProperty<EnumUnitPropertyInstance, St
 	 * @param eupi the type instance to be used
 	 */
 	public BeanPropertyEnum(EnumUnitPropertyInstance eupi) {
-		setTypeInstance(eupi);
+		super(eupi);
 	}
 	
 	@Override

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyFloat.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyFloat.java
@@ -27,7 +27,7 @@ import de.dlr.sc.virsat.model.dvlm.qudv.util.QudvUnitHelper;
  * @author fisc_ph
  *
  */
-public class BeanPropertyFloat extends ABeanUnitProperty<Double> {
+public class BeanPropertyFloat extends ABeanUnitValueProperty<Double> {
 
 	/**
 	 * Standard Constructor

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyFloat.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyFloat.java
@@ -24,7 +24,6 @@ import de.dlr.sc.virsat.model.dvlm.qudv.util.QudvUnitHelper;
 
 /**
  * Class to wrap FloatPropertyInstances
- * @author fisc_ph
  *
  */
 public class BeanPropertyFloat extends ABeanUnitValueProperty<Double> {
@@ -40,7 +39,7 @@ public class BeanPropertyFloat extends ABeanUnitValueProperty<Double> {
 	 * @param uvpi the type instance to be used
 	 */
 	public BeanPropertyFloat(UnitValuePropertyInstance uvpi) {
-		setTypeInstance(uvpi);
+		super(uvpi);
 	}
 	
 	@Override

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyInt.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyInt.java
@@ -23,7 +23,7 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.UnitValuePropert
  * @author fisc_ph
  *
  */
-public class BeanPropertyInt extends ABeanUnitProperty<Long> {
+public class BeanPropertyInt extends ABeanUnitValueProperty<Long> {
 
 	/**
 	 * Standard Constructor

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyInt.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyInt.java
@@ -20,7 +20,6 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.UnitValuePropert
 
 /**
  * Class to wrap IntPropertyInstances
- * @author fisc_ph
  *
  */
 public class BeanPropertyInt extends ABeanUnitValueProperty<Long> {
@@ -36,7 +35,7 @@ public class BeanPropertyInt extends ABeanUnitValueProperty<Long> {
 	 * @param uvpi the type instance to be used
 	 */
 	public BeanPropertyInt(UnitValuePropertyInstance uvpi) {
-		setTypeInstance(uvpi);
+		super(uvpi);
 	}
 	
 	@Override

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyReference.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyReference.java
@@ -29,7 +29,7 @@ import de.dlr.sc.virsat.model.dvlm.json.ABeanObjectAdapter;
  * Bean class to wrap the referenced beans of ReferencePropertyInstances
  * @param <BEAN_TYPE> type of the referenced bean
  */
-public class BeanPropertyReference<BEAN_TYPE extends IBeanObject<? extends ATypeInstance>> extends ABeanObject<ReferencePropertyInstance> implements IBeanProperty<ReferencePropertyInstance, BEAN_TYPE> {
+public class BeanPropertyReference<BEAN_TYPE extends IBeanObject<? extends ATypeInstance>> extends ABeanProperty<ReferencePropertyInstance, BEAN_TYPE> implements IBeanProperty<ReferencePropertyInstance, BEAN_TYPE> {
 
 	public BeanPropertyReference() { }
 

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyReference.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyReference.java
@@ -17,7 +17,6 @@ import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 
-import de.dlr.sc.virsat.model.concept.types.ABeanObject;
 import de.dlr.sc.virsat.model.concept.types.IBeanObject;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanTypeInstanceFactory;
 import de.dlr.sc.virsat.model.dvlm.categories.ATypeInstance;
@@ -29,7 +28,7 @@ import de.dlr.sc.virsat.model.dvlm.json.ABeanObjectAdapter;
  * Bean class to wrap the referenced beans of ReferencePropertyInstances
  * @param <BEAN_TYPE> type of the referenced bean
  */
-public class BeanPropertyReference<BEAN_TYPE extends IBeanObject<? extends ATypeInstance>> extends ABeanProperty<ReferencePropertyInstance, BEAN_TYPE> implements IBeanProperty<ReferencePropertyInstance, BEAN_TYPE> {
+public class BeanPropertyReference<BEAN_TYPE extends IBeanObject<? extends ATypeInstance>> extends ABeanProperty<ReferencePropertyInstance, BEAN_TYPE> {
 
 	public BeanPropertyReference() { }
 
@@ -38,7 +37,7 @@ public class BeanPropertyReference<BEAN_TYPE extends IBeanObject<? extends AType
 	 * @param rpi the type instance to be used
 	 */
 	public BeanPropertyReference(ReferencePropertyInstance rpi) {
-		setTypeInstance(rpi);
+		super(rpi);
 	}
 	
 	private ATypeInstance safeGetTypeInstance(BEAN_TYPE value) {

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyResource.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyResource.java
@@ -29,10 +29,9 @@ import de.dlr.sc.virsat.model.dvlm.json.UriAdapter;
 
 /**
  * Class to wrap Resource Property Instance
- * @author fisc_ph
  *
  */
-public class BeanPropertyResource extends ABeanProperty<ResourcePropertyInstance, URI> implements IBeanProperty<ResourcePropertyInstance, URI> {
+public class BeanPropertyResource extends ABeanProperty<ResourcePropertyInstance, URI> {
 
 	/**
 	 * Default constructor
@@ -46,7 +45,7 @@ public class BeanPropertyResource extends ABeanProperty<ResourcePropertyInstance
 	 * @param rpi the resource property instance
 	 */
 	public BeanPropertyResource(ResourcePropertyInstance rpi) {
-		this.ti = rpi;
+		super(rpi);
 	}
 	
 	/**

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyResource.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyResource.java
@@ -32,7 +32,7 @@ import de.dlr.sc.virsat.model.dvlm.json.UriAdapter;
  * @author fisc_ph
  *
  */
-public class BeanPropertyResource extends ABeanObject<ResourcePropertyInstance> implements IBeanProperty<ResourcePropertyInstance, URI> {
+public class BeanPropertyResource extends ABeanProperty<ResourcePropertyInstance, URI> implements IBeanProperty<ResourcePropertyInstance, URI> {
 
 	/**
 	 * Default constructor

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyString.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyString.java
@@ -19,11 +19,10 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.Propertyinstance
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyInstance;
 
 /**
- * Class to wrap IntPropertyInstances
- * @author fisc_ph
+ * Class to wrap StringPropertyInstances
  *
  */
-public class BeanPropertyString extends ABeanValueProperty<String> {
+public class BeanPropertyString extends ABeanValueProperty<ValuePropertyInstance, String> {
 
 	/**
 	 * Standard Constructor
@@ -36,7 +35,7 @@ public class BeanPropertyString extends ABeanValueProperty<String> {
 	 * @param vpi the type instance to be used
 	 */
 	public BeanPropertyString(ValuePropertyInstance vpi) {
-		setTypeInstance(vpi);
+		super(vpi);
 	}
 	
 	@Override

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyString.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyString.java
@@ -23,7 +23,7 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.ValuePropertyIns
  * @author fisc_ph
  *
  */
-public class BeanPropertyString extends ABeanProperty<String> {
+public class BeanPropertyString extends ABeanValueProperty<String> {
 
 	/**
 	 * Standard Constructor

--- a/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/VirSatTransactionalAdapterFactoryContentProvider.java
+++ b/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/VirSatTransactionalAdapterFactoryContentProvider.java
@@ -158,7 +158,7 @@ public class VirSatTransactionalAdapterFactoryContentProvider extends org.eclips
 	 * @param changedObject The object that will be changed for example the StringPropertyInstance
 	 * @param notifyObject The object that should also receive a notification such as the ReferencePropertyInstance so it can notify its content provider correctly
 	 */
-	protected void redirectNotification(ABeanValueProperty<?> changedObject, Object notifyObject) {
+	protected void redirectNotification(ABeanValueProperty<?, ?> changedObject, Object notifyObject) {
 		redirectNotification(changedObject.getTypeInstance(), notifyObject);
 	}
 	

--- a/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/VirSatTransactionalAdapterFactoryContentProvider.java
+++ b/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/contentProvider/VirSatTransactionalAdapterFactoryContentProvider.java
@@ -26,7 +26,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.views.properties.IPropertySource;
 
 import de.dlr.sc.virsat.model.concept.types.category.ABeanCategoryAssignment;
-import de.dlr.sc.virsat.model.concept.types.property.ABeanProperty;
+import de.dlr.sc.virsat.model.concept.types.property.ABeanValueProperty;
 import de.dlr.sc.virsat.model.dvlm.categories.ICategoryAssignmentContainer;
 import de.dlr.sc.virsat.project.editingDomain.VirSatEditingDomainRegistry;
 import de.dlr.sc.virsat.project.editingDomain.util.VirSatTransactionalEditingDomainHelper;
@@ -158,7 +158,7 @@ public class VirSatTransactionalAdapterFactoryContentProvider extends org.eclips
 	 * @param changedObject The object that will be changed for example the StringPropertyInstance
 	 * @param notifyObject The object that should also receive a notification such as the ReferencePropertyInstance so it can notify its content provider correctly
 	 */
-	protected void redirectNotification(ABeanProperty<?> changedObject, Object notifyObject) {
+	protected void redirectNotification(ABeanValueProperty<?> changedObject, Object notifyObject) {
 		redirectNotification(changedObject.getTypeInstance(), notifyObject);
 	}
 	


### PR DESCRIPTION
- Renamed `ABeanProperty` to `ABeanValueProperty`
- Renamed `ABeanUnitProperty` to `ABeanUnitValueProperty`
- Added  `ABeanProperty` that wraps `APropertyInstance` and is extended by all bean property classes
- All bean constructores now use `super` instead of `setTypeInstance`
- Removed redundand `implements` statements

Closes https://github.com/virtualsatellite/VirtualSatellite4-Core/issues/802