### PR TITLE
Added missing canExport check for calling exporters from the wizard

### DIFF
--- a/de.dlr.sc.virsat.excel.test/src/de/dlr/sc/virsat/excel/ExcelExporterTest.java
+++ b/de.dlr.sc.virsat.excel.test/src/de/dlr/sc/virsat/excel/ExcelExporterTest.java
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EcoreFactory;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,9 +32,9 @@ import de.dlr.sc.virsat.excel.exporter.IExport;
 public class ExcelExporterTest {
 
 	/**
-	 * Mockup exporter accepting Strings
+	 * Mockup exporter accepting EObjects
 	 */
-	public class StringExporter implements IExport {
+	public class EObjectExporter implements IExport {
 
 		@Override
 		public void export(EObject eObject, String path, boolean useDefaultTemplate, String templatePath) {
@@ -42,7 +43,7 @@ public class ExcelExporterTest {
 
 		@Override
 		public boolean canExport(Object selection) {
-			return selection instanceof String;
+			return selection instanceof EObject;
 		}
 	}
 
@@ -58,7 +59,7 @@ public class ExcelExporterTest {
 					new ConfigurationElementHandle(null, 0) {
 						@Override
 						public Object createExecutableExtension(String propertyName) throws CoreException {
-							return new StringExporter();
+							return new EObjectExporter();
 						}
 					}
 				};
@@ -69,17 +70,21 @@ public class ExcelExporterTest {
 	@Test
 	public void testCanExport() throws CoreException {
 		ExcelExporter exporter = new ExcelExporter(registry);
-		boolean canExportString = exporter.canExport("Test");
-		assertTrue("String exporter can export a String", canExportString);
+		boolean canExportEObject = exporter.canExport(EcoreFactory.eINSTANCE.createEObject());
+		assertTrue("EObject exporter can export an eObject", canExportEObject);
 		boolean canExportObject = exporter.canExport(new Object());
-		assertFalse("String exporter cannot export an Object", canExportObject);
+		assertFalse("EObject exporter cannot export an Object", canExportObject);
 	}
 
 	@Test
 	public void testExport() throws CoreException {
 		ExcelExporter exporter = new ExcelExporter(registry);
 		assertFalse(executed);
-		exporter.export(null, null, false, null);
+		exporter.export(EcoreFactory.eINSTANCE.createEObject(), null, false, null);
 		assertTrue(executed);
+		
+		executed = false;
+		exporter.export(null, null, false, null);
+		assertFalse(executed);
 	}
 }

--- a/de.dlr.sc.virsat.excel.ui/src/de/dlr/sc/virsat/excel/ui/wizards/ExportWizard.java
+++ b/de.dlr.sc.virsat.excel.ui/src/de/dlr/sc/virsat/excel/ui/wizards/ExportWizard.java
@@ -15,14 +15,13 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.jface.dialogs.DialogSettings;
-import org.eclipse.jface.dialogs.ErrorDialog;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.Wizard;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.statushandlers.StatusManager;
 
 import de.dlr.sc.virsat.excel.exporter.ExcelExporter;
 import de.dlr.sc.virsat.model.dvlm.provider.DVLMEditPlugin;
@@ -99,8 +98,7 @@ public class ExportWizard extends Wizard implements INewWizard {
 					"Successfully exported to excel file to " + path));
 		} catch (Exception e) {
 			Status status = new Status(Status.ERROR, "de.dlr.sc.virsat.excel.ui", "Failed to perform an export operation! ", e);
-			DVLMEditPlugin.getPlugin().getLog().log(status);
-			ErrorDialog.openError(Display.getDefault().getActiveShell(), "Excel IO Failed", "Export failed", status);
+			StatusManager.getManager().handle(status, StatusManager.LOG | StatusManager.SHOW);
 			return false;
 		}
 		return true;
@@ -121,8 +119,7 @@ public class ExportWizard extends Wizard implements INewWizard {
 			canExport = ee.canExport(page.getSelection());
 		} catch (CoreException e) {
 			Status status = new Status(Status.ERROR, "de.dlr.sc.virsat.excel.ui", "Failed to perform an export operation! ", e);
-			DVLMEditPlugin.getPlugin().getLog().log(status);
-			ErrorDialog.openError(Display.getDefault().getActiveShell(), "Excel IO Failed", "Export failed", status);
+			StatusManager.getManager().handle(status, StatusManager.LOG | StatusManager.SHOW);
 		}
 		return (canExport && page.isComplete());
 	}

--- a/de.dlr.sc.virsat.excel/src/de/dlr/sc/virsat/excel/exporter/ExcelExporter.java
+++ b/de.dlr.sc.virsat.excel/src/de/dlr/sc/virsat/excel/exporter/ExcelExporter.java
@@ -50,7 +50,10 @@ public class ExcelExporter {
 		for (IConfigurationElement iConfElement : config) {
 			Object object = iConfElement.createExecutableExtension("class");
 			if (object instanceof IExport) {
-				((IExport) object).export(eObject, path, useDefaultTemplate, templatePath);
+				IExport exporter = (IExport) object;
+				if (exporter.canExport(eObject)) {
+					exporter.export(eObject, path, useDefaultTemplate, templatePath);
+				}
 			}
 		}
 	}
@@ -62,17 +65,16 @@ public class ExcelExporter {
 	 * @throws CoreException
 	 */
 	public boolean canExport(Object object) throws CoreException {
-		boolean canBeExported = false;
 		IConfigurationElement[] config = registry.getConfigurationElementsFor(IEXPORT_ID);
 		for (IConfigurationElement iConfElement : config) {
 			Object obj = iConfElement.createExecutableExtension("class");
 			if (obj instanceof IExport) {
-				canBeExported = ((IExport) obj).canExport(object);
+				boolean canBeExported = ((IExport) obj).canExport(object);
 				if (canBeExported) {
-					break;
+					return true;
 				}
 			}
 		}
-		return canBeExported;
+		return false;
 	}
 }


### PR DESCRIPTION
- Added missing check that lead to always executing only the functional electrical architecture excel exporter
- Some minor code refactorings

Closes #336

---
Task #336: There seems to be no way to trigger the Excel Export of State
Machines