### PR TITLE
Removed PropertyResource

### DIFF
--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/ModelAccessResourceTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/ModelAccessResourceTest.java
@@ -142,6 +142,8 @@ public class ModelAccessResourceTest extends AServerRepositoryTest {
 			}
 		};
 		ed.getCommandStack().execute(recordingCommand);
+		
+		VirSatTransactionalEditingDomain.waitForFiringOfAccumulatedResourceChangeEvents();
 	}
 	
 	@After
@@ -360,7 +362,6 @@ public class ModelAccessResourceTest extends AServerRepositoryTest {
 		Response response = webTarget.path(ModelAccessResource.PATH)
 				.path(projectName)
 				.path(ModelAccessResource.PROPERTY)
-				.path(ModelAccessResource.STRING)
 				.request()
 				.put(Entity.json(jsonIn));
 		assertEquals(HttpStatus.OK_200, response.getStatus());
@@ -368,17 +369,15 @@ public class ModelAccessResourceTest extends AServerRepositoryTest {
 	}
 	
 	/**
-	 * PUT a property of a specified type and assert that the server returns OK
+	 * PUT a property and assert that the server returns OK
 	 * @param property bean property to PUT
-	 * @param type the type of the property
 	 */
 	@SuppressWarnings("rawtypes")
-	private void testPutProperty(IBeanObject property, String type) {
+	private void testPutProperty(IBeanObject property) {
 		
 		Response response = webTarget.path(ModelAccessResource.PATH)
 				.path(projectName)
 				.path(ModelAccessResource.PROPERTY)
-				.path(type)
 				.request()
 				.put(Entity.entity(property, MediaType.APPLICATION_JSON_TYPE));
 		assertEquals(HttpStatus.OK_200, response.getStatus());
@@ -386,38 +385,38 @@ public class ModelAccessResourceTest extends AServerRepositoryTest {
 	
 	@Test
 	public void testPropertyBoolPut() throws JAXBException {
-		testPutProperty(beanBool, ModelAccessResource.BOOLEAN);
+		testPutProperty(beanBool);
 	}
 	
 	@Test
 	public void testPropertyStringPut() throws JAXBException {
-		testPutProperty(beanString, ModelAccessResource.STRING);
+		testPutProperty(beanString);
 	}
 	
 	@Test
 	public void testPropertyEnumPut() throws JAXBException {
-		testPutProperty(beanEnum, ModelAccessResource.ENUM);
+		testPutProperty(beanEnum);
 	}
 	
 	@Test
 	public void testPropertyFloatPut() throws JAXBException {
-		testPutProperty(beanFloat, ModelAccessResource.FLOAT);
+		testPutProperty(beanFloat);
 	}
 	
 	@Test
 	public void testPropertyIntPut() throws JAXBException {
-		testPutProperty(beanInt, ModelAccessResource.INT);
+		testPutProperty(beanInt);
 	}
 	
 	@Test
 	public void testPropertyResourcePut() throws JAXBException {
-		testPutProperty(beanResource, ModelAccessResource.RESOURCE);
+		testPutProperty(beanResource);
 	}
 	
 	@Test
 	public void testPropertyReferencePut() throws JAXBException {
-		testPutProperty(beanReferenceProp, ModelAccessResource.REFERENCE);
-		testPutProperty(beanReferenceCa, ModelAccessResource.REFERENCE);
+		testPutProperty(beanReferenceProp);
+		testPutProperty(beanReferenceCa);
 	}
 	
 	@Test
@@ -433,7 +432,6 @@ public class ModelAccessResourceTest extends AServerRepositoryTest {
 		Response response = webTarget.path(ModelAccessResource.PATH)
 				.path(projectName)
 				.path(ModelAccessResource.PROPERTY)
-				.path(ModelAccessResource.COMPOSED)
 				.request()
 				.put(Entity.json(jsonIn));
 		assertEquals(HttpStatus.OK_200, response.getStatus());

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ModelAccessResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ModelAccessResource.java
@@ -30,14 +30,7 @@ import de.dlr.sc.virsat.model.concept.types.category.ABeanCategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanCategoryAssignmentFactory;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanPropertyFactory;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanStructuralElementInstanceFactory;
-import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyBoolean;
-import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyComposed;
-import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyEnum;
-import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyFloat;
-import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyInt;
-import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyReference;
-import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyResource;
-import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyString;
+import de.dlr.sc.virsat.model.concept.types.property.ABeanProperty;
 import de.dlr.sc.virsat.model.concept.types.structural.ABeanStructuralElementInstance;
 import de.dlr.sc.virsat.model.concept.types.structural.IBeanStructuralElementInstance;
 import de.dlr.sc.virsat.model.dvlm.Repository;
@@ -66,15 +59,6 @@ public class ModelAccessResource {
 	public static final String CA = "ca";
 	public static final String CA_AND_PROPERTIES = "caAndProperties";
 	public static final String PROPERTY = "property";
-	
-	public static final String BOOLEAN = "boolean";
-	public static final String STRING = "string";
-	public static final String INT = "int";
-	public static final String FLOAT = "float";
-	public static final String ENUM = "enum";
-	public static final String RESOURCE = "resource";
-	public static final String REFERENCE = "reference";
-	public static final String COMPOSED = "composed";
 
 	@Inject
 	public ModelAccessResource(TransactionalJsonProvider provider) { 
@@ -120,93 +104,22 @@ public class ModelAccessResource {
 		private Response createBadRequestResponse(String msg) {
 			return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
 		}
-	
-		@Path(PROPERTY)
-		public PropertyResource accessProperty() {
-			return new PropertyResource(repository);
+		
+		@GET
+		@Path(PROPERTY + "/{propertyUuid}")
+		@Produces(MediaType.APPLICATION_JSON)
+		public Response getProperty(@PathParam("propertyUuid") String propertyUuid) {
+			return Response.status(Response.Status.OK).entity(
+					new BeanPropertyFactory().getInstanceFor(
+							RepositoryUtility.findProperty(propertyUuid, repository)
+					)).build();
 		}
 		
-		/*
-		 * A function for each property bean because 
-		 * the generic definition with wildcards
-		 * of a bean property (ABeanObject<? extends APropertyInstance)
-		 * is not supported
-		 * 
-		 * If a new property should be supported 
-		 * it has to be added here
-		 */
-		public static class PropertyResource {
-			private Repository repository;
-			
-			public PropertyResource(Repository repository) {
-				this.repository = repository;
-			}
-			
-			@GET
-			@Path("/{propertyUuid}")
-			@Produces(MediaType.APPLICATION_JSON)
-			public Response getProperty(@PathParam("propertyUuid") String propertyUuid) {
-				return Response.status(Response.Status.OK).entity(
-						new BeanPropertyFactory().getInstanceFor(
-								RepositoryUtility.findProperty(propertyUuid, repository)
-						)).build();
-			}
-			
-			@PUT
-			@Path(STRING)
-			@Consumes(MediaType.APPLICATION_JSON)
-			public Response putProperty(BeanPropertyString bean) {
-				return Response.status(Response.Status.OK).build();
-			}
-			
-			@PUT
-			@Path(INT)
-			@Consumes(MediaType.APPLICATION_JSON)
-			public Response putProperty(BeanPropertyInt bean) {
-				return Response.status(Response.Status.OK).build();
-			}
-			
-			@PUT
-			@Path(FLOAT)
-			@Consumes(MediaType.APPLICATION_JSON)
-			public Response putProperty(BeanPropertyFloat bean) {
-				return Response.status(Response.Status.OK).build();
-			}
-			
-			@PUT
-			@Path(ENUM)
-			@Consumes(MediaType.APPLICATION_JSON)
-			public Response putProperty(BeanPropertyEnum bean) {
-				return Response.status(Response.Status.OK).build();
-			}
-			
-			@PUT
-			@Path(RESOURCE)
-			@Consumes(MediaType.APPLICATION_JSON)
-			public Response putProperty(BeanPropertyResource bean) {
-				return Response.status(Response.Status.OK).build();
-			}
-			
-			@PUT
-			@Path(BOOLEAN)
-			@Consumes(MediaType.APPLICATION_JSON)
-			public Response putProperty(BeanPropertyBoolean bean) {
-				return Response.status(Response.Status.OK).build();
-			}
-			
-			@PUT
-			@Path(REFERENCE)
-			@Consumes(MediaType.APPLICATION_JSON)
-			public Response putProperty(@SuppressWarnings("rawtypes") BeanPropertyReference bean) {
-				return Response.status(Response.Status.OK).build();
-			}
-			
-			@PUT
-			@Path(COMPOSED)
-			@Consumes(MediaType.APPLICATION_JSON)
-			public Response putProperty(@SuppressWarnings("rawtypes") BeanPropertyComposed bean) {
-				return Response.status(Response.Status.OK).build();
-			}
+		@PUT
+		@Path(PROPERTY)
+		@Consumes(MediaType.APPLICATION_JSON)
+		public Response putProperty(ABeanProperty<?, ?> bean) {
+			return Response.status(Response.Status.OK).build();
 		}
 		
 		/**


### PR DESCRIPTION
Removed `Property Resource` that is not needed anymore because a abstract ABeanProperty for all bean properties was introduced in https://github.com/virtualsatellite/VirtualSatellite4-Core/issues/802.

Closes https://github.com/virtualsatellite/VirtualSatellite4-Core/issues/804