### PR TITLE
Fix NPE when opening a graphiti diagram

### DIFF
--- a/de.dlr.sc.virsat.graphiti.ui/src/de/dlr/sc/virsat/graphiti/ui/diagram/editor/VirSatDiagramBehavior.java
+++ b/de.dlr.sc.virsat.graphiti.ui/src/de/dlr/sc/virsat/graphiti/ui/diagram/editor/VirSatDiagramBehavior.java
@@ -9,6 +9,8 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.graphiti.ui.diagram.editor;
 
+import org.eclipse.draw2d.geometry.Point;
+import org.eclipse.gef.GraphicalViewer;
 import org.eclipse.graphiti.ui.editor.DefaultPersistencyBehavior;
 import org.eclipse.graphiti.ui.editor.DefaultUpdateBehavior;
 import org.eclipse.graphiti.ui.editor.DiagramBehavior;
@@ -35,12 +37,27 @@ public class VirSatDiagramBehavior extends DiagramBehavior {
 	protected DefaultUpdateBehavior createUpdateBehavior() {
 		
 		// Create an update behavior that uses the VirSatTransactionalEditingDomain
-		
 		return new VirSatDiagramUpdateBehavior(this);
 	}
 	
 	@Override
 	protected DefaultPersistencyBehavior createPersistencyBehavior() {
 		return new VirSatDiagramPersistencyBehavior(this);
+	}
+	
+	@Override
+	public Point calculateRealMouseLocation(Point nativeLocation) {
+		// Make sure there exists a control element for the viewer when executing this
+		// method. During initialization of a graphiti editor this method might be triggered
+		// to initialize undo/redo actions if the last command on the command stack 
+		// involves connections. If we do not have a control element for the viewer yet then
+		// simply return the native location to initialize the editor actions.
+		GraphicalViewer viewer = getDiagramContainer().getGraphicalViewer();
+		if (viewer.getControl() != null) {
+			return super.calculateRealMouseLocation(nativeLocation);
+		} else {
+			return nativeLocation;
+		}
+		
 	}
 }


### PR DESCRIPTION
- Make sure the graphical viewer has an editor control when calculating
the real mouse location
- If no control exists yet because the editor is being initialized, then
simply return the native location to initialize the editor actions

Closing #816