### PR TITLE
Improve look and feel of state machine diagrams

### DIFF
--- a/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/StateMachineDoubleClickFeature.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/StateMachineDoubleClickFeature.java
@@ -82,8 +82,15 @@ public class StateMachineDoubleClickFeature extends VirsatCategoryAssignmentOpen
 				ed.getCommandStack().execute(command);
 				
 				//Update diagram label
-				Connection connection = (Connection) context.getPictogramElements()[0];
-				Text text = (Text) connection.getConnectionDecorators().get(0).getGraphicsAlgorithm();
+				PictogramElement subject = context.getPictogramElements()[0];
+				Connection connection = null;
+				Text text = null;
+				if (subject instanceof Connection) {
+					connection = (Connection) subject;
+					text = (Text) connection.getConnectionDecorators().get(0).getGraphicsAlgorithm();
+				} else {
+					text = (Text) subject.getGraphicsAlgorithm();
+				}
 				ITransitionLabelProvider labelProvider = new LabelProviderInstantiator().getLabelProvider();
 				text.setValue(labelProvider.getLabel(transition));	
 			}

--- a/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/stateMachines/StateMachineAddFeature.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/stateMachines/StateMachineAddFeature.java
@@ -52,6 +52,7 @@ public class StateMachineAddFeature extends VirSatAddShapeFeature {
 	public static final int PADDING_X = 10;
 	public static final int PADDING_Y = 10;
 	public static final int STATEPADDING = 50;
+	public static final int ROUNDED_CORNERS = 10;
 	
 	public static final IColorConstant ELEMENT_TEXT_FOREGROUND = IColorConstant.BLACK;
 	public static final IColorConstant ELEMENT_FOREGROUND =	new ColorConstant(98, 131, 167);	
@@ -95,7 +96,9 @@ public class StateMachineAddFeature extends VirSatAddShapeFeature {
 		RoundedRectangle roundedRectangle = gaService.createRoundedRectangle(containerShape, CORNER_WIDTH, CORNER_HEIGHT);		
 		roundedRectangle.setLineWidth(LINE_WIDTH);		
 		roundedRectangle.setForeground(manageColor(ELEMENT_FOREGROUND));
-		roundedRectangle.setBackground(manageColor(ELEMENT_BACKGROUND));	
+		roundedRectangle.setBackground(manageColor(ELEMENT_BACKGROUND));
+		roundedRectangle.setCornerHeight(ROUNDED_CORNERS);
+		roundedRectangle.setCornerWidth(ROUNDED_CORNERS);
 		gaService.setLocationAndSize(roundedRectangle, context.getX(), context.getY(), width, height);		
 		link(containerShape, sm);
 		

--- a/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/stateMachines/StateMachineAddFeature.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/stateMachines/StateMachineAddFeature.java
@@ -106,11 +106,13 @@ public class StateMachineAddFeature extends VirSatAddShapeFeature {
 		Shape lineShape = peCreateService.createShape(containerShape, false);		
 		Polyline polyline = gaService.createPolyline(lineShape, new int[] { 0, linePosY + PADDING_Y, linePosX + PADDING_X + 2, linePosY + PADDING_Y });		
 		polyline.setLineWidth(LINE_WIDTH);
+		polyline.setForeground(manageColor(ELEMENT_FOREGROUND));
 		
 		// Create Shape with line2
 		Shape lineShape2 = peCreateService.createShape(containerShape, false);		
 		Polyline polyline2 = gaService.createPolyline(lineShape2, new int[] { linePosX + PADDING_X, 0, linePosX + PADDING_X,  linePosY + PADDING_Y + 2 });		
 		polyline2.setLineWidth(LINE_WIDTH);
+		polyline2.setForeground(manageColor(ELEMENT_FOREGROUND));
 		
 		// Create Shape with Type Label
 		Shape typeShape = peCreateService.createShape(containerShape, false);		

--- a/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/states/StateAddFeature.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/states/StateAddFeature.java
@@ -25,6 +25,7 @@ import org.eclipse.graphiti.mm.pictograms.Shape;
 import org.eclipse.graphiti.services.Graphiti;
 import org.eclipse.graphiti.services.IGaService;
 import org.eclipse.graphiti.services.IPeCreateService;
+import org.eclipse.graphiti.util.ColorConstant;
 import org.eclipse.graphiti.util.IColorConstant;
 
 import de.dlr.sc.virsat.graphiti.ui.diagram.feature.VirSatAddShapeFeature;
@@ -38,13 +39,16 @@ import de.dlr.sc.virsat.model.extension.statemachines.model.StateMachine;
  */
 
 public class StateAddFeature extends VirSatAddShapeFeature {
-	public static  final int RADIUS = 50;
+	public static  final int RADIUS = 65;
 	
 	public static final int INDEX_ELLIPSE = 0;
 	public static final int INDEX_INITIAL_ARROW = 1;
 	public static final int INDEX_TEXT = 2;
 	
 	public static final int INITIAL_ARROW_SIZE = 15;
+	public static final int CONTAINER_SIZE = RADIUS + INITIAL_ARROW_SIZE * 2;
+	
+	public static final IColorConstant ELEMENT_BACKGROUND =	new ColorConstant(232, 94, 74);
 	
 	/** 
 	 * Default constructor.
@@ -103,12 +107,12 @@ public class StateAddFeature extends VirSatAddShapeFeature {
         
         
         Rectangle invisibleRectangle = gaService.createInvisibleRectangle(containerShape);
-		gaService.setLocationAndSize(invisibleRectangle, context.getX(), context.getY(), RADIUS, RADIUS);
+		gaService.setLocationAndSize(invisibleRectangle, context.getX(), context.getY(), CONTAINER_SIZE, CONTAINER_SIZE);
         
         ContainerShape ellipseShape = peCreateService.createContainerShape(containerShape, true);
         
         Ellipse ellipse = gaService.createEllipse(ellipseShape);
-        ellipse.setBackground(manageColor(IColorConstant.RED));
+        ellipse.setBackground(manageColor(ELEMENT_BACKGROUND));
         ellipse.setLineVisible(false);
         ellipseShape.setActive(false);
 

--- a/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/states/StateLayoutFeature.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/states/StateLayoutFeature.java
@@ -34,7 +34,8 @@ public class StateLayoutFeature extends VirSatLayoutFeature  {
 	@Override
 	public boolean layout(ILayoutContext context) {
 		ContainerShape cs = (ContainerShape) context.getPictogramElement();
-
+		
+		int csWidth = cs.getGraphicsAlgorithm().getWidth();
 		int csHeight = cs.getGraphicsAlgorithm().getHeight();
 		
 		Shape ellipseShape = cs.getChildren().get(StateAddFeature.INDEX_ELLIPSE);
@@ -43,28 +44,27 @@ public class StateLayoutFeature extends VirSatLayoutFeature  {
 		
 		// Offset of bounding box to enable adding initial state arrow to appear
 		int ellipseOffset = initialArrowShape.getGraphicsAlgorithm().getWidth();
-		int ellipsRadius = csHeight - ellipseOffset * 2;
+		int ellipsHeight = csHeight - ellipseOffset * 2;
+		int ellipsWidth = csWidth - ellipseOffset * 2;
 		
 		Graphiti.getGaService().setLocationAndSize(
 				ellipseShape.getGraphicsAlgorithm(), 
 				ellipseOffset, 
 				ellipseOffset,
-				ellipsRadius, 
-				ellipsRadius
+				ellipsWidth, 
+				ellipsHeight
 		);
 
 		initialArrowShape.getGraphicsAlgorithm().setY(
 				(csHeight - initialArrowShape.getGraphicsAlgorithm().getHeight()) / 2
 		);
 		
-		
-		
 		Graphiti.getGaService().setLocationAndSize(
 				textShape.getGraphicsAlgorithm(), 
 				ellipseOffset, 
 				ellipseOffset,
-				ellipsRadius, 
-				ellipsRadius
+				ellipsWidth, 
+				ellipsHeight
 		);
 		
 		return true;

--- a/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/states/StateLayoutFeature.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/states/StateLayoutFeature.java
@@ -16,8 +16,6 @@ import org.eclipse.graphiti.mm.pictograms.Shape;
 import org.eclipse.graphiti.services.Graphiti;
 
 import de.dlr.sc.virsat.graphiti.ui.diagram.feature.VirSatLayoutFeature;
-import de.dlr.sc.virsat.model.extension.statemachines.model.State;
-import de.dlr.sc.virsat.model.extension.statemachines.model.StateMachine;
 
 /**
  * Layout feature for states. Adjusts the internal shapes to match
@@ -36,38 +34,37 @@ public class StateLayoutFeature extends VirSatLayoutFeature  {
 	@Override
 	public boolean layout(ILayoutContext context) {
 		ContainerShape cs = (ContainerShape) context.getPictogramElement();
-		
-		State state = (State) getBusinessObjectForPictogramElement(cs);
-		StateMachine sm = state.getParentCaBeanOfClass(StateMachine.class);
-		
-		int csWidth = cs.getGraphicsAlgorithm().getWidth();
+
 		int csHeight = cs.getGraphicsAlgorithm().getHeight();
 		
 		Shape ellipseShape = cs.getChildren().get(StateAddFeature.INDEX_ELLIPSE);
 		Shape initialArrowShape = cs.getChildren().get(StateAddFeature.INDEX_INITIAL_ARROW);
 		Shape textShape = cs.getChildren().get(StateAddFeature.INDEX_TEXT);
 		
-		int ellipseOffset = state.equals(sm.getInitialState()) ? initialArrowShape.getGraphicsAlgorithm().getWidth() : 0;
-		int ellipsWidth = csWidth - ellipseOffset;
+		// Offset of bounding box to enable adding initial state arrow to appear
+		int ellipseOffset = initialArrowShape.getGraphicsAlgorithm().getWidth();
+		int ellipsRadius = csHeight - ellipseOffset * 2;
 		
 		Graphiti.getGaService().setLocationAndSize(
 				ellipseShape.getGraphicsAlgorithm(), 
 				ellipseOffset, 
-				0,
-				ellipsWidth, 
-				csHeight
+				ellipseOffset,
+				ellipsRadius, 
+				ellipsRadius
 		);
 
 		initialArrowShape.getGraphicsAlgorithm().setY(
 				(csHeight - initialArrowShape.getGraphicsAlgorithm().getHeight()) / 2
 		);
 		
+		
+		
 		Graphiti.getGaService().setLocationAndSize(
 				textShape.getGraphicsAlgorithm(), 
 				ellipseOffset, 
-				0,
-				ellipsWidth, 
-				csHeight
+				ellipseOffset,
+				ellipsRadius, 
+				ellipsRadius
 		);
 		
 		return true;


### PR DESCRIPTION
- Change color of states
- Fix states being resized incorrectly when defined as initial state
- Add rounding corners of state machine container shape
- Improve double click handling when clicked on transition labels

Closing #231