### PR TITLE
Improved build stability

### DIFF
--- a/bash/maven_build.sh
+++ b/bash/maven_build.sh
@@ -71,6 +71,7 @@ checkforMavenProblems() {
 	| grep -v "Artifact not found:" \
 	| grep -v "An error occurred while transferring artifact canonical:" \
 	| grep -v "Unable to read repository at" \
+	| grep -v "Unknown Host:" \
 	|| exit 0 && exit 1;)
 }
 


### PR DESCRIPTION
- Grepping out irrelevant warnings

Closes #856 


---
Task #856: Improve build stability by excluding irrelevant warnings