### PR TITLE
Improved build stability 

### DIFF
--- a/bash/setup.sh
+++ b/bash/setup.sh
@@ -22,7 +22,7 @@ sudo apt-get install openjdk-8-jdk xvfb metacity libvtk6-java libzmq5 libzmq-jav
 # cd ..
   
 # -------------------------------------
-# Installing OverTarget
+# Installing Overtarget
 # -------------------------------------
 
 echo "Installing and running Overtarget"

--- a/bash/setup.sh
+++ b/bash/setup.sh
@@ -25,7 +25,7 @@ sudo apt-get install openjdk-8-jdk xvfb metacity libvtk6-java libzmq5 libzmq-jav
 # Installing OverTarget
 # -------------------------------------
 
-echo "Installing and running OverTarget"
+echo "Installing and running Overtarget"
 ./bash/maven_build.sh -j dependencies -p dependencies
   
 # -------------------------------------------------------------------

--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/project/resources/dmf/DmfResourceTest.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/project/resources/dmf/DmfResourceTest.java
@@ -26,11 +26,7 @@ import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.transaction.RecordingCommand;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 
 import de.dlr.sc.virsat.concept.unittest.util.test.AConceptProjectTestCase;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyString;
@@ -69,9 +65,6 @@ import de.dlr.sc.virsat.model.external.tests.ExternalTestType;
 public class DmfResourceTest extends AConceptProjectTestCase {
 
 	public static final int TEST_CASE_TIMEOUT = 10000;
-	
-	@ClassRule
-	public static TestRule timeout = new DisableOnDebug(Timeout.millis(TEST_CASE_TIMEOUT));
 
 	private Concept concept;
 	

--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/project/resources/dmf/DmfResourceTest.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/project/resources/dmf/DmfResourceTest.java
@@ -18,17 +18,26 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
-import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceDescription;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EPackage;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.transaction.RecordingCommand;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
 
-import de.dlr.sc.virsat.concept.unittest.util.test.AConceptProjectTestCase;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyString;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoriesFactory;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
@@ -44,7 +53,9 @@ import de.dlr.sc.virsat.model.dvlm.concepts.ConceptsFactory;
 import de.dlr.sc.virsat.model.dvlm.dmf.DObject;
 import de.dlr.sc.virsat.model.dvlm.dmf.DObjectContainer;
 import de.dlr.sc.virsat.model.dvlm.dmf.UnresolveableDObject;
+import de.dlr.sc.virsat.model.dvlm.roles.UserRegistry;
 import de.dlr.sc.virsat.model.dvlm.structural.StructuralElementInstance;
+import de.dlr.sc.virsat.model.extension.tests.model.AConceptTestCase;
 import de.dlr.sc.virsat.model.extension.tests.model.EReferenceTest;
 import de.dlr.sc.virsat.model.extension.tests.model.TestCategoryAllProperty;
 import de.dlr.sc.virsat.model.extension.tests.model.TestCategoryComposition;
@@ -55,6 +66,9 @@ import de.dlr.sc.virsat.model.extension.tests.model.TestStructuralElement;
 import de.dlr.sc.virsat.model.extension.tests.tests.EnumTestEnum;
 import de.dlr.sc.virsat.model.extension.tests.tests.TestsFactory;
 import de.dlr.sc.virsat.model.external.tests.ExternalTestType;
+import de.dlr.sc.virsat.project.editingDomain.VirSatEditingDomainRegistry;
+import de.dlr.sc.virsat.project.editingDomain.VirSatTransactionalEditingDomain;
+import de.dlr.sc.virsat.project.resources.VirSatResourceSet;
 
 /**
  * This class tests the methods of DmfResource
@@ -62,35 +76,64 @@ import de.dlr.sc.virsat.model.external.tests.ExternalTestType;
  *
  */
 
-public class DmfResourceTest extends AConceptProjectTestCase {
+public class DmfResourceTest extends AConceptTestCase {
 
-	public static final int TEST_CASE_TIMEOUT = 10000;
-
+	public static final int TEST_CASE_TIMEOUT = 5000;
+	
+	@ClassRule
+	public static TestRule timeout = new DisableOnDebug(Timeout.millis(TEST_CASE_TIMEOUT));
+	
+	private IProject project;
+	private VirSatResourceSet resSet;
+	private VirSatTransactionalEditingDomain ed;
 	private Concept concept;
 	
 	protected EPackage testExternalPackage;
 	private static final String PLATFORM_MODEL_PATH = "/de.dlr.sc.virsat.model.external.tests/model/ExternalModel.ecore";
 	
 	@Before
-	public void setUp() throws CoreException  {
-		super.setUp();
+	public void setUp() throws Exception {
+		concept = loadConceptFromPlugin();
 		
-		addEditingDomainAndRepository();
+		IWorkspaceRoot wsRoot = ResourcesPlugin.getWorkspace().getRoot();
+		IWorkspaceDescription wsd = ResourcesPlugin.getWorkspace().getDescription();
+		wsd.setAutoBuilding(false);
+		ResourcesPlugin.getWorkspace().setDescription(wsd);
+		wsRoot.deleteMarkers(IMarker.PROBLEM, true, IResource.DEPTH_INFINITE);
 		
-		concept = loadConceptFromPlugin(de.dlr.sc.virsat.model.extension.tests.Activator.getPluginId());
+		project = wsRoot.getProject("dmfResourceTests");
+		if (project.exists()) {
+			project.delete(true, null);
+		}
 		
-		editingDomain.getCommandStack().execute(new RecordingCommand(editingDomain) {
+		project.create(null);
+		project.open(null);
+
+		UserRegistry.getInstance().setSuperUser(true);
+		
+		resSet = VirSatResourceSet.getResourceSet(project, false);
+		ed = VirSatEditingDomainRegistry.INSTANCE.getEd(resSet);
+		ed.getCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getResources().clear();
-				rs.initializeModelsAndResourceSet();
-				rs.getRepository().getActiveConcepts().add(concept);
+				resSet.getResources().clear();
+				resSet.initializeModelsAndResourceSet();
+				resSet.getRepository().getActiveConcepts().add(concept);
 			}
 		});
 		
 		URI metamodelURI = URI.createPlatformPluginURI(PLATFORM_MODEL_PATH, true);
-		Resource metamodelResource = rs.getResource(metamodelURI, true);
+		Resource metamodelResource = resSet.getResource(metamodelURI, true);
 		testExternalPackage = (EPackage) metamodelResource.getContents().get(0);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (project.exists()) {
+			project.delete(true, null);
+		}
+		UserRegistry.getInstance().setSuperUser(false);
+		ResourcesPlugin.getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
 	}
 	
 	@Test
@@ -115,16 +158,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		
 		beanTestStructuralElement.add(beanTestCategoryAssignment);
 
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -186,16 +229,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		
 		beanTestStructuralElement.add(beanTestCategoryAssignment);
 
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -235,16 +278,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		beanTestStructuralElement.add(beanTestCategoryAssignmentArray);
 		beanTestStructuralElement.add(beanTestCategoryAssignmentReferenced);
 		
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -282,16 +325,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		
 		beanTestStructuralElement.add(beanTestCategoryAssignment);
 
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -328,16 +371,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		beanTestStructuralElement.add(beanTestCategoryAssignmentReference);
 		beanTestStructuralElement.add(beanTestCategoryAssignment);
 
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -377,17 +420,17 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		final int TEST_VALUE_INT = 10;
 		beanTestCategoryAssignment.setTestInt(TEST_VALUE_INT);
 
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElementOther.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElementOther.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -423,16 +466,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		beanTestCategoryAssignmentComposed.getTestSubCategory().setTestInt(TEST_VALUE_INT);
 		beanTestStructuralElement.add(beanTestCategoryAssignmentComposed);
 
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -471,16 +514,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		
 		beanTestStructuralElement.getStructuralElementInstance().getCategoryAssignments().add(noDmfCa);
 
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -509,16 +552,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 	public void testSaveSingleDObject() throws IOException {
 		TestStructuralElement beanTestStructuralElement = new TestStructuralElement(concept);
 		
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -575,16 +618,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 	public void testSaveDObjectWithEReference() throws IOException {
 		TestStructuralElement beanTestStructuralElement = new TestStructuralElement(concept);
 		
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -602,8 +645,8 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		
 		final ExternalTestType TEST_EREFERENCE_VALUE = de.dlr.sc.virsat.model.external.tests.TestsFactory.eINSTANCE.createExternalTestType();
 		URI testExternalModelInstanceURI = originalSeiUri.trimFileExtension().appendFileExtension("etests");
-		Resource testExternalModelInstanceResource = rs.createResource(testExternalModelInstanceURI);
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		Resource testExternalModelInstanceResource = resSet.createResource(testExternalModelInstanceURI);
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
 				testExternalModelInstanceResource.getContents().add(TEST_EREFERENCE_VALUE);
@@ -634,16 +677,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 	public void testSaveReferencedDObjectSameContainment() throws IOException {
 		TestStructuralElement beanTestStructuralElement = new TestStructuralElement(concept);
 
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -684,16 +727,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		TestStructuralElement beanTestStructuralElement = new TestStructuralElement(concept);
 		TestStructuralElement beanTestStructuralElementOther = new TestStructuralElement(concept);
 
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElementOther.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElementOther.getStructuralElementInstance());
 			}
 		});
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
-		Resource resSeiOther = rs.getStructuralElementInstanceResource(beanTestStructuralElementOther.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSeiOther = resSet.getStructuralElementInstanceResource(beanTestStructuralElementOther.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -709,7 +752,7 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		Resource dmfResourceOther = dmfResourceSet.getResource(dmfSeiUriOther, true);
 		Resource dmfResource = dmfResourceSet.getResource(dmfSeiUri, true);
 		
-		editingDomain.saveAll();
+		ed.saveAll();
 		
 		DObjectContainer dObjectContainerOther = (DObjectContainer) dmfResourceOther.getContents().get(0);
 		de.dlr.sc.virsat.model.extension.tests.tests.TestCategoryReference dmfCategoryAssignmentReference = TestsFactory.eINSTANCE.createTestCategoryReference();
@@ -750,16 +793,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		TestStructuralElement beanTestStructuralElement = new TestStructuralElement(concept);
 		TestStructuralElement beanTestStructuralElementOther = new TestStructuralElement(concept);
 
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElementOther.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElementOther.getStructuralElementInstance());
 			}
 		});
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
-		Resource resSeiOther = rs.getStructuralElementInstanceResource(beanTestStructuralElementOther.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSeiOther = resSet.getStructuralElementInstanceResource(beanTestStructuralElementOther.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -775,7 +818,7 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		Resource dmfResourceOther = dmfResourceSet.getResource(dmfSeiUriOther, true);
 		Resource dmfResource = dmfResourceSet.getResource(dmfSeiUri, true);
 		
-		editingDomain.saveAll();
+		ed.saveAll();
 		
 		DObjectContainer dObjectContainerOther = (DObjectContainer) dmfResourceOther.getContents().get(0);
 		de.dlr.sc.virsat.model.extension.tests.tests.TestCategoryReference dmfCategoryAssignmentReference = TestsFactory.eINSTANCE.createTestCategoryReference();
@@ -827,16 +870,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 	public void testSaveContainedDObject() throws IOException {
 		TestStructuralElement beanTestStructuralElement = new TestStructuralElement(concept);
 
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -876,16 +919,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 	public void testSaveDObjectWithArray() throws IOException {
 		TestStructuralElement beanTestStructuralElement = new TestStructuralElement(concept);
 
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -928,16 +971,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 	public void testSaveDObjectWithReferenceArray() throws IOException {
 		TestStructuralElement beanTestStructuralElement = new TestStructuralElement(concept);
 
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -989,17 +1032,17 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		
 		beanTestStructuralElement.getStructuralElementInstance().getCategoryAssignments().add(noDmfCa);
 		
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				editingDomain.getResourceSet().getRepository().getActiveConcepts().add(concept);
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				ed.getResourceSet().getRepository().getActiveConcepts().add(concept);
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();
@@ -1031,16 +1074,16 @@ public class DmfResourceTest extends AConceptProjectTestCase {
 		TestCategoryAllProperty beanTestCategoryAssignment = new TestCategoryAllProperty(concept);
 		beanTestStructuralElement.add(beanTestCategoryAssignment);
 
-		editingDomain.getVirSatCommandStack().execute(new RecordingCommand(editingDomain) {
+		ed.getVirSatCommandStack().execute(new RecordingCommand(ed) {
 			@Override
 			protected void doExecute() {
-				rs.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+				resSet.getAndAddStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 			}
 		});
 
-		editingDomain.saveAll();
+		ed.saveAll();
 
-		Resource resSei = rs.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
+		Resource resSei = resSet.getStructuralElementInstanceResource(beanTestStructuralElement.getStructuralElementInstance());
 		
 		Resource.Factory.Registry resourceRegistry = Resource.Factory.Registry.INSTANCE;
 		Map<String, Object> m = resourceRegistry.getExtensionToFactoryMap();

--- a/de.dlr.sc.virsat.project.test/src/de/dlr/sc/virsat/project/test/AProjectTestCase.java
+++ b/de.dlr.sc.virsat.project.test/src/de/dlr/sc/virsat/project/test/AProjectTestCase.java
@@ -25,6 +25,7 @@ import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.transaction.RecordingCommand;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestName;
@@ -49,8 +50,8 @@ public abstract class AProjectTestCase {
 	protected static final int MAX_TEST_CASE_TIMEOUT_SECONDS = 30;
 	protected static final int MAX_TEST_CASE_WAIT_TIME_MILLI_SECONDS = 1000;
 	
-	@Rule
-	public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(MAX_TEST_CASE_TIMEOUT_SECONDS));
+	@ClassRule
+	public static TestRule timeout = new DisableOnDebug(Timeout.seconds(MAX_TEST_CASE_TIMEOUT_SECONDS));
 	
 	protected static final String TEST_PROJECT_NAME = "testProject";
 	private static final String JUNIT_DEBUG_PROJECT_TEST_CASE = "JUNIT_DEBUG_PROJECT_TEST_CASE";

--- a/de.dlr.sc.virsat.project.test/src/de/dlr/sc/virsat/project/test/AProjectTestCase.java
+++ b/de.dlr.sc.virsat.project.test/src/de/dlr/sc/virsat/project/test/AProjectTestCase.java
@@ -25,7 +25,6 @@ import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.transaction.RecordingCommand;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestName;
@@ -50,8 +49,8 @@ public abstract class AProjectTestCase {
 	protected static final int MAX_TEST_CASE_TIMEOUT_SECONDS = 30;
 	protected static final int MAX_TEST_CASE_WAIT_TIME_MILLI_SECONDS = 1000;
 	
-	@ClassRule
-	public static TestRule timeout = new DisableOnDebug(Timeout.seconds(MAX_TEST_CASE_TIMEOUT_SECONDS));
+	@Rule
+	public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(MAX_TEST_CASE_TIMEOUT_SECONDS));
 	
 	protected static final String TEST_PROJECT_NAME = "testProject";
 	private static final String JUNIT_DEBUG_PROJECT_TEST_CASE = "JUNIT_DEBUG_PROJECT_TEST_CASE";

--- a/de.dlr.sc.virsat.project.test/src/de/dlr/sc/virsat/project/test/AProjectTestCase.java
+++ b/de.dlr.sc.virsat.project.test/src/de/dlr/sc/virsat/project/test/AProjectTestCase.java
@@ -26,7 +26,10 @@ import org.eclipse.emf.transaction.RecordingCommand;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
 
 import de.dlr.sc.virsat.model.dvlm.Repository;
 import de.dlr.sc.virsat.model.dvlm.roles.IUserContext;
@@ -46,6 +49,8 @@ public abstract class AProjectTestCase {
 	protected static final int MAX_TEST_CASE_TIMEOUT_SECONDS = 30;
 	protected static final int MAX_TEST_CASE_WAIT_TIME_MILLI_SECONDS = 1000;
 	
+	@Rule
+	public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(MAX_TEST_CASE_TIMEOUT_SECONDS));
 	
 	protected static final String TEST_PROJECT_NAME = "testProject";
 	private static final String JUNIT_DEBUG_PROJECT_TEST_CASE = "JUNIT_DEBUG_PROJECT_TEST_CASE";

--- a/de.dlr.sc.virsat.project.test/src/de/dlr/sc/virsat/project/test/AProjectTestCase.java
+++ b/de.dlr.sc.virsat.project.test/src/de/dlr/sc/virsat/project/test/AProjectTestCase.java
@@ -26,10 +26,7 @@ import org.eclipse.emf.transaction.RecordingCommand;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.rules.DisableOnDebug;
 import org.junit.rules.TestName;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
 
 import de.dlr.sc.virsat.model.dvlm.Repository;
 import de.dlr.sc.virsat.model.dvlm.roles.IUserContext;
@@ -49,8 +46,6 @@ public abstract class AProjectTestCase {
 	protected static final int MAX_TEST_CASE_TIMEOUT_SECONDS = 30;
 	protected static final int MAX_TEST_CASE_WAIT_TIME_MILLI_SECONDS = 1000;
 	
-	@Rule
-	public TestRule globalTimeout = new DisableOnDebug(Timeout.seconds(MAX_TEST_CASE_TIMEOUT_SECONDS));
 	
 	protected static final String TEST_PROJECT_NAME = "testProject";
 	private static final String JUNIT_DEBUG_PROJECT_TEST_CASE = "JUNIT_DEBUG_PROJECT_TEST_CASE";

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/RoleManagementTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/RoleManagementTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import de.dlr.sc.virsat.model.extension.ps.model.ElementDefinition;
 import de.dlr.sc.virsat.model.extension.ps.model.ProductTree;
 import de.dlr.sc.virsat.model.extension.ps.model.ProductTreeDomain;
+import de.dlr.sc.virsat.project.ui.perspective.CorePerspective;
 
 public class RoleManagementTest extends ASwtBotTestCase {
 	
@@ -61,7 +62,7 @@ public class RoleManagementTest extends ASwtBotTestCase {
 		generateScreenshot();
 		
 		// Check for the warnings
-		SWTBotView problemView = bot.viewByTitle("Problems");
+		SWTBotView problemView = openView(CorePerspective.ID_PROBLEM_VIEW);
 		problemView.show();
 		expand(problemView.bot().tree().getTreeItem("Warnings (2 items)"));
 		problemView.bot().tree().getTreeItem("Warnings (2 items)").getNode("There are duplicate names in namespace: 'SubSystem'.").select();

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/RoleManagementTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/RoleManagementTest.java
@@ -59,8 +59,6 @@ public class RoleManagementTest extends ASwtBotTestCase {
 		SWTBotTableItem newDisciplineTableItem = createNewDiscipline("SubSystem", "other_user");
 		save();
 		
-		generateScreenshot();
-		
 		// Check for the warnings
 		SWTBotView problemView = openView(CorePerspective.ID_PROBLEM_VIEW);
 		problemView.show();

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/RoleManagementTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/RoleManagementTest.java
@@ -58,6 +58,8 @@ public class RoleManagementTest extends ASwtBotTestCase {
 		SWTBotTableItem newDisciplineTableItem = createNewDiscipline("SubSystem", "other_user");
 		save();
 		
+		generateScreenshot();
+		
 		// Check for the warnings
 		SWTBotView problemView = bot.viewByTitle("Problems");
 		problemView.show();


### PR DESCRIPTION
- Re-added downloading and installing of Overtarget into Maven m2. Gost lost in a previous PR and only worked due to m2 caching.
- Changed to different version of DmfResourceTest (With a Class absed rule for timeout but without inheriting from AProjectTestCase which has a global timeout rule and causes jacoco issues on random)
- CHanged acquision of Problems view in RoleManagementTest to get it by ID rather than name since there are known issues from doing that in ValidatorTests.