### PR TITLE
Uploading all surefire reports upon CI failure - (Task #893)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,6 +192,17 @@ jobs:
           path: 
             swtbot/*
 
+      # --------------------------------------------
+      # Upload Surefire Reports to github artifacts
+      # --------------------------------------------            
+      - name: Upload Surefire Reports on Failure
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: Surefire Reports
+          path: 
+            ./**/target/surefire-reports/*
+
   # -----------------------------------------------------
   # Build and Test - Checkstyle Job
   # -----------------------------------------------------


### PR DESCRIPTION
- When a build failure occurs in the Build and Test Job, all reports generated by Surefire are uploaded

Closes #893

---
Task #893: Upload Surefire Reports in case of CI Failure