### PR TITLE
Added create endpoints

### DIFF
--- a/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/concepts/util/ActiveConceptHelperTest.java
+++ b/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/dvlm/concepts/util/ActiveConceptHelperTest.java
@@ -149,6 +149,12 @@ public class ActiveConceptHelperTest {
 	}
 
 	@Test
+	public void testGetCategoryByFqn() {
+		Category category = acHelper.getCategory(testCategoryOne.getFullQualifiedName());
+		assertEquals("Found the correct Category", testCategoryOne, category);
+	}
+
+	@Test
 	public void testGetCategoryByConceptAndCategoryFqn() {
 		Category category = ActiveConceptHelper.getCategory(testConcept, TEST_CONCEPT_ID + "." + TEST_CATEGORY_ID_ONE);
 		assertEquals("Found the correct Category", testCategoryOne, category);
@@ -317,7 +323,7 @@ public class ActiveConceptHelperTest {
 	
 	@Test
 	public void testGetConcept() {
-		AProperty propertyOne = PropertydefinitionsFactory.eINSTANCE.createBooleanProperty();				
+		AProperty propertyOne = PropertydefinitionsFactory.eINSTANCE.createBooleanProperty();
 		testCategoryOne.getProperties().add(propertyOne);
 		
 		Concept returnedConceptOfCategory = ActiveConceptHelper.getConcept(testCategoryOne);
@@ -340,6 +346,9 @@ public class ActiveConceptHelperTest {
 		
 		StructuralElement seNull = ActiveConceptHelper.getStructuralElement(testConcept, TEST_INVALID_ID);
 		assertNull("Found null object", seNull);
+		
+		StructuralElement seByFqn = acHelper.getStructuralElement(seOne.getFullQualifiedName());
+		assertEquals("return the correct concept of the category one", testSeOne, seByFqn);
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/concepts/util/ActiveConceptHelper.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/concepts/util/ActiveConceptHelper.java
@@ -250,6 +250,20 @@ public class ActiveConceptHelper {
 	}
 	
 	/**
+	 * Call this method to retrieve a Category from a Concept by its 
+	 * full qualified name consisting of the Concept and Category name
+	 * @param fullQualifiedName Concept name + "." + Category name
+	 * @return the Category in case it was found, otherwise null
+	 */
+	public Category getCategory(String fullQualifiedName) {
+		int idx = fullQualifiedName.lastIndexOf(".");
+		Concept concept = getConcept(fullQualifiedName.substring(0, idx));
+		String categoryFqn = fullQualifiedName.substring(idx + 1);
+		
+		return getCategory(concept, categoryFqn);
+	}
+	
+	/**
 	 * This method hands back the full qualified path of a type and the Concept as well
 	 * @param type the category or property to start searching from
 	 * @return the full qualified path being delimited with "."
@@ -401,6 +415,20 @@ public class ActiveConceptHelper {
 			}
 		}
 		return null;
+	}
+	
+	/**
+	 * Call this method to retrieve a Structural Element from a Concept by its 
+	 * full qualified name consisting of the Concept and Structural Element name
+	 * @param fullQualifiedName Concept name + "." + Structural Element name
+	 * @return the StructuralElement in case it was found, otherwise null
+	 */
+	public StructuralElement getStructuralElement(String fullQualifiedName) {
+		int idx = fullQualifiedName.lastIndexOf(".");
+		Concept concept = getConcept(fullQualifiedName.substring(0, idx));
+		String seName = fullQualifiedName.substring(idx + 1);
+		
+		return getStructuralElement(concept, seName);
 	}
 	
 	/**

--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/ModelAccessResourceTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/ModelAccessResourceTest.java
@@ -159,8 +159,8 @@ public class ModelAccessResourceTest extends AModelAccessResourceTest {
 				.queryParam(ModelAccessResource.QP_FULL_QUALIFIED_NAME, wantedTypeFqn)
 				.request()
 				.header(HttpHeaders.AUTHORIZATION, USER_WITH_REPO_HEADER)
-				.post(Entity.json("test"));
+				.post(Entity.json(null));
 		
-		assertSeiGotCreated(response, wantedTypeFqn, ed, ed.getResourceSet().getRepository().getRootEntities());
+		assertIUuidGotCreated(response, wantedTypeFqn, ed, ed.getResourceSet().getRepository().getRootEntities());
 	}
 }

--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/ModelAccessResourceTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/ModelAccessResourceTest.java
@@ -9,10 +9,12 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.server.resources;
 
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -28,8 +30,10 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Test;
 
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyString;
+import de.dlr.sc.virsat.model.dvlm.Repository;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
 import de.dlr.sc.virsat.model.dvlm.json.JAXBUtility;
+import de.dlr.sc.virsat.server.dataaccess.RepositoryUtility;
 import de.dlr.sc.virsat.server.test.VersionControlTestHelper;
 
 public class ModelAccessResourceTest extends AModelAccessResourceTest {
@@ -148,5 +152,28 @@ public class ModelAccessResourceTest extends AModelAccessResourceTest {
 		
 		assertEquals("No new commit on get without remote changes", commits, 
 				VersionControlTestHelper.countCommits(testServerRepository.getLocalRepositoryPath()));
+	}
+	
+	// TODO
+	@Test
+	public void testCreateRootSei() throws Exception {
+		Repository repository = ed.getResourceSet().getRepository();
+		String wantedTypeFqn = tSei.getFullQualifiedSturcturalElementName();
+		
+		Response response = webTarget
+				.path(ModelAccessResource.ROOT_SEIS)
+				.queryParam(ModelAccessResource.QP_FULL_QUALIFIED_NAME, wantedTypeFqn)
+				.request()
+				.header(HttpHeaders.AUTHORIZATION, USER_WITH_REPO_HEADER)
+				.post(Entity.json("test"));
+		
+		assertEquals(HttpStatus.OK_200, response.getStatus());
+		// TODO: add in abstract test cases
+		String uuid = response.readEntity(String.class);
+		
+		sei = RepositoryUtility.findSei(uuid, repository);
+		assertNotNull(sei);
+		assertEquals(wantedTypeFqn, sei.getType().getFullQualifiedName());
+		assertThat("Structural element instance is correctly added to repository", repository.getRootEntities(), hasItems(sei));
 	}
 }

--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/ModelAccessResourceTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/ModelAccessResourceTest.java
@@ -9,12 +9,10 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.server.resources;
 
-import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -30,10 +28,8 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Test;
 
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyString;
-import de.dlr.sc.virsat.model.dvlm.Repository;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
 import de.dlr.sc.virsat.model.dvlm.json.JAXBUtility;
-import de.dlr.sc.virsat.server.dataaccess.RepositoryUtility;
 import de.dlr.sc.virsat.server.test.VersionControlTestHelper;
 
 public class ModelAccessResourceTest extends AModelAccessResourceTest {
@@ -154,10 +150,8 @@ public class ModelAccessResourceTest extends AModelAccessResourceTest {
 				VersionControlTestHelper.countCommits(testServerRepository.getLocalRepositoryPath()));
 	}
 	
-	// TODO
 	@Test
 	public void testCreateRootSei() throws Exception {
-		Repository repository = ed.getResourceSet().getRepository();
 		String wantedTypeFqn = tSei.getFullQualifiedSturcturalElementName();
 		
 		Response response = webTarget
@@ -167,13 +161,6 @@ public class ModelAccessResourceTest extends AModelAccessResourceTest {
 				.header(HttpHeaders.AUTHORIZATION, USER_WITH_REPO_HEADER)
 				.post(Entity.json("test"));
 		
-		assertEquals(HttpStatus.OK_200, response.getStatus());
-		// TODO: add in abstract test cases
-		String uuid = response.readEntity(String.class);
-		
-		sei = RepositoryUtility.findSei(uuid, repository);
-		assertNotNull(sei);
-		assertEquals(wantedTypeFqn, sei.getType().getFullQualifiedName());
-		assertThat("Structural element instance is correctly added to repository", repository.getRootEntities(), hasItems(sei));
+		assertSeiGotCreated(response, wantedTypeFqn, ed, ed.getResourceSet().getRepository().getRootEntities());
 	}
 }

--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResourceTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResourceTest.java
@@ -122,13 +122,26 @@ public class CategoryAssignmentResourceTest extends AModelAccessResourceTest {
 	}
 	
 	@Test
-	public void testErrorResponses() {
-		assertBadRequestResponse(
-				getTestRequestBuilder(ModelAccessResource.CA + "/unknown").get(), 
-				CategoryAssignmentResource.COULD_NOT_FIND_REQUESTED_CA);
+	public void testCreateCa() throws Exception {
+		String wantedTypeFqn = tcBeanA.getFullQualifiedCategoryName();
 		
-		assertBadRequestResponse(
-				getTestRequestBuilder(ModelAccessResource.CA + "/unknown").delete(), 
-				CategoryAssignmentResource.COULD_NOT_FIND_REQUESTED_CA);
+		Response response = webTarget
+				.path(ModelAccessResource.CA)
+				.path(tSei.getUuid())
+				.queryParam(ModelAccessResource.QP_FULL_QUALIFIED_NAME, wantedTypeFqn)
+				.request()
+				.header(HttpHeaders.AUTHORIZATION, USER_WITH_REPO_HEADER)
+				.post(Entity.json(null));
+		
+		assertIUuidGotCreated(response, wantedTypeFqn, ed, tSei.getStructuralElementInstance().getCategoryAssignments());
+	}
+	
+	@Test
+	public void testErrorResponses() {
+		assertNotFoundResponse(getTestRequestBuilder(ModelAccessResource.CA + "/unknown").get());
+		
+		assertNotFoundResponse(getTestRequestBuilder(ModelAccessResource.CA + "/unknown").delete());
+		
+		assertNotFoundResponse(getTestRequestBuilder(ModelAccessResource.CA + "/unknown").post(Entity.json(null)));
 	}
 }

--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/modelaccess/PropertyResourceTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/modelaccess/PropertyResourceTest.java
@@ -126,8 +126,6 @@ public class PropertyResourceTest extends AModelAccessResourceTest {
 	
 	@Test
 	public void testErrorResponses() {
-		assertBadRequestResponse(
-				getTestRequestBuilder(ModelAccessResource.PROPERTY + "/unknown").get(), 
-				PropertyResource.COULD_NOT_FIND_REQUESTED_PROPERTY);
+		assertNotFoundResponse(getTestRequestBuilder(ModelAccessResource.PROPERTY + "/unknown").get());
 	}
 }

--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResourceTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResourceTest.java
@@ -9,20 +9,12 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.server.resources.modelaccess;
 
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 
-import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Test;
 
-import de.dlr.sc.virsat.model.dvlm.Repository;
-import de.dlr.sc.virsat.server.dataaccess.RepositoryUtility;
 import de.dlr.sc.virsat.server.resources.AModelAccessResourceTest;
 import de.dlr.sc.virsat.server.resources.ModelAccessResource;
 
@@ -64,16 +56,8 @@ public class StructuralElementInstanceResourceTest extends AModelAccessResourceT
 				.request()
 				.header(HttpHeaders.AUTHORIZATION, USER_WITH_REPO_HEADER)
 				.post(Entity.json(null));
-		// TODO: func for assert
-		Repository repository = ed.getResourceSet().getRepository();
 		
-		assertEquals(HttpStatus.OK_200, response.getStatus());
-		String uuid = response.readEntity(String.class);
-		
-		sei = RepositoryUtility.findSei(uuid, repository);
-		assertNotNull(sei);
-		assertEquals(wantedTypeFqn, sei.getType().getFullQualifiedName());
-		assertThat("Structural element instance is correctly added to parent sei", tSei.getStructuralElementInstance().getChildren(), hasItems(sei));
+		assertSeiGotCreated(response, wantedTypeFqn, ed, tSei.getStructuralElementInstance().getChildren());
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResourceTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResourceTest.java
@@ -57,17 +57,15 @@ public class StructuralElementInstanceResourceTest extends AModelAccessResourceT
 				.header(HttpHeaders.AUTHORIZATION, USER_WITH_REPO_HEADER)
 				.post(Entity.json(null));
 		
-		assertSeiGotCreated(response, wantedTypeFqn, ed, tSei.getStructuralElementInstance().getChildren());
+		assertIUuidGotCreated(response, wantedTypeFqn, ed, tSei.getStructuralElementInstance().getChildren());
 	}
 	
 	@Test
 	public void testErrorResponses() {
-		assertBadRequestResponse(
-				getTestRequestBuilder(ModelAccessResource.SEI + "/unknown").get(), 
-				StructuralElementInstanceResource.COULD_NOT_FIND_REQUESTED_SEI);
+		assertNotFoundResponse(getTestRequestBuilder(ModelAccessResource.SEI + "/unknown").get());
 		
-		assertBadRequestResponse(
-				getTestRequestBuilder(ModelAccessResource.SEI + "/unknown").delete(), 
-				StructuralElementInstanceResource.COULD_NOT_FIND_REQUESTED_SEI);
+		assertNotFoundResponse(getTestRequestBuilder(ModelAccessResource.SEI + "/unknown").delete());
+		
+		assertNotFoundResponse(getTestRequestBuilder(ModelAccessResource.CA + "/unknown").post(Entity.json(null)));
 	}
 }

--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResourceTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResourceTest.java
@@ -9,12 +9,24 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.server.resources.modelaccess;
 
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.jetty.http.HttpStatus;
 import org.junit.Test;
 
+import de.dlr.sc.virsat.model.dvlm.Repository;
+import de.dlr.sc.virsat.server.dataaccess.RepositoryUtility;
+import de.dlr.sc.virsat.server.resources.AModelAccessResourceTest;
 import de.dlr.sc.virsat.server.resources.ModelAccessResource;
-import de.dlr.sc.virsat.server.resources.ModelAccessResourceTest;
 
-public class StructuralElementInstanceResourceTest extends ModelAccessResourceTest {
+public class StructuralElementInstanceResourceTest extends AModelAccessResourceTest {
 
 	@Test
 	public void testSeiGet() throws Exception {
@@ -39,6 +51,29 @@ public class StructuralElementInstanceResourceTest extends ModelAccessResourceTe
 	@Test
 	public void testChildSeiPut() throws Exception {
 		testPutSei(tSeiChild);
+	}
+	
+	@Test
+	public void testCreateSei() throws Exception {
+		String wantedTypeFqn = tSei.getFullQualifiedSturcturalElementName();
+		
+		Response response = webTarget
+				.path(ModelAccessResource.SEI)
+				.path(tSei.getUuid())
+				.queryParam(ModelAccessResource.QP_FULL_QUALIFIED_NAME, wantedTypeFqn)
+				.request()
+				.header(HttpHeaders.AUTHORIZATION, USER_WITH_REPO_HEADER)
+				.post(Entity.json(null));
+		// TODO: func for assert
+		Repository repository = ed.getResourceSet().getRepository();
+		
+		assertEquals(HttpStatus.OK_200, response.getStatus());
+		String uuid = response.readEntity(String.class);
+		
+		sei = RepositoryUtility.findSei(uuid, repository);
+		assertNotNull(sei);
+		assertEquals(wantedTypeFqn, sei.getType().getFullQualifiedName());
+		assertThat("Structural element instance is correctly added to parent sei", tSei.getStructuralElementInstance().getChildren(), hasItems(sei));
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ApiErrorHelper.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ApiErrorHelper.java
@@ -15,11 +15,16 @@ public class ApiErrorHelper {
 
 	public static final String SUCCESSFUL_OPERATION = "Successful operation";
 	public static final String SYNC_ERROR = "Synchronization error";
+	public static final String COULD_NOT_FIND_REQUESTED_ELEMENT = "Could not find requested element";
 	
 	private ApiErrorHelper() { };
 	
 	public static Response createBadRequestResponse(String msg) {
 		return Response.status(Response.Status.BAD_REQUEST).entity(msg).build();
+	}
+
+	public static Response createNotFoundErrorResponse() {
+		return createBadRequestResponse(COULD_NOT_FIND_REQUESTED_ELEMENT);
 	}
 
 	public static Response createSyncErrorResponse(String msg) {

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ModelAccessResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ModelAccessResource.java
@@ -224,7 +224,7 @@ public class ModelAccessResource {
 				@ApiResponse(
 						code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 						message = ApiErrorHelper.SYNC_ERROR)})
-		public Response createSei(@QueryParam(value = ModelAccessResource.QP_FULL_QUALIFIED_NAME) 
+		public Response createRootSei(@QueryParam(value = ModelAccessResource.QP_FULL_QUALIFIED_NAME) 
 			@ApiParam(value = "Full qualified name of the SEI type", required = true) String fullQualifiedName) {
 			try {
 				serverRepository.syncRepository();

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ModelAccessResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ModelAccessResource.java
@@ -44,7 +44,7 @@ import de.dlr.sc.virsat.model.dvlm.concepts.registry.ActiveConceptConfigurationE
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
 import de.dlr.sc.virsat.model.dvlm.structural.StructuralElement;
 import de.dlr.sc.virsat.model.dvlm.structural.StructuralElementInstance;
-import de.dlr.sc.virsat.model.dvlm.structural.StructuralFactory;
+import de.dlr.sc.virsat.model.dvlm.structural.util.StructuralInstantiator;
 import de.dlr.sc.virsat.project.editingDomain.VirSatTransactionalEditingDomain;
 import de.dlr.sc.virsat.project.structure.command.CreateAddSeiWithFileStructureCommand;
 import de.dlr.sc.virsat.server.auth.ServerRoles;
@@ -304,14 +304,8 @@ public class ModelAccessResource {
 	 */
 	public static String createSeiFromFqn(String fullQualifiedName, EObject owner, VirSatTransactionalEditingDomain editingDomain) {
 		ActiveConceptHelper helper = new ActiveConceptHelper(editingDomain.getResourceSet().getRepository());
-		
-		StructuralElementInstance newSei = StructuralFactory.eINSTANCE.createStructuralElementInstance();
-		
-		// Add the correct type using the fqn
-		int idx = fullQualifiedName.lastIndexOf(".");
-		Concept concept = helper.getConcept(fullQualifiedName.substring(0, idx));
-		StructuralElement se = ActiveConceptHelper.getStructuralElement(concept, fullQualifiedName.substring(idx + 1));
-		newSei.setType(se);
+		StructuralElement se = helper.getStructuralElement(fullQualifiedName);
+		StructuralElementInstance newSei = new StructuralInstantiator().generateInstance(se, null);
 		
 		Command createCommand = CreateAddSeiWithFileStructureCommand.create(editingDomain, owner, newSei);
 		editingDomain.getCommandStack().execute(createCommand);

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ModelAccessResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ModelAccessResource.java
@@ -145,7 +145,7 @@ public class ModelAccessResource {
 	 *   - Get and update ca with properties by uuid
 	 *   - Get and update properties by uuid
 	 */
-	@Api(hidden = true)
+	@Api(hidden = true, authorizations = {@Authorization(value = "basic")})
 	@RolesAllowed({ServerRoles.ADMIN, ServerRoles.USER})
 	public static class RepoModelAccessResource {
 		

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResource.java
@@ -214,5 +214,4 @@ public class CategoryAssignmentResource {
 			return ApiErrorHelper.createSyncErrorResponse(e.getMessage());
 		}
 	}
-	
 }

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResource.java
@@ -43,8 +43,9 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
 
-@Api(hidden = true)
+@Api(hidden = true, authorizations = {@Authorization(value = "basic")})
 public class CategoryAssignmentResource {
 	
 	private RepoModelAccessResource parentResource;

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResource.java
@@ -29,11 +29,10 @@ import de.dlr.sc.virsat.model.concept.types.category.ABeanCategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanCategoryAssignmentFactory;
 import de.dlr.sc.virsat.model.dvlm.Repository;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoriesFactory;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoriesPackage;
 import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
-import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
 import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
 import de.dlr.sc.virsat.model.dvlm.structural.StructuralElementInstance;
 import de.dlr.sc.virsat.project.editingDomain.VirSatTransactionalEditingDomain;
@@ -155,14 +154,8 @@ public class CategoryAssignmentResource {
 			}
 			
 			ActiveConceptHelper helper = new ActiveConceptHelper(ed.getResourceSet().getRepository());
-			
-			CategoryAssignment newCa = CategoriesFactory.eINSTANCE.createCategoryAssignment();
-			
-			// Add the correct type using the fqn
-			int idx = fullQualifiedName.lastIndexOf(".");
-			Concept concept = helper.getConcept(fullQualifiedName.substring(0, idx));
-			Category category = ActiveConceptHelper.getCategory(concept, fullQualifiedName.substring(idx + 1));
-			newCa.setType(category);
+			Category category = helper.getCategory(fullQualifiedName);
+			CategoryAssignment newCa = new CategoryInstantiator().generateInstance(category, null);
 			
 			Command createCommand = AddCommand.create(ed, parentSei, CategoriesPackage.Literals.ICATEGORY_ASSIGNMENT_CONTAINER__CATEGORY_ASSIGNMENTS, newCa);
 			ed.getCommandStack().execute(createCommand);

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResource.java
@@ -142,7 +142,7 @@ public class CategoryAssignmentResource {
 			@ApiResponse(
 					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 					message = ApiErrorHelper.SYNC_ERROR)})
-	public Response createSei(@PathParam("parentUuid") @ApiParam(value = "parent uuid", required = true) String parentUuid,
+	public Response createCa(@PathParam("parentUuid") @ApiParam(value = "parent uuid", required = true) String parentUuid,
 			@QueryParam(value = ModelAccessResource.QP_FULL_QUALIFIED_NAME)
 			@ApiParam(value = "Full qualified name of the CA type", required = true) String fullQualifiedName) {
 		try {

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResource.java
@@ -12,25 +12,35 @@ package de.dlr.sc.virsat.server.resources.modelaccess;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.command.AddCommand;
 import org.eclipse.jetty.http.HttpStatus;
 
 import de.dlr.sc.virsat.model.concept.types.category.ABeanCategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanCategoryAssignmentFactory;
 import de.dlr.sc.virsat.model.dvlm.Repository;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoriesFactory;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoriesPackage;
+import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
+import de.dlr.sc.virsat.model.dvlm.structural.StructuralElementInstance;
 import de.dlr.sc.virsat.project.editingDomain.VirSatTransactionalEditingDomain;
 import de.dlr.sc.virsat.server.dataaccess.RepositoryUtility;
 import de.dlr.sc.virsat.server.repository.ServerRepository;
 import de.dlr.sc.virsat.server.resources.ApiErrorHelper;
+import de.dlr.sc.virsat.server.resources.ModelAccessResource;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -39,8 +49,6 @@ import io.swagger.annotations.ApiResponses;
 
 @Api(hidden = true)
 public class CategoryAssignmentResource {
-	
-	public static final String COULD_NOT_FIND_REQUESTED_CA = "Could not find requested CA";
 
 	private Repository repository;
 	private ServerRepository serverRepository;
@@ -68,7 +76,7 @@ public class CategoryAssignmentResource {
 					message = ApiErrorHelper.SUCCESSFUL_OPERATION),
 			@ApiResponse(
 					code = HttpStatus.BAD_REQUEST_400, 
-					message = COULD_NOT_FIND_REQUESTED_CA),
+					message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
 			@ApiResponse(
 					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 					message = ApiErrorHelper.SYNC_ERROR)})
@@ -79,7 +87,7 @@ public class CategoryAssignmentResource {
 			CategoryAssignment ca = RepositoryUtility.findCa(caUuid, repository);
 			
 			if (ca == null) {
-				return ApiErrorHelper.createBadRequestResponse(COULD_NOT_FIND_REQUESTED_CA);
+				return ApiErrorHelper.createNotFoundErrorResponse();
 			}
 			
 			IBeanCategoryAssignment beanCa = new BeanCategoryAssignmentFactory().getInstanceFor(ca);
@@ -115,6 +123,58 @@ public class CategoryAssignmentResource {
 	}
 	
 	/** **/
+	@POST
+	@Path("/{parentUuid}")
+	@Consumes(MediaType.APPLICATION_JSON)
+	@ApiOperation(
+			consumes = "application/json",
+			value = "Create CA",
+			httpMethod = "POST",
+			notes = "This service creates a new CategoryAssignment and returns it")
+	@ApiResponses(value = { 
+			@ApiResponse(
+					code = HttpStatus.OK_200,
+					response = String.class,
+					message = ApiErrorHelper.SUCCESSFUL_OPERATION),
+			@ApiResponse(
+					code = HttpStatus.BAD_REQUEST_400, 
+					message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
+			@ApiResponse(
+					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
+					message = ApiErrorHelper.SYNC_ERROR)})
+	public Response createSei(@PathParam("parentUuid") @ApiParam(value = "parent uuid", required = true) String parentUuid,
+			@QueryParam(value = ModelAccessResource.QP_FULL_QUALIFIED_NAME)
+			@ApiParam(value = "Full qualified name of the CA type", required = true) String fullQualifiedName) {
+		try {
+			serverRepository.syncRepository();
+			
+			StructuralElementInstance parentSei = RepositoryUtility.findSei(parentUuid, repository);
+			
+			if (parentSei == null) {
+				return ApiErrorHelper.createNotFoundErrorResponse();
+			}
+			
+			ActiveConceptHelper helper = new ActiveConceptHelper(ed.getResourceSet().getRepository());
+			
+			CategoryAssignment newCa = CategoriesFactory.eINSTANCE.createCategoryAssignment();
+			
+			// Add the correct type using the fqn
+			int idx = fullQualifiedName.lastIndexOf(".");
+			Concept concept = helper.getConcept(fullQualifiedName.substring(0, idx));
+			Category category = ActiveConceptHelper.getCategory(concept, fullQualifiedName.substring(idx + 1));
+			newCa.setType(category);
+			
+			Command createCommand = AddCommand.create(ed, parentSei, CategoriesPackage.Literals.ICATEGORY_ASSIGNMENT_CONTAINER__CATEGORY_ASSIGNMENTS, newCa);
+			ed.getCommandStack().execute(createCommand);
+			
+			serverRepository.syncRepository();
+			return Response.ok(newCa.getUuid().toString()).build();
+		} catch (Exception e) {
+			return ApiErrorHelper.createSyncErrorResponse(e.getMessage());
+		}
+	}
+	
+	/** **/
 	@DELETE
 	@Path("/{caUuid}")
 	@Produces(MediaType.APPLICATION_JSON)
@@ -129,7 +189,7 @@ public class CategoryAssignmentResource {
 					message = ApiErrorHelper.SUCCESSFUL_OPERATION),
 			@ApiResponse(
 					code = HttpStatus.BAD_REQUEST_400,
-					message = COULD_NOT_FIND_REQUESTED_CA),
+					message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
 			@ApiResponse(
 					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 					message = ApiErrorHelper.SYNC_ERROR)})
@@ -141,7 +201,7 @@ public class CategoryAssignmentResource {
 			// Delete CA
 			CategoryAssignment ca = RepositoryUtility.findCa(caUuid, repository);
 			if (ca == null) {
-				return ApiErrorHelper.createBadRequestResponse(COULD_NOT_FIND_REQUESTED_CA);
+				return ApiErrorHelper.createNotFoundErrorResponse();
 			}
 			
 			Command deleteCommand = new BeanCategoryAssignmentFactory().getInstanceFor(ca).delete(ed);

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/PropertyResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/PropertyResource.java
@@ -37,8 +37,6 @@ import io.swagger.annotations.ApiResponses;
 @Api(hidden = true)
 public class PropertyResource {
 	
-	public static final String COULD_NOT_FIND_REQUESTED_PROPERTY = "Could not find requested property";
-	
 	private Repository repository;
 	private ServerRepository serverRepository;
 	
@@ -63,7 +61,7 @@ public class PropertyResource {
 					message = ApiErrorHelper.SUCCESSFUL_OPERATION),
 			@ApiResponse(
 					code = HttpStatus.BAD_REQUEST_400, 
-					message = COULD_NOT_FIND_REQUESTED_PROPERTY),
+					message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
 			@ApiResponse(
 					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 					message = ApiErrorHelper.SYNC_ERROR)})
@@ -74,7 +72,7 @@ public class PropertyResource {
 			APropertyInstance property = RepositoryUtility.findProperty(propertyUuid, repository);
 			
 			if (property == null) {
-				return ApiErrorHelper.createBadRequestResponse(COULD_NOT_FIND_REQUESTED_PROPERTY);
+				return ApiErrorHelper.createNotFoundErrorResponse();
 			}
 			
 			IBeanObject<? extends APropertyInstance> beanProperty = new BeanPropertyFactory().getInstanceFor(property);

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/PropertyResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/PropertyResource.java
@@ -32,8 +32,9 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
 
-@Api(hidden = true)
+@Api(hidden = true, authorizations = {@Authorization(value = "basic")})
 public class PropertyResource {
 	
 	private RepoModelAccessResource parentResource;

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResource.java
@@ -39,8 +39,9 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
 
-@Api(hidden = true)
+@Api(hidden = true, authorizations = {@Authorization(value = "basic")})
 public class StructuralElementInstanceResource {
 	
 	private RepoModelAccessResource parentResource;

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResource.java
@@ -45,8 +45,6 @@ import io.swagger.annotations.ApiResponses;
 @Api(hidden = true)
 public class StructuralElementInstanceResource {
 	
-	public static final String COULD_NOT_FIND_REQUESTED_SEI = "Could not find requested SEI";
-	
 	private Repository repository;
 	private ServerRepository serverRepository;
 	private VirSatTransactionalEditingDomain ed;
@@ -73,7 +71,7 @@ public class StructuralElementInstanceResource {
 					message = ApiErrorHelper.SUCCESSFUL_OPERATION),
 			@ApiResponse(
 					code = HttpStatus.BAD_REQUEST_400, 
-					message = COULD_NOT_FIND_REQUESTED_SEI),
+					message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
 			@ApiResponse(
 					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 					message = ApiErrorHelper.SYNC_ERROR)})
@@ -83,7 +81,7 @@ public class StructuralElementInstanceResource {
 			StructuralElementInstance sei = RepositoryUtility.findSei(seiUuid, repository);
 			
 			if (sei == null) {
-				return ApiErrorHelper.createBadRequestResponse(COULD_NOT_FIND_REQUESTED_SEI);
+				return ApiErrorHelper.createNotFoundErrorResponse();
 			}
 			
 			IBeanStructuralElementInstance beanSei = new BeanStructuralElementInstanceFactory().getInstanceFor(sei);
@@ -133,6 +131,9 @@ public class StructuralElementInstanceResource {
 					response = String.class,
 					message = ApiErrorHelper.SUCCESSFUL_OPERATION),
 			@ApiResponse(
+					code = HttpStatus.BAD_REQUEST_400, 
+					message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
+			@ApiResponse(
 					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 					message = ApiErrorHelper.SYNC_ERROR)})
 	public Response createSei(@PathParam("parentUuid") @ApiParam(value = "parent uuid", required = true) String parentUuid,
@@ -144,7 +145,7 @@ public class StructuralElementInstanceResource {
 			StructuralElementInstance parentSei = RepositoryUtility.findSei(parentUuid, repository);
 			
 			if (parentSei == null) {
-				return ApiErrorHelper.createBadRequestResponse(COULD_NOT_FIND_REQUESTED_SEI);
+				return ApiErrorHelper.createNotFoundErrorResponse();
 			}
 			String newSeiUuid = ModelAccessResource.createSeiFromFqn(fullQualifiedName, parentSei, ed);
 			
@@ -171,7 +172,7 @@ public class StructuralElementInstanceResource {
 					message = ApiErrorHelper.SUCCESSFUL_OPERATION),
 			@ApiResponse(
 					code = HttpStatus.BAD_REQUEST_400,
-					message = COULD_NOT_FIND_REQUESTED_SEI),
+					message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
 			@ApiResponse(
 					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 					message = ApiErrorHelper.SYNC_ERROR)})
@@ -183,7 +184,7 @@ public class StructuralElementInstanceResource {
 			// Delete Sei
 			StructuralElementInstance sei = RepositoryUtility.findSei(seiUuid, repository);
 			if (sei == null) {
-				return ApiErrorHelper.createBadRequestResponse(COULD_NOT_FIND_REQUESTED_SEI);
+				return ApiErrorHelper.createNotFoundErrorResponse();
 			}
 			
 			Command deleteCommand = CreateRemoveSeiWithFileStructureCommand.create(sei, RemoveFileStructureCommand.DELETE_RESOURCE_OPERATION_FUNCTION);


### PR DESCRIPTION
Added three create endpoints and test cases for:
- RootSei in ModelAccessResource
- Sei in StructuralElementInstanceResource
- Ca in CategoryAssignmentResource

Also added some minor improvement in the server errors.

@SaMuellerDLR the only think we don't handle at the moment are composed beans. For example what if one wants to create a ca inside a composed bean?

Closes #964