### PR TITLE
PR1: Added qudv beans

### DIFF
--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyEnumTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyEnumTest.java
@@ -20,6 +20,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import de.dlr.sc.virsat.model.concept.types.factory.BeanUnitFactory;
+import de.dlr.sc.virsat.model.concept.types.qudv.IBeanUnit;
 import de.dlr.sc.virsat.model.dvlm.DVLMFactory;
 import de.dlr.sc.virsat.model.dvlm.Repository;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoriesFactory;
@@ -205,5 +207,56 @@ public class BeanPropertyEnumTest  extends ABeanPropertyTest {
 		beanProperty.setUnit("Gargl");
 		assertEquals("Unit gargl still needs to be invented, thus gramm should be the truth", "Gram", eupi.getUnit().getName());
 		assertEquals("Unit gargl still needs to be invented, thus gramm should be the truth", "Gram", beanProperty.getUnit());
+	}
+	
+	@Test
+	public void testSetUnitBeanEditingDomain() {
+		setUpRepo();
+		
+		AUnit kmUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Kilometer");
+		IBeanUnit<? extends AUnit> kmBean = new BeanUnitFactory().getInstanceFor(kmUnit);
+		beanProperty.setUnitBean(ed, kmBean).execute();
+		assertEquals("Unit has been set correctly", kmUnit, eupi.getUnit());
+		
+		AUnit gUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Gram");
+		IBeanUnit<? extends AUnit> gBean = new BeanUnitFactory().getInstanceFor(gUnit);
+		beanProperty.setUnitBean(ed, gBean).execute();
+		assertEquals("Unit has been changed correctly", gUnit, eupi.getUnit());
+
+		Command cmd = beanProperty.setUnitBean(ed, null);
+		assertFalse("The unit can not been changed", cmd.canExecute());
+	}
+
+	@Test
+	public void testSetUnitBean() {
+		setUpRepo();
+		
+		AUnit kmUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Kilometer");
+		IBeanUnit<? extends AUnit> kmBean = new BeanUnitFactory().getInstanceFor(kmUnit);
+		beanProperty.setUnitBean(kmBean);
+		assertEquals("Unit has been set correctly", kmUnit, eupi.getUnit());
+		
+		AUnit gUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Gram");
+		IBeanUnit<? extends AUnit> gBean = new BeanUnitFactory().getInstanceFor(gUnit);
+		beanProperty.setUnitBean(gBean);
+		assertEquals("Unit has been changed correctly", gUnit, eupi.getUnit());
+
+		beanProperty.setUnitBean(null);
+		assertEquals("The unit has not been changed", gUnit, eupi.getUnit());
+	}
+	
+	@Test
+	public void testGetUnitBean() {
+		setUpRepo();
+		
+		AUnit kmUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Kilometer");
+		IBeanUnit<? extends AUnit> kmBean = new BeanUnitFactory().getInstanceFor(kmUnit);
+		beanProperty.setUnitBean(kmBean);
+		assertEquals("Got correct unit", kmBean.getUnit(), beanProperty.getUnitBean().getUnit());
+		
+		AUnit gUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Gram");
+		IBeanUnit<? extends AUnit> gBean = new BeanUnitFactory().getInstanceFor(gUnit);
+		beanProperty.setUnitBean(gBean);
+		assertEquals("Got correct unit", gBean.getUnit(), beanProperty.getUnitBean().getUnit());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyFloatTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyFloatTest.java
@@ -18,6 +18,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import de.dlr.sc.virsat.model.concept.types.factory.BeanUnitFactory;
+import de.dlr.sc.virsat.model.concept.types.qudv.IBeanUnit;
 import de.dlr.sc.virsat.model.dvlm.DVLMFactory;
 import de.dlr.sc.virsat.model.dvlm.Repository;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoriesFactory;
@@ -283,5 +285,56 @@ public class BeanPropertyFloatTest extends ABeanPropertyTest {
 		final double EPSILON = 0.001;
 		assertEquals("Unit has been set correctly", other.getUnit(), beanProperty.getUnit());
 		assertEquals("Value has been set correctly", other.getValue(), beanProperty.getValue(), EPSILON);
+	}
+	
+	@Test
+	public void testSetUnitBeanEditingDomain() {
+		setUpRepo();
+		
+		AUnit kmUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Kilometer");
+		IBeanUnit<? extends AUnit> kmBean = new BeanUnitFactory().getInstanceFor(kmUnit);
+		beanProperty.setUnitBean(ed, kmBean).execute();
+		assertEquals("Unit has been set correctly", kmUnit, uvpi.getUnit());
+		
+		AUnit gUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Gram");
+		IBeanUnit<? extends AUnit> gBean = new BeanUnitFactory().getInstanceFor(gUnit);
+		beanProperty.setUnitBean(ed, gBean).execute();
+		assertEquals("Unit has been changed correctly", gUnit, uvpi.getUnit());
+
+		Command cmd = beanProperty.setUnitBean(ed, null);
+		assertFalse("The unit can not been changed", cmd.canExecute());
+	}
+
+	@Test
+	public void testSetUnitBean() {
+		setUpRepo();
+		
+		AUnit kmUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Kilometer");
+		IBeanUnit<? extends AUnit> kmBean = new BeanUnitFactory().getInstanceFor(kmUnit);
+		beanProperty.setUnitBean(kmBean);
+		assertEquals("Unit has been set correctly", kmUnit, uvpi.getUnit());
+		
+		AUnit gUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Gram");
+		IBeanUnit<? extends AUnit> gBean = new BeanUnitFactory().getInstanceFor(gUnit);
+		beanProperty.setUnitBean(gBean);
+		assertEquals("Unit has been changed correctly", gUnit, uvpi.getUnit());
+
+		beanProperty.setUnitBean(null);
+		assertEquals("The unit has not been changed", gUnit, uvpi.getUnit());
+	}
+	
+	@Test
+	public void testGetUnitBean() {
+		setUpRepo();
+		
+		AUnit kmUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Kilometer");
+		IBeanUnit<? extends AUnit> kmBean = new BeanUnitFactory().getInstanceFor(kmUnit);
+		beanProperty.setUnitBean(kmBean);
+		assertEquals("Got correct unit", kmBean.getUnit(), beanProperty.getUnitBean().getUnit());
+		
+		AUnit gUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Gram");
+		IBeanUnit<? extends AUnit> gBean = new BeanUnitFactory().getInstanceFor(gUnit);
+		beanProperty.setUnitBean(gBean);
+		assertEquals("Got correct unit", gBean.getUnit(), beanProperty.getUnitBean().getUnit());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyIntTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyIntTest.java
@@ -20,6 +20,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import de.dlr.sc.virsat.model.concept.types.factory.BeanUnitFactory;
+import de.dlr.sc.virsat.model.concept.types.qudv.IBeanUnit;
 import de.dlr.sc.virsat.model.dvlm.DVLMFactory;
 import de.dlr.sc.virsat.model.dvlm.Repository;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoriesFactory;
@@ -30,6 +32,7 @@ import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.Propertyinstance
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.UnitValuePropertyInstance;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
 import de.dlr.sc.virsat.model.dvlm.concepts.ConceptsFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
 import de.dlr.sc.virsat.model.dvlm.qudv.SystemOfUnits;
 import de.dlr.sc.virsat.model.dvlm.qudv.util.QudvUnitHelper;
 import de.dlr.sc.virsat.model.dvlm.roles.UserRegistry;
@@ -231,5 +234,56 @@ public class BeanPropertyIntTest extends ABeanPropertyTest {
 		final double EPSILON = 0.001;
 		assertEquals("Unit has been set correctly", other.getUnit(), beanProperty.getUnit());
 		assertEquals("Value has been set correctly", other.getValue(), beanProperty.getValue(), EPSILON);
+	}
+	
+	@Test
+	public void testSetUnitBeanEditingDomain() {
+		setUpRepo();
+		
+		AUnit kmUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Kilometer");
+		IBeanUnit<? extends AUnit> kmBean = new BeanUnitFactory().getInstanceFor(kmUnit);
+		beanProperty.setUnitBean(ed, kmBean).execute();
+		assertEquals("Unit has been set correctly", kmUnit, uvpi.getUnit());
+		
+		AUnit gUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Gram");
+		IBeanUnit<? extends AUnit> gBean = new BeanUnitFactory().getInstanceFor(gUnit);
+		beanProperty.setUnitBean(ed, gBean).execute();
+		assertEquals("Unit has been changed correctly", gUnit, uvpi.getUnit());
+
+		Command cmd = beanProperty.setUnitBean(ed, null);
+		assertFalse("The unit can not been changed", cmd.canExecute());
+	}
+
+	@Test
+	public void testSetUnitBean() {
+		setUpRepo();
+		
+		AUnit kmUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Kilometer");
+		IBeanUnit<? extends AUnit> kmBean = new BeanUnitFactory().getInstanceFor(kmUnit);
+		beanProperty.setUnitBean(kmBean);
+		assertEquals("Unit has been set correctly", kmUnit, uvpi.getUnit());
+		
+		AUnit gUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Gram");
+		IBeanUnit<? extends AUnit> gBean = new BeanUnitFactory().getInstanceFor(gUnit);
+		beanProperty.setUnitBean(gBean);
+		assertEquals("Unit has been changed correctly", gUnit, uvpi.getUnit());
+
+		beanProperty.setUnitBean(null);
+		assertEquals("The unit has not been changed", gUnit, uvpi.getUnit());
+	}
+	
+	@Test
+	public void testGetUnitBean() {
+		setUpRepo();
+		
+		AUnit kmUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Kilometer");
+		IBeanUnit<? extends AUnit> kmBean = new BeanUnitFactory().getInstanceFor(kmUnit);
+		beanProperty.setUnitBean(kmBean);
+		assertEquals("Got correct unit", kmBean.getUnit(), beanProperty.getUnitBean().getUnit());
+		
+		AUnit gUnit = QudvUnitHelper.getInstance().getUnitByName(sou, "Gram");
+		IBeanUnit<? extends AUnit> gBean = new BeanUnitFactory().getInstanceFor(gUnit);
+		beanProperty.setUnitBean(gBean);
+		assertEquals("Got correct unit", gBean.getUnit(), beanProperty.getUnitBean().getUnit());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanQuantityKindTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanQuantityKindTest.java
@@ -28,19 +28,19 @@ import de.dlr.sc.virsat.model.dvlm.categories.provider.DVLMCategoriesItemProvide
 import de.dlr.sc.virsat.model.dvlm.concepts.provider.ConceptsItemProviderAdapterFactory;
 import de.dlr.sc.virsat.model.dvlm.general.provider.GeneralItemProviderAdapterFactory;
 import de.dlr.sc.virsat.model.dvlm.provider.DVLMDVLMItemProviderAdapterFactory;
-import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.AQuantityKind;
 import de.dlr.sc.virsat.model.dvlm.qudv.provider.QudvItemProviderAdapterFactory;
 import de.dlr.sc.virsat.model.dvlm.roles.provider.RolesItemProviderAdapterFactory;
 import de.dlr.sc.virsat.model.dvlm.structural.provider.DVLMStructuralItemProviderAdapterFactory;
 import de.dlr.sc.virsat.model.dvlm.units.provider.UnitsItemProviderAdapterFactory;
 
-public abstract class ABeanUnitTest {
-
+public abstract class ABeanQuantityKindTest {
+	
 	protected ComposedAdapterFactory adapterFactory;
 	protected EditingDomain ed;
 	
-	protected ABeanUnit<?> aBeanUnit;
-	protected AUnit aUnit;
+	protected ABeanQuantityKind<?> aBeanQuantityKind;
+	protected AQuantityKind aQuantityKind;
 	
 	protected static final String TEST_NAME = "name";
 	protected static final String TEST_SYMBOL = "symbol";
@@ -67,50 +67,50 @@ public abstract class ABeanUnitTest {
 	
 	@Test
 	public void testGetUuid() {
-		String beanUuid = aBeanUnit.getUuid();
-		String unitUuid = aUnit.getUuid().toString();
+		String beanUuid = aBeanQuantityKind.getUuid();
+		String unitUuid = aQuantityKind.getUuid().toString();
 		assertEquals("Got correct UUID of bean", unitUuid, beanUuid);
 	}
 	
 	@Test
 	public void testGetName() {
-		aUnit.setName(TEST_NAME);
-		assertEquals("Got correct name", TEST_NAME, aBeanUnit.getName());
+		aQuantityKind.setName(TEST_NAME);
+		assertEquals("Got correct name", TEST_NAME, aBeanQuantityKind.getName());
 	}
 
 	@Test
 	public void testSetName() {
-		aBeanUnit.setName(TEST_NAME);
-		assertEquals("Got correct name", TEST_NAME, aUnit.getName());
+		aBeanQuantityKind.setName(TEST_NAME);
+		assertEquals("Got correct name", TEST_NAME, aQuantityKind.getName());
 	}
 
 	@Test
 	public void testSetNameEditingDomain() {
-		Command setCommand = aBeanUnit.setName(ed, TEST_NAME);
-		assertNull("Command was not yet executed", aUnit.getName());
+		Command setCommand = aBeanQuantityKind.setName(ed, TEST_NAME);
+		assertNull("Command was not yet executed", aQuantityKind.getName());
 		
 		setCommand.execute();
-		assertEquals("Name is correctly set", TEST_NAME, aUnit.getName());
+		assertEquals("Name is correctly set", TEST_NAME, aQuantityKind.getName());
 	}
 	
 	@Test
 	public void testGetSymbol() {
-		aUnit.setSymbol(TEST_SYMBOL);
-		assertEquals("Got correct name", TEST_SYMBOL, aBeanUnit.getSymbol());
+		aQuantityKind.setSymbol(TEST_SYMBOL);
+		assertEquals("Got correct name", TEST_SYMBOL, aBeanQuantityKind.getSymbol());
 	}
 
 	@Test
 	public void testSetSymbol() {
-		aBeanUnit.setSymbol(TEST_SYMBOL);
-		assertEquals("Got correct name", TEST_SYMBOL, aUnit.getSymbol());
+		aBeanQuantityKind.setSymbol(TEST_SYMBOL);
+		assertEquals("Got correct name", TEST_SYMBOL, aQuantityKind.getSymbol());
 	}
 	
 	@Test
 	public void testSetSymbolEditingDomain() {
-		Command setCommand = aBeanUnit.setSymbol(ed, TEST_SYMBOL);
-		assertNull("Command was not yet executed", aUnit.getSymbol());
+		Command setCommand = aBeanQuantityKind.setSymbol(ed, TEST_SYMBOL);
+		assertNull("Command was not yet executed", aQuantityKind.getSymbol());
 		
 		setCommand.execute();
-		assertEquals("Got correct symbol", TEST_SYMBOL, aUnit.getSymbol());
+		assertEquals("Got correct symbol", TEST_SYMBOL, aQuantityKind.getSymbol());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanUnitTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanUnitTest.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.eclipse.emf.common.command.BasicCommandStack;
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
+import org.eclipse.emf.edit.provider.ReflectiveItemProviderAdapterFactory;
+import org.eclipse.emf.edit.provider.resource.ResourceItemProviderAdapterFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.provider.PropertydefinitionsItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.provider.PropertyinstancesItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.categories.provider.DVLMCategoriesItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.concepts.provider.ConceptsItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.general.provider.GeneralItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.provider.DVLMDVLMItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.provider.QudvItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.roles.provider.RolesItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.structural.provider.DVLMStructuralItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.units.provider.UnitsItemProviderAdapterFactory;
+
+public abstract class ABeanUnitTest {
+
+	protected ComposedAdapterFactory adapterFactory;
+	protected EditingDomain ed;
+	
+	protected ABeanUnit<?> aBeanUnit;
+	protected AUnit aUnit;
+	
+	protected static final String TEST_NAME = "name";
+	protected static final String TEST_SYMBOL = "symbol";
+	
+	@Before
+	public void setUp() throws Exception {
+		adapterFactory = new ComposedAdapterFactory(ComposedAdapterFactory.Descriptor.Registry.INSTANCE);
+		
+		adapterFactory.addAdapterFactory(new ResourceItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new DVLMDVLMItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new DVLMStructuralItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new GeneralItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new ConceptsItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new RolesItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new UnitsItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new DVLMCategoriesItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new PropertydefinitionsItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new PropertyinstancesItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new QudvItemProviderAdapterFactory());
+		
+		ed = new AdapterFactoryEditingDomain(adapterFactory, new BasicCommandStack());
+	}
+	
+	@Test
+	public void testGetUuid() {
+		String beanUuid = aBeanUnit.getUuid();
+		String unitUuid = aUnit.getUuid().toString();
+		assertEquals("Got correct UUID of bean", unitUuid, beanUuid);
+	}
+	
+	@Test
+	public void testGetName() {
+		aUnit.setName(TEST_NAME);
+		assertEquals("Got correct name", TEST_NAME, aBeanUnit.getName());
+	}
+
+	@Test
+	public void testSetName() {
+		aBeanUnit.setName(TEST_NAME);
+		assertEquals("Got correct name", TEST_NAME, aUnit.getName());
+	}
+
+	@Test
+	public void testSetNameEditingDomain() {
+		Command setCommand = aBeanUnit.setName(ed, TEST_NAME);
+		
+		// The command is not yet executed, the name should not have changed
+		assertNull("Command was not yet executed", aUnit.getName());
+		
+		// Now we execute the command and the name should be correctly set
+		setCommand.execute();
+		assertEquals("Name is correctly set", TEST_NAME, aUnit.getName());
+	}
+	
+	@Test
+	public void testGetSymbol() {
+		aUnit.setSymbol(TEST_SYMBOL);
+		assertEquals("Got correct name", TEST_SYMBOL, aBeanUnit.getSymbol());
+	}
+
+	@Test
+	public void testSetSymbol() {
+		aBeanUnit.setSymbol(TEST_SYMBOL);
+		assertEquals("Got correct name", TEST_SYMBOL, aUnit.getSymbol());
+	}
+	
+	@Test
+	public void testSetSymbolEditingDomain() {
+		Command setCommand = aBeanUnit.setSymbol(ed, TEST_SYMBOL);
+		
+		// The command is not yet executed, the name should not have changed
+		assertNull("Command was not yet executed", aUnit.getSymbol());
+		
+		// Now we execute the command and the name should be correctly set
+		setCommand.execute();
+		assertEquals("Got correct symbol", TEST_SYMBOL, aUnit.getSymbol());
+	}
+}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanUnitTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanUnitTest.java
@@ -29,6 +29,8 @@ import de.dlr.sc.virsat.model.dvlm.concepts.provider.ConceptsItemProviderAdapter
 import de.dlr.sc.virsat.model.dvlm.general.provider.GeneralItemProviderAdapterFactory;
 import de.dlr.sc.virsat.model.dvlm.provider.DVLMDVLMItemProviderAdapterFactory;
 import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.SimpleQuantityKind;
 import de.dlr.sc.virsat.model.dvlm.qudv.provider.QudvItemProviderAdapterFactory;
 import de.dlr.sc.virsat.model.dvlm.roles.provider.RolesItemProviderAdapterFactory;
 import de.dlr.sc.virsat.model.dvlm.structural.provider.DVLMStructuralItemProviderAdapterFactory;
@@ -41,6 +43,7 @@ public abstract class ABeanUnitTest {
 	
 	protected ABeanUnit<?> aBeanUnit;
 	protected AUnit aUnit;
+	protected SimpleQuantityKind simpleQuantityKind;
 	
 	protected static final String TEST_NAME = "name";
 	protected static final String TEST_SYMBOL = "symbol";
@@ -63,6 +66,8 @@ public abstract class ABeanUnitTest {
 		adapterFactory.addAdapterFactory(new QudvItemProviderAdapterFactory());
 		
 		ed = new AdapterFactoryEditingDomain(adapterFactory, new BasicCommandStack());
+		
+		simpleQuantityKind = QudvFactory.eINSTANCE.createSimpleQuantityKind();
 	}
 	
 	@Test
@@ -96,13 +101,13 @@ public abstract class ABeanUnitTest {
 	@Test
 	public void testGetSymbol() {
 		aUnit.setSymbol(TEST_SYMBOL);
-		assertEquals("Got correct name", TEST_SYMBOL, aBeanUnit.getSymbol());
+		assertEquals("Got correct symbol", TEST_SYMBOL, aBeanUnit.getSymbol());
 	}
 
 	@Test
 	public void testSetSymbol() {
 		aBeanUnit.setSymbol(TEST_SYMBOL);
-		assertEquals("Got correct name", TEST_SYMBOL, aUnit.getSymbol());
+		assertEquals("Got correct symbol", TEST_SYMBOL, aUnit.getSymbol());
 	}
 	
 	@Test
@@ -112,5 +117,27 @@ public abstract class ABeanUnitTest {
 		
 		setCommand.execute();
 		assertEquals("Got correct symbol", TEST_SYMBOL, aUnit.getSymbol());
+	}
+	
+	@Test
+	public void testGetQuanityKind() {
+		assertNull("Got empty bean for no quantityKind", aBeanUnit.getQuantityKindBean());
+		aUnit.setQuantityKind(simpleQuantityKind);
+		assertEquals("Got correct quantityKind", simpleQuantityKind, aBeanUnit.getQuantityKindBean().getQuantityKind());
+	}
+
+	@Test
+	public void testSetQuanityKind() {
+		aBeanUnit.setQuantityKindBean(new BeanQuantityKindSimple(simpleQuantityKind));
+		assertEquals("Got correct quantityKind", simpleQuantityKind, aBeanUnit.getQuantityKindBean().getQuantityKind());
+	}
+	
+	@Test
+	public void testSetQuanityKindEditingDomain() {
+		Command setCommand = aBeanUnit.setQuantityKindBean(ed, new BeanQuantityKindSimple(simpleQuantityKind));
+		assertNull("Command was not yet executed", aBeanUnit.getQuantityKindBean());
+		
+		setCommand.execute();
+		assertEquals("Got correct quantityKind", simpleQuantityKind, aBeanUnit.getQuantityKindBean().getQuantityKind());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanFactorQuantityKindTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanFactorQuantityKindTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.eclipse.emf.common.command.BasicCommandStack;
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
+import org.eclipse.emf.edit.provider.ReflectiveItemProviderAdapterFactory;
+import org.eclipse.emf.edit.provider.resource.ResourceItemProviderAdapterFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.provider.PropertydefinitionsItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.provider.PropertyinstancesItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.categories.provider.DVLMCategoriesItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.concepts.provider.ConceptsItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.general.provider.GeneralItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.provider.DVLMDVLMItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.QuantityKindFactor;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.SimpleQuantityKind;
+import de.dlr.sc.virsat.model.dvlm.qudv.provider.QudvItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.roles.provider.RolesItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.structural.provider.DVLMStructuralItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.units.provider.UnitsItemProviderAdapterFactory;
+
+public class BeanFactorQuantityKindTest {
+	
+	private AdapterFactoryEditingDomain ed;
+	
+	private QuantityKindFactor factor;
+	private BeanFactorQuantityKind factorBean;
+	private SimpleQuantityKind testQuantityKind;
+
+	private BeanQuantityKindSimple testQuantityKindBean;
+	
+	private static final double TEST_EXPONENT = 20.56;
+	private static final double EPSILON = 0.001;
+	
+	@Before
+	public void setUp() throws Exception {
+		ComposedAdapterFactory adapterFactory = new ComposedAdapterFactory(ComposedAdapterFactory.Descriptor.Registry.INSTANCE);
+		
+		adapterFactory.addAdapterFactory(new ResourceItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new DVLMDVLMItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new DVLMStructuralItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new GeneralItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new ConceptsItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new RolesItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new UnitsItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new DVLMCategoriesItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new PropertydefinitionsItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new PropertyinstancesItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new QudvItemProviderAdapterFactory());
+		
+		ed = new AdapterFactoryEditingDomain(adapterFactory, new BasicCommandStack());
+		
+		factor = QudvFactory.eINSTANCE.createQuantityKindFactor();
+		factorBean = new BeanFactorQuantityKind();
+		factorBean.setFactor(factor);
+		
+		testQuantityKind = QudvFactory.eINSTANCE.createSimpleQuantityKind();
+		testQuantityKindBean = new BeanQuantityKindSimple(testQuantityKind);
+	}
+	
+	@Test
+	public void testGetUuid() {
+		String beanUuid = factorBean.getUuid();
+		String unitUuid = factor.getUuid().toString();
+		assertEquals("Got correct UUID of bean", unitUuid, beanUuid);
+	}
+	
+	@Test
+	public void testGetExponent() {
+		factor.setExponent(TEST_EXPONENT);
+		assertEquals("Got right value", TEST_EXPONENT, factorBean.getExponent(), EPSILON);
+	}
+	
+	@Test
+	public void testSetExponent() {
+		assertEquals("Initial value", 0.0, factor.getExponent(), EPSILON);
+		factorBean.setExponent(TEST_EXPONENT);
+		
+		assertEquals("Value correctly set", TEST_EXPONENT, factor.getExponent(), EPSILON);
+	}
+	
+	@Test
+	public void testSetExponentEditingDomain() {
+		assertEquals("Initial value", 0.0, factor.getExponent(), EPSILON);
+		Command cmd = factorBean.setExponent(ed, TEST_EXPONENT);
+		cmd.execute();
+		
+		assertEquals("Value correctly set", TEST_EXPONENT, factor.getExponent(), EPSILON);
+	}
+	
+	@Test
+	public void testGetUnit() {
+		factor.setQuantityKind(testQuantityKind);
+		assertEquals("Got right value", testQuantityKind, factorBean.getQuantityKindBean().getQuantityKind());
+	}
+	
+	@Test
+	public void testSetUnit() {
+		assertNull("Initial value", factor.getQuantityKind());
+		factorBean.setQuantityKindBean(testQuantityKindBean);
+		
+		assertEquals("Value correctly set", testQuantityKind, factor.getQuantityKind());
+	}
+	
+	@Test
+	public void testSetUnitEditingDomain() {
+		assertNull("Initial value", factor.getQuantityKind());
+		Command cmd = factorBean.setQuantityKindBean(ed, testQuantityKindBean);
+		cmd.execute();
+		
+		assertEquals("Value correctly set", testQuantityKind, factor.getQuantityKind());
+	}
+}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanFactorUnitTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanFactorUnitTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.eclipse.emf.common.command.BasicCommandStack;
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
+import org.eclipse.emf.edit.provider.ReflectiveItemProviderAdapterFactory;
+import org.eclipse.emf.edit.provider.resource.ResourceItemProviderAdapterFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.provider.PropertydefinitionsItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.provider.PropertyinstancesItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.categories.provider.DVLMCategoriesItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.concepts.provider.ConceptsItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.general.provider.GeneralItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.provider.DVLMDVLMItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.SimpleUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.UnitFactor;
+import de.dlr.sc.virsat.model.dvlm.qudv.provider.QudvItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.roles.provider.RolesItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.structural.provider.DVLMStructuralItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.units.provider.UnitsItemProviderAdapterFactory;
+
+public class BeanFactorUnitTest {
+	
+	private AdapterFactoryEditingDomain ed;
+	
+	private UnitFactor factor;
+	private BeanFactorUnit factorBean;
+	private SimpleUnit testUnit;
+
+	private BeanUnitSimple testUnitBean;
+	
+	private static final double TEST_EXPONENT = 20.56;
+	private static final double EPSILON = 0.001;
+	
+	@Before
+	public void setUp() throws Exception {
+		ComposedAdapterFactory adapterFactory = new ComposedAdapterFactory(ComposedAdapterFactory.Descriptor.Registry.INSTANCE);
+		
+		adapterFactory.addAdapterFactory(new ResourceItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new DVLMDVLMItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new DVLMStructuralItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new GeneralItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new ConceptsItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new RolesItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new UnitsItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new DVLMCategoriesItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new PropertydefinitionsItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new PropertyinstancesItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new QudvItemProviderAdapterFactory());
+		
+		ed = new AdapterFactoryEditingDomain(adapterFactory, new BasicCommandStack());
+		
+		factor = QudvFactory.eINSTANCE.createUnitFactor();
+		factorBean = new BeanFactorUnit();
+		factorBean.setFactor(factor);
+		
+		testUnit = QudvFactory.eINSTANCE.createSimpleUnit();
+		testUnitBean = new BeanUnitSimple(testUnit);
+	}
+	
+	@Test
+	public void testGetUuid() {
+		String beanUuid = factorBean.getUuid();
+		String unitUuid = factor.getUuid().toString();
+		assertEquals("Got correct UUID of bean", unitUuid, beanUuid);
+	}
+	
+	@Test
+	public void testGetExponent() {
+		factor.setExponent(TEST_EXPONENT);
+		assertEquals("Got right value", TEST_EXPONENT, factorBean.getExponent(), EPSILON);
+	}
+	
+	@Test
+	public void testSetExponent() {
+		assertEquals("Initial value", 0.0, factor.getExponent(), EPSILON);
+		factorBean.setExponent(TEST_EXPONENT);
+		
+		assertEquals("Value correctly set", TEST_EXPONENT, factor.getExponent(), EPSILON);
+	}
+	
+	@Test
+	public void testSetExponentEditingDomain() {
+		assertEquals("Initial value", 0.0, factor.getExponent(), EPSILON);
+		Command cmd = factorBean.setExponent(ed, TEST_EXPONENT);
+		cmd.execute();
+		
+		assertEquals("Value correctly set", TEST_EXPONENT, factor.getExponent(), EPSILON);
+	}
+	
+	@Test
+	public void testGetUnit() {
+		factor.setUnit(testUnit);
+		assertEquals("Got right value", testUnit, factorBean.getUnitBean().getUnit());
+	}
+	
+	@Test
+	public void testSetUnit() {
+		assertNull("Initial value", factor.getUnit());
+		factorBean.setUnitBean(testUnitBean);
+		
+		assertEquals("Value correctly set", testUnit, factor.getUnit());
+	}
+	
+	@Test
+	public void testSetUnitEditingDomain() {
+		assertNull("Initial value", factor.getUnit());
+		Command cmd = factorBean.setUnitBean(ed, testUnitBean);
+		cmd.execute();
+		
+		assertEquals("Value correctly set", testUnit, factor.getUnit());
+	}
+}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanPrefixTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanPrefixTest.java
@@ -91,11 +91,8 @@ public class BeanPrefixTest {
 	@Test
 	public void testSetNameEditingDomain() {
 		Command setCommand = prefixBean.setName(ed, TEST_NAME);
-		
-		// The command is not yet executed, the name should not have changed
 		assertNull("Command was not yet executed", prefix.getName());
 		
-		// Now we execute the command and the name should be correctly set
 		setCommand.execute();
 		assertEquals("Name is correctly set", TEST_NAME, prefix.getName());
 	}
@@ -115,11 +112,8 @@ public class BeanPrefixTest {
 	@Test
 	public void testSetSymbolEditingDomain() {
 		Command setCommand = prefixBean.setSymbol(ed, TEST_SYMBOL);
-		
-		// The command is not yet executed, the name should not have changed
 		assertNull("Command was not yet executed", prefix.getSymbol());
 		
-		// Now we execute the command and the name should be correctly set
 		setCommand.execute();
 		assertEquals("Got correct symbol", TEST_SYMBOL, prefix.getSymbol());
 	}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanPrefixTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanPrefixTest.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.eclipse.emf.common.command.BasicCommandStack;
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.domain.AdapterFactoryEditingDomain;
+import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
+import org.eclipse.emf.edit.provider.ReflectiveItemProviderAdapterFactory;
+import org.eclipse.emf.edit.provider.resource.ResourceItemProviderAdapterFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.provider.PropertydefinitionsItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.provider.PropertyinstancesItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.categories.provider.DVLMCategoriesItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.concepts.provider.ConceptsItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.general.provider.GeneralItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.provider.DVLMDVLMItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.Prefix;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.provider.QudvItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.roles.provider.RolesItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.structural.provider.DVLMStructuralItemProviderAdapterFactory;
+import de.dlr.sc.virsat.model.dvlm.units.provider.UnitsItemProviderAdapterFactory;
+
+public class BeanPrefixTest {
+
+	private AdapterFactoryEditingDomain ed;
+	
+	private Prefix prefix;
+	private BeanPrefix prefixBean;
+	private static final String TEST_NAME = "name";
+	private static final String TEST_SYMBOL = "symbol";
+	private static final double TEST_FACTOR = 20.56;
+	private static final double EPSILON = 0.001;
+	
+	@Before
+	public void setUp() throws Exception {
+		ComposedAdapterFactory adapterFactory = new ComposedAdapterFactory(ComposedAdapterFactory.Descriptor.Registry.INSTANCE);
+		
+		adapterFactory.addAdapterFactory(new ResourceItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new DVLMDVLMItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new DVLMStructuralItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new GeneralItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new ConceptsItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new RolesItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new UnitsItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new DVLMCategoriesItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new PropertydefinitionsItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new PropertyinstancesItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new ReflectiveItemProviderAdapterFactory());
+		adapterFactory.addAdapterFactory(new QudvItemProviderAdapterFactory());
+		
+		ed = new AdapterFactoryEditingDomain(adapterFactory, new BasicCommandStack());
+		
+		prefix = QudvFactory.eINSTANCE.createPrefix();
+		prefixBean = new BeanPrefix();
+		prefixBean.setPrefix(prefix);
+	}
+	
+	@Test
+	public void testGetUuid() {
+		String beanUuid = prefixBean.getUuid();
+		String unitUuid = prefix.getUuid().toString();
+		assertEquals("Got correct UUID of bean", unitUuid, beanUuid);
+	}
+	
+	@Test
+	public void testGetName() {
+		prefix.setName(TEST_NAME);
+		assertEquals("Got correct name", TEST_NAME, prefixBean.getName());
+	}
+
+	@Test
+	public void testSetName() {
+		prefixBean.setName(TEST_NAME);
+		assertEquals("Got correct name", TEST_NAME, prefix.getName());
+	}
+
+	@Test
+	public void testSetNameEditingDomain() {
+		Command setCommand = prefixBean.setName(ed, TEST_NAME);
+		
+		// The command is not yet executed, the name should not have changed
+		assertNull("Command was not yet executed", prefix.getName());
+		
+		// Now we execute the command and the name should be correctly set
+		setCommand.execute();
+		assertEquals("Name is correctly set", TEST_NAME, prefix.getName());
+	}
+	
+	@Test
+	public void testGetSymbol() {
+		prefix.setSymbol(TEST_SYMBOL);
+		assertEquals("Got correct name", TEST_SYMBOL, prefixBean.getSymbol());
+	}
+
+	@Test
+	public void testSetSymbol() {
+		prefixBean.setSymbol(TEST_SYMBOL);
+		assertEquals("Got correct name", TEST_SYMBOL, prefix.getSymbol());
+	}
+	
+	@Test
+	public void testSetSymbolEditingDomain() {
+		Command setCommand = prefixBean.setSymbol(ed, TEST_SYMBOL);
+		
+		// The command is not yet executed, the name should not have changed
+		assertNull("Command was not yet executed", prefix.getSymbol());
+		
+		// Now we execute the command and the name should be correctly set
+		setCommand.execute();
+		assertEquals("Got correct symbol", TEST_SYMBOL, prefix.getSymbol());
+	}
+	
+	@Test
+	public void getFactor() {
+		prefix.setFactor(TEST_FACTOR);
+		assertEquals("Got right value", TEST_FACTOR, prefixBean.getFactor(), EPSILON);
+	}
+	
+	@Test
+	public void testSetFactor() {
+		assertEquals("Initial value", 0.0, prefix.getFactor(), EPSILON);
+		prefixBean.setFactor(TEST_FACTOR);
+		
+		assertEquals("Value correctly set", TEST_FACTOR, prefix.getFactor(), EPSILON);
+	}
+	
+	@Test
+	public void testSetFactorEditingDomain() {
+		assertEquals("Initial value", 0.0, prefix.getFactor(), EPSILON);
+		Command cmd = prefixBean.setFactor(ed, TEST_FACTOR);
+		cmd.execute();
+		
+		assertEquals("Value correctly set", TEST_FACTOR, prefix.getFactor(), EPSILON);
+	}
+}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindDerivedTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindDerivedTest.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.emf.common.command.Command;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.DerivedQuantityKind;
+import de.dlr.sc.virsat.model.dvlm.qudv.QuantityKindFactor;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvFactory;
+
+public class BeanQuantityKindDerivedTest extends ABeanQuantityKindTest {
+
+	private DerivedQuantityKind derivedQuantityKind;
+	private BeanQuantityKindDerived derivedBeanQuantityKind;
+	private QuantityKindFactor factor;
+	private BeanFactorQuantityKind beanFactor;
+
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		
+		derivedQuantityKind = QudvFactory.eINSTANCE.createDerivedQuantityKind();
+		derivedBeanQuantityKind = new BeanQuantityKindDerived();
+		derivedBeanQuantityKind.setQuantityKind(derivedQuantityKind);
+		
+		aQuantityKind = derivedQuantityKind;
+		aBeanQuantityKind = derivedBeanQuantityKind;
+		
+		factor = QudvFactory.eINSTANCE.createQuantityKindFactor();
+		beanFactor = new BeanFactorQuantityKind(factor);
+	}
+	
+	@Test
+	public void testGetFactors() {
+		assertTrue("Initial no factors", derivedBeanQuantityKind.getFactorBeans().isEmpty());
+		derivedQuantityKind.getFactor().add(factor);
+		
+		List<BeanFactorQuantityKind> beanFactors = derivedBeanQuantityKind.getFactorBeans();
+		assertEquals("Right amount of elements", 1, beanFactors.size());
+		assertEquals("Right element found", factor, beanFactors.get(0).getFactor());
+	}
+	
+	@Test
+	public void testSetFactors() {
+		assertTrue("Initial no factors", derivedBeanQuantityKind.getFactorBeans().isEmpty());
+		derivedBeanQuantityKind.setFactorBeans(Arrays.asList(beanFactor));
+		
+		List<QuantityKindFactor> factors = derivedQuantityKind.getFactor();
+		assertEquals("Right amount of elements", 1, factors.size());
+		assertEquals("Right element found", factor, factors.get(0));
+	}
+	
+	@Test
+	public void testAddFactor() {
+		assertTrue("Initial no factors", derivedBeanQuantityKind.getFactorBeans().isEmpty());
+		derivedBeanQuantityKind.addFactor(beanFactor);
+		
+		List<QuantityKindFactor> factors = derivedQuantityKind.getFactor();
+		assertEquals("Right amount of elements", 1, factors.size());
+		assertEquals("Right element found", factor, factors.get(0));
+	}
+	
+	@Test
+	public void testAddFactorEditingDomain() {
+		assertTrue("Initial no factors", derivedBeanQuantityKind.getFactorBeans().isEmpty());
+		Command cmd = derivedBeanQuantityKind.addFactor(ed, beanFactor);
+		cmd.execute();
+		
+		List<QuantityKindFactor> factors = derivedQuantityKind.getFactor();
+		assertEquals("Right amount of elements", 1, factors.size());
+		assertEquals("Right element found", factor, factors.get(0));
+	}
+	
+	@Test
+	public void testRemoveFactor() {
+		derivedQuantityKind.getFactor().add(factor);
+		assertEquals("Initial one element", 1, derivedQuantityKind.getFactor().size());
+		derivedBeanQuantityKind.removeFactor(beanFactor);
+		
+		assertTrue("Factor removed", derivedBeanQuantityKind.getFactorBeans().isEmpty());
+	}
+	
+	@Test
+	public void testRemoveFactorEditingDomain() {
+		derivedQuantityKind.getFactor().add(factor);
+		assertEquals("Initial one element", 1, derivedQuantityKind.getFactor().size());
+		Command cmd = derivedBeanQuantityKind.removeFactor(ed, beanFactor);
+		cmd.execute();
+		
+		assertTrue("Factor removed", derivedBeanQuantityKind.getFactorBeans().isEmpty());
+	}
+}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindFactoryTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindFactoryTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import de.dlr.sc.virsat.model.concept.types.factory.BeanQuantityKindFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.AQuantityKind;
+import de.dlr.sc.virsat.model.dvlm.qudv.DerivedQuantityKind;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.SimpleQuantityKind;
+
+public class BeanQuantityKindFactoryTest {
+
+	@Test
+	public void testBeanQuantityKindSimpleFromFactory() {
+		SimpleQuantityKind simpleQuantityKind = QudvFactory.eINSTANCE.createSimpleQuantityKind();
+		
+		BeanQuantityKindFactory beanQuantityKindFactory = new BeanQuantityKindFactory();
+		IBeanQuantityKind<? extends AQuantityKind> beanQuantityKindSimple = beanQuantityKindFactory.getInstanceFor(simpleQuantityKind);
+		
+		assertTrue(beanQuantityKindSimple instanceof BeanQuantityKindSimple);
+		assertEquals(simpleQuantityKind, beanQuantityKindSimple.getQuantityKind());
+	}
+	
+	@Test
+	public void testBeanQuantityKindDerivedFromFactory() {
+		DerivedQuantityKind derivedQuantityKind = QudvFactory.eINSTANCE.createDerivedQuantityKind();
+		
+		BeanQuantityKindFactory beanQuantityKindFactory = new BeanQuantityKindFactory();
+		IBeanQuantityKind<? extends AQuantityKind> beanQuantityKindDerived = beanQuantityKindFactory.getInstanceFor(derivedQuantityKind);
+		
+		assertTrue(beanQuantityKindDerived instanceof BeanQuantityKindDerived);
+		assertEquals(derivedQuantityKind, beanQuantityKindDerived.getQuantityKind());
+	}
+}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindSimpleTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindSimpleTest.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import org.junit.Before;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.SimpleQuantityKind;
+
+public class BeanQuantityKindSimpleTest extends ABeanQuantityKindTest {
+
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		
+		SimpleQuantityKind simpleQuantityKind = QudvFactory.eINSTANCE.createSimpleQuantityKind();
+		BeanQuantityKindSimple simpleQuantityKindBean = new BeanQuantityKindSimple();
+		simpleQuantityKindBean.setQuantityKind(simpleQuantityKind);
+		
+		aQuantityKind = simpleQuantityKind;
+		aBeanQuantityKind = simpleQuantityKindBean;
+	}
+}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitAffineConversionTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitAffineConversionTest.java
@@ -10,6 +10,8 @@
 package de.dlr.sc.virsat.model.concept.types.qudv;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.emf.common.command.Command;
 import org.junit.Before;
@@ -82,5 +84,28 @@ public class BeanUnitAffineConversionTest extends ABeanUnitTest {
 		cmd.execute();
 		
 		assertEquals("Value correctly set", TEST_OFFSET, affineConversionUnit.getOffset(), EPSILON);
+	}
+	
+	@Test
+	public void getIsInvertable() {
+		affineConversionUnit.setIsInvertible(true);
+		assertEquals("Got right value", affineConversionUnit.isIsInvertible(), affineConversionBeanUnit.getIsInvertible());
+	}
+	
+	@Test
+	public void testSetIsInvertable() {
+		assertFalse("Is false initial", affineConversionUnit.isIsInvertible());
+		affineConversionBeanUnit.setIsInvertible(true);
+		
+		assertTrue("Value correctly set", affineConversionUnit.isIsInvertible());
+	}
+	
+	@Test
+	public void testSetIsInvertableEditingDomain() {
+		assertFalse("Is false initial", affineConversionUnit.isIsInvertible());
+		Command cmd = affineConversionBeanUnit.setIsInvertible(ed, true);
+		cmd.execute();
+		
+		assertTrue("Value correctly set", affineConversionUnit.isIsInvertible());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitAffineConversionTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitAffineConversionTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.emf.common.command.Command;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.AffineConversionUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvFactory;
+
+public class BeanUnitAffineConversionTest extends ABeanUnitTest {
+
+	private AffineConversionUnit affineConversionUnit;
+	private BeanUnitAffineConversion affineConversionBeanUnit;
+	private static final double TEST_FACTOR = 20.56;
+	private static final double TEST_OFFSET = 42.69;
+	private static final double EPSILON = 0.001;
+	
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		
+		affineConversionUnit = QudvFactory.eINSTANCE.createAffineConversionUnit();
+		affineConversionBeanUnit = new BeanUnitAffineConversion();
+		affineConversionBeanUnit.setUnit(affineConversionUnit);
+		
+		aUnit = affineConversionUnit;
+		aBeanUnit = affineConversionBeanUnit;
+	}
+	
+	@Test
+	public void getFactor() {
+		affineConversionUnit.setFactor(TEST_FACTOR);
+		assertEquals("Got right value", TEST_FACTOR, affineConversionBeanUnit.getFactor(), EPSILON);
+	}
+	
+	@Test
+	public void testSetFactor() {
+		assertEquals("Initial value", 0.0, affineConversionUnit.getFactor(), EPSILON);
+		affineConversionBeanUnit.setFactor(TEST_FACTOR);
+		
+		assertEquals("Value correctly set", TEST_FACTOR, affineConversionUnit.getFactor(), EPSILON);
+	}
+	
+	@Test
+	public void testSetFactorEditingDomain() {
+		assertEquals("Initial value", 0.0, affineConversionUnit.getFactor(), EPSILON);
+		Command cmd = affineConversionBeanUnit.setFactor(ed, TEST_FACTOR);
+		cmd.execute();
+		
+		assertEquals("Value correctly set", TEST_FACTOR, affineConversionUnit.getFactor(), EPSILON);
+	}
+	
+	@Test
+	public void getOffset() {
+		affineConversionUnit.setOffset(TEST_OFFSET);
+		assertEquals("Got right value", TEST_OFFSET, affineConversionBeanUnit.getOffset(), EPSILON);
+	}
+	
+	@Test
+	public void testSetOffset() {
+		assertEquals("Initial value", 0.0, affineConversionUnit.getOffset(), EPSILON);
+		affineConversionBeanUnit.setOffset(TEST_OFFSET);
+		
+		assertEquals("Value correctly set", TEST_OFFSET, affineConversionUnit.getOffset(), EPSILON);
+	}
+	
+	@Test
+	public void testSetOffsetEditingDomain() {
+		assertEquals("Initial value", 0.0, affineConversionUnit.getOffset(), EPSILON);
+		Command cmd = affineConversionBeanUnit.setOffset(ed, TEST_OFFSET);
+		cmd.execute();
+		
+		assertEquals("Value correctly set", TEST_OFFSET, affineConversionUnit.getOffset(), EPSILON);
+	}
+}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitDerivedTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitDerivedTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.util.EList;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.DerivedUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.UnitFactor;
+
+public class BeanUnitDerivedTest extends ABeanUnitTest {
+
+	private DerivedUnit derivedUnit;
+	private BeanUnitDerived derivedBeanUnit;
+	private UnitFactor factor;
+	private BeanFactorUnit beanFactor;
+
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		
+		derivedUnit = QudvFactory.eINSTANCE.createDerivedUnit();
+		derivedBeanUnit = new BeanUnitDerived();
+		derivedBeanUnit.setUnit(derivedUnit);
+		
+		aUnit = derivedUnit;
+		aBeanUnit = derivedBeanUnit;
+		
+		factor = QudvFactory.eINSTANCE.createUnitFactor();
+		beanFactor = new BeanFactorUnit(factor);
+	}
+	
+	@Test
+	public void testGetFactors() {
+		assertTrue("Initial no factors", derivedBeanUnit.getFactorBeans().isEmpty());
+		derivedUnit.getFactor().add(factor);
+		
+		List<BeanFactorUnit> beanFactors = derivedBeanUnit.getFactorBeans();
+		assertEquals("Right amount of elements", 1, beanFactors.size());
+		assertEquals("Right element found", factor, beanFactors.get(0).getFactor());
+	}
+	
+	@Test
+	public void testSetFactors() {
+		assertTrue("Initial no factors", derivedBeanUnit.getFactorBeans().isEmpty());
+		derivedBeanUnit.setFactors(Arrays.asList(beanFactor));
+		
+		EList<UnitFactor> factors = derivedUnit.getFactor();
+		assertEquals("Right amount of elements", 1, factors.size());
+		assertEquals("Right element found", factor, factors.get(0));
+	}
+	
+	@Test
+	public void testAddFactor() {
+		assertTrue("Initial no factors", derivedBeanUnit.getFactorBeans().isEmpty());
+		derivedBeanUnit.addFactor(beanFactor);
+		
+		EList<UnitFactor> factors = derivedUnit.getFactor();
+		assertEquals("Right amount of elements", 1, factors.size());
+		assertEquals("Right element found", factor, factors.get(0));
+	}
+	
+	@Test
+	public void testAddFactorEditingDomain() {
+		assertTrue("Initial no factors", derivedBeanUnit.getFactorBeans().isEmpty());
+		Command cmd = derivedBeanUnit.addFactor(ed, beanFactor);
+		cmd.execute();
+		
+		EList<UnitFactor> factors = derivedUnit.getFactor();
+		assertEquals("Right amount of elements", 1, factors.size());
+		assertEquals("Right element found", factor, factors.get(0));
+	}
+	
+	@Test
+	public void testRemoveFactor() {
+		derivedUnit.getFactor().add(factor);
+		assertEquals("Initial one element", 1, derivedUnit.getFactor().size());
+		derivedBeanUnit.removeFactor(beanFactor);
+		
+		assertTrue("Factor removed", derivedBeanUnit.getFactorBeans().isEmpty());
+	}
+	
+	@Test
+	public void testRemoveFactorEditingDomain() {
+		derivedUnit.getFactor().add(factor);
+		assertEquals("Initial one element", 1, derivedUnit.getFactor().size());
+		Command cmd = derivedBeanUnit.removeFactor(ed, beanFactor);
+		cmd.execute();
+		
+		assertTrue("Factor removed", derivedBeanUnit.getFactorBeans().isEmpty());
+	}
+}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitDerivedTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitDerivedTest.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.emf.common.command.Command;
-import org.eclipse.emf.common.util.EList;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -61,7 +60,7 @@ public class BeanUnitDerivedTest extends ABeanUnitTest {
 		assertTrue("Initial no factors", derivedBeanUnit.getFactorBeans().isEmpty());
 		derivedBeanUnit.setFactors(Arrays.asList(beanFactor));
 		
-		EList<UnitFactor> factors = derivedUnit.getFactor();
+		List<UnitFactor> factors = derivedUnit.getFactor();
 		assertEquals("Right amount of elements", 1, factors.size());
 		assertEquals("Right element found", factor, factors.get(0));
 	}
@@ -71,7 +70,7 @@ public class BeanUnitDerivedTest extends ABeanUnitTest {
 		assertTrue("Initial no factors", derivedBeanUnit.getFactorBeans().isEmpty());
 		derivedBeanUnit.addFactor(beanFactor);
 		
-		EList<UnitFactor> factors = derivedUnit.getFactor();
+		List<UnitFactor> factors = derivedUnit.getFactor();
 		assertEquals("Right amount of elements", 1, factors.size());
 		assertEquals("Right element found", factor, factors.get(0));
 	}
@@ -82,7 +81,7 @@ public class BeanUnitDerivedTest extends ABeanUnitTest {
 		Command cmd = derivedBeanUnit.addFactor(ed, beanFactor);
 		cmd.execute();
 		
-		EList<UnitFactor> factors = derivedUnit.getFactor();
+		List<UnitFactor> factors = derivedUnit.getFactor();
 		assertEquals("Right amount of elements", 1, factors.size());
 		assertEquals("Right element found", factor, factors.get(0));
 	}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitFactoryTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitFactoryTest.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import de.dlr.sc.virsat.model.concept.types.factory.BeanUnitFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.AffineConversionUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.DerivedUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.LinearConversionUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.PrefixedUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.SimpleUnit;
+
+public class BeanUnitFactoryTest {
+
+	@Test
+	public void testBeanUnitSimpleFromFactory() {
+		SimpleUnit simpleUnit = QudvFactory.eINSTANCE.createSimpleUnit();
+		
+		BeanUnitFactory beanUnitFactory = new BeanUnitFactory();
+		IBeanUnit<? extends AUnit> beanUnitSimple = beanUnitFactory.getInstanceFor(simpleUnit);
+		
+		assertTrue(beanUnitSimple instanceof BeanUnitSimple);
+		assertEquals(simpleUnit, beanUnitSimple.getUnit());
+	}
+	
+	@Test
+	public void testBeanUnitPrefixedFromFactory() {
+		PrefixedUnit prefixedUnit = QudvFactory.eINSTANCE.createPrefixedUnit();
+		
+		BeanUnitFactory beanUnitFactory = new BeanUnitFactory();
+		IBeanUnit<? extends AUnit> beanUnitPrefixed = beanUnitFactory.getInstanceFor(prefixedUnit);
+		
+		assertTrue(beanUnitPrefixed instanceof BeanUnitPrefixed);
+		assertEquals(prefixedUnit, beanUnitPrefixed.getUnit());
+	}
+	
+	@Test
+	public void testBeanUnitDerivedFromFactory() {
+		DerivedUnit derivedUnit = QudvFactory.eINSTANCE.createDerivedUnit();
+		
+		BeanUnitFactory beanUnitFactory = new BeanUnitFactory();
+		IBeanUnit<? extends AUnit> beanUnitDerived = beanUnitFactory.getInstanceFor(derivedUnit);
+		
+		assertTrue(beanUnitDerived instanceof BeanUnitDerived);
+		assertEquals(derivedUnit, beanUnitDerived.getUnit());
+	}
+	
+	@Test
+	public void testBeanUnitLinearConversionFromFactory() {
+		LinearConversionUnit linearConversionUnit = QudvFactory.eINSTANCE.createLinearConversionUnit();
+		
+		BeanUnitFactory beanUnitFactory = new BeanUnitFactory();
+		IBeanUnit<? extends AUnit> beanUnitLinearConversion = beanUnitFactory.getInstanceFor(linearConversionUnit);
+		
+		assertTrue(beanUnitLinearConversion instanceof BeanUnitLinearConversion);
+		assertEquals(linearConversionUnit, beanUnitLinearConversion.getUnit());
+	}
+	
+	@Test
+	public void testBeanUnitAffineConversionFromFactory() {
+		AffineConversionUnit affineConversionUnit = QudvFactory.eINSTANCE.createAffineConversionUnit();
+		
+		BeanUnitFactory beanUnitFactory = new BeanUnitFactory();
+		IBeanUnit<? extends AUnit> beanUnitAffineConversion = beanUnitFactory.getInstanceFor(affineConversionUnit);
+		
+		assertTrue(beanUnitAffineConversion instanceof BeanUnitAffineConversion);
+		assertEquals(affineConversionUnit, beanUnitAffineConversion.getUnit());
+	}
+}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitLinearConversionTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitLinearConversionTest.java
@@ -10,6 +10,8 @@
 package de.dlr.sc.virsat.model.concept.types.qudv;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.emf.common.command.Command;
 import org.junit.Before;
@@ -58,5 +60,28 @@ public class BeanUnitLinearConversionTest extends ABeanUnitTest {
 		cmd.execute();
 		
 		assertEquals("Value correctly set", TEST_FACTOR, linearConversionUnit.getFactor(), EPSILON);
+	}
+	
+	@Test
+	public void getIsInvertable() {
+		linearConversionUnit.setIsInvertible(true);
+		assertEquals("Got right value", linearConversionUnit.isIsInvertible(), linearConversionBeanUnit.getIsInvertible());
+	}
+	
+	@Test
+	public void testSetIsInvertable() {
+		assertFalse("Is false initial", linearConversionUnit.isIsInvertible());
+		linearConversionBeanUnit.setIsInvertible(true);
+		
+		assertTrue("Value correctly set", linearConversionUnit.isIsInvertible());
+	}
+	
+	@Test
+	public void testSetIsInvertableEditingDomain() {
+		assertFalse("Is false initial", linearConversionUnit.isIsInvertible());
+		Command cmd = linearConversionBeanUnit.setIsInvertible(ed, true);
+		cmd.execute();
+		
+		assertTrue("Value correctly set", linearConversionUnit.isIsInvertible());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitLinearConversionTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitLinearConversionTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.emf.common.command.Command;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.LinearConversionUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvFactory;
+
+public class BeanUnitLinearConversionTest extends ABeanUnitTest {
+
+	private LinearConversionUnit linearConversionUnit;
+	private BeanUnitLinearConversion linearConversionBeanUnit;
+	private static final double TEST_FACTOR = 20.56;
+	private static final double EPSILON = 0.001;
+
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		
+		linearConversionUnit = QudvFactory.eINSTANCE.createLinearConversionUnit();
+		linearConversionBeanUnit = new BeanUnitLinearConversion();
+		linearConversionBeanUnit.setUnit(linearConversionUnit);
+		
+		aUnit = linearConversionUnit;
+		aBeanUnit = linearConversionBeanUnit;
+	}
+	
+	@Test
+	public void getFactor() {
+		linearConversionUnit.setFactor(TEST_FACTOR);
+		assertEquals("Got right value", TEST_FACTOR, linearConversionBeanUnit.getFactor(), EPSILON);
+	}
+	
+	@Test
+	public void testSetFactor() {
+		assertEquals("Initial value", 0.0, linearConversionUnit.getFactor(), EPSILON);
+		linearConversionBeanUnit.setFactor(TEST_FACTOR);
+		
+		assertEquals("Value correctly set", TEST_FACTOR, linearConversionUnit.getFactor(), EPSILON);
+	}
+	
+	@Test
+	public void testSetFactorEditingDomain() {
+		assertEquals("Initial value", 0.0, linearConversionUnit.getFactor(), EPSILON);
+		Command cmd = linearConversionBeanUnit.setFactor(ed, TEST_FACTOR);
+		cmd.execute();
+		
+		assertEquals("Value correctly set", TEST_FACTOR, linearConversionUnit.getFactor(), EPSILON);
+	}
+}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitPrefixedTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitPrefixedTest.java
@@ -10,7 +10,9 @@
 package de.dlr.sc.virsat.model.concept.types.qudv;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.emf.common.command.Command;
 import org.junit.Before;
@@ -63,5 +65,28 @@ public class BeanUnitPrefixedTest extends ABeanUnitTest {
 		cmd.execute();
 		
 		assertEquals("Value correctly set", prefix, prefixedUnit.getPrefix());
+	}
+	
+	@Test
+	public void getIsInvertable() {
+		prefixedUnit.setIsInvertible(true);
+		assertEquals("Got right value", prefixedUnit.isIsInvertible(), prefixedBeanUnit.getIsInvertible());
+	}
+	
+	@Test
+	public void testSetIsInvertable() {
+		assertFalse("Is false initial", prefixedUnit.isIsInvertible());
+		prefixedBeanUnit.setIsInvertible(true);
+		
+		assertTrue("Value correctly set", prefixedUnit.isIsInvertible());
+	}
+	
+	@Test
+	public void testSetIsInvertableEditingDomain() {
+		assertFalse("Is false initial", prefixedUnit.isIsInvertible());
+		Command cmd = prefixedBeanUnit.setIsInvertible(ed, true);
+		cmd.execute();
+		
+		assertTrue("Value correctly set", prefixedUnit.isIsInvertible());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitPrefixedTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitPrefixedTest.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.eclipse.emf.common.command.Command;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.Prefix;
+import de.dlr.sc.virsat.model.dvlm.qudv.PrefixedUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvFactory;
+
+public class BeanUnitPrefixedTest extends ABeanUnitTest {
+
+	private PrefixedUnit prefixedUnit;
+	private BeanUnitPrefixed prefixedBeanUnit;
+	private Prefix prefix;
+	private BeanPrefix beanPrefix;
+
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		
+		prefixedUnit = QudvFactory.eINSTANCE.createPrefixedUnit();
+		prefixedBeanUnit = new BeanUnitPrefixed();
+		prefixedBeanUnit.setUnit(prefixedUnit);
+		
+		aUnit = prefixedUnit;
+		aBeanUnit = prefixedBeanUnit;
+		
+		prefix = QudvFactory.eINSTANCE.createPrefix();
+		beanPrefix = new BeanPrefix(prefix);
+	}
+	
+	@Test
+	public void getPrefix() {
+		prefixedUnit.setPrefix(prefix);
+		assertEquals("Got right value", prefix, prefixedBeanUnit.getPrefixBean().getPrefix());
+	}
+	
+	@Test
+	public void testSetPrefix() {
+		assertNull("Is null initial", prefixedUnit.getPrefix());
+		prefixedBeanUnit.setPrefix(beanPrefix);
+		
+		assertEquals("Value correctly set", prefix, prefixedUnit.getPrefix());
+	}
+	
+	@Test
+	public void testSetPrefixEditingDomain() {
+		assertNull("Is null initial", prefixedUnit.getPrefix());
+		Command cmd = prefixedBeanUnit.setPrefix(ed, beanPrefix);
+		cmd.execute();
+		
+		assertEquals("Value correctly set", prefix, prefixedUnit.getPrefix());
+	}
+}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitSimpleTest.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitSimpleTest.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import org.junit.Before;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.SimpleUnit;
+
+public class BeanUnitSimpleTest extends ABeanUnitTest {
+
+	@Before
+	public void setUp() throws Exception {
+		super.setUp();
+		
+		SimpleUnit simpleUnit = QudvFactory.eINSTANCE.createSimpleUnit();
+		BeanUnitSimple simpleUnitBean = new BeanUnitSimple();
+		simpleUnitBean.setUnit(simpleUnit);
+		
+		aUnit = simpleUnit;
+		aBeanUnit = simpleUnitBean;
+	}
+}

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/edit/test/AllTests.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/edit/test/AllTests.java
@@ -30,6 +30,9 @@ import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyFloatTest;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyIntTest;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyResourceTest;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyStringTest;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanFactorQuantityKindTest;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanFactorUnitTest;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanPrefixTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitAffineConversionTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitDerivedTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitLinearConversionTest;
@@ -154,7 +157,10 @@ import junit.framework.JUnit4TestAdapter;
 				BeanUnitDerivedTest.class,
 				BeanUnitLinearConversionTest.class,
 				BeanUnitPrefixedTest.class,
-				BeanUnitSimpleTest.class
+				BeanUnitSimpleTest.class,
+				BeanPrefixTest.class,
+				BeanFactorUnitTest.class,
+				BeanFactorQuantityKindTest.class
 				})
 
 /**

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/edit/test/AllTests.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/edit/test/AllTests.java
@@ -34,9 +34,11 @@ import de.dlr.sc.virsat.model.concept.types.qudv.BeanFactorQuantityKindTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanFactorUnitTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanPrefixTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanQuantityKindDerivedTest;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanQuantityKindFactoryTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanQuantityKindSimpleTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitAffineConversionTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitDerivedTest;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitFactoryTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitLinearConversionTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitPrefixedTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitSimpleTest;
@@ -164,7 +166,9 @@ import junit.framework.JUnit4TestAdapter;
 				BeanFactorUnitTest.class,
 				BeanFactorQuantityKindTest.class,
 				BeanQuantityKindSimpleTest.class,
-				BeanQuantityKindDerivedTest.class
+				BeanQuantityKindDerivedTest.class,
+				BeanQuantityKindFactoryTest.class,
+				BeanUnitFactoryTest.class
 				})
 
 /**

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/edit/test/AllTests.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/edit/test/AllTests.java
@@ -33,6 +33,8 @@ import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyStringTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanFactorQuantityKindTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanFactorUnitTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanPrefixTest;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanQuantityKindDerivedTest;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanQuantityKindSimpleTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitAffineConversionTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitDerivedTest;
 import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitLinearConversionTest;
@@ -160,7 +162,9 @@ import junit.framework.JUnit4TestAdapter;
 				BeanUnitSimpleTest.class,
 				BeanPrefixTest.class,
 				BeanFactorUnitTest.class,
-				BeanFactorQuantityKindTest.class
+				BeanFactorQuantityKindTest.class,
+				BeanQuantityKindSimpleTest.class,
+				BeanQuantityKindDerivedTest.class
 				})
 
 /**

--- a/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/edit/test/AllTests.java
+++ b/de.dlr.sc.virsat.model.edit.test/src/de/dlr/sc/virsat/model/edit/test/AllTests.java
@@ -30,6 +30,11 @@ import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyFloatTest;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyIntTest;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyResourceTest;
 import de.dlr.sc.virsat.model.concept.types.property.BeanPropertyStringTest;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitAffineConversionTest;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitDerivedTest;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitLinearConversionTest;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitPrefixedTest;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitSimpleTest;
 import de.dlr.sc.virsat.model.concept.types.structural.BeanStructuralElementInstanceTest;
 import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.provider.DVLMEnumValueDefinitionItemProviderTest;
 import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.provider.DVLMPropertydefinitionsItemProviderAdapterFactoryTest;
@@ -144,7 +149,12 @@ import junit.framework.JUnit4TestAdapter;
 				IUuidAdapterTest.class,
 				UriAdapterTest.class,
 				ABeanStructuralElementInstanceAdapterTest.class,
-				BeanPropertyTypeAdapterTest.class
+				BeanPropertyTypeAdapterTest.class,
+				BeanUnitAffineConversionTest.class,
+				BeanUnitDerivedTest.class,
+				BeanUnitLinearConversionTest.class,
+				BeanUnitPrefixedTest.class,
+				BeanUnitSimpleTest.class
 				})
 
 /**

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/factory/BeanQuantityKindFactory.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/factory/BeanQuantityKindFactory.java
@@ -21,20 +21,20 @@ public class BeanQuantityKindFactory {
 
 	private BeanQuantityKindFactorySwitch bufs = new BeanQuantityKindFactorySwitch();
 	
-	public IBeanQuantityKind getInstanceFor(AQuantityKind quantityKind) {
-		IBeanQuantityKind beanQuantityKind = bufs.doSwitch(quantityKind);
-		beanQuantityKind.setQuantityKind(quantityKind);
+	public IBeanQuantityKind<? extends AQuantityKind> getInstanceFor(AQuantityKind quantityKind) {
+		IBeanQuantityKind<? extends AQuantityKind> beanQuantityKind = bufs.doSwitch(quantityKind);
+		beanQuantityKind.setAQuantityKind(quantityKind);
 		return beanQuantityKind;
 	}
 	
-	private static class BeanQuantityKindFactorySwitch extends QudvSwitch<IBeanQuantityKind> {
+	private static class BeanQuantityKindFactorySwitch extends QudvSwitch<IBeanQuantityKind<? extends AQuantityKind>> {
 		@Override
-		public IBeanQuantityKind caseDerivedQuantityKind(DerivedQuantityKind object) {
+		public IBeanQuantityKind<? extends AQuantityKind> caseDerivedQuantityKind(DerivedQuantityKind object) {
 			return new BeanQuantityKindDerived();
 		}
 		
 		@Override
-		public IBeanQuantityKind caseSimpleQuantityKind(SimpleQuantityKind object) {
+		public IBeanQuantityKind<? extends AQuantityKind> caseSimpleQuantityKind(SimpleQuantityKind object) {
 			return new BeanQuantityKindSimple();
 		}
 	}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/factory/BeanQuantityKindFactory.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/factory/BeanQuantityKindFactory.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.factory;
+
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanQuantityKindDerived;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanQuantityKindSimple;
+import de.dlr.sc.virsat.model.concept.types.qudv.IBeanQuantityKind;
+import de.dlr.sc.virsat.model.dvlm.qudv.AQuantityKind;
+import de.dlr.sc.virsat.model.dvlm.qudv.DerivedQuantityKind;
+import de.dlr.sc.virsat.model.dvlm.qudv.SimpleQuantityKind;
+import de.dlr.sc.virsat.model.dvlm.qudv.util.QudvSwitch;
+
+public class BeanQuantityKindFactory {
+
+	private BeanQuantityKindFactorySwitch bufs = new BeanQuantityKindFactorySwitch();
+	
+	public IBeanQuantityKind getInstanceFor(AQuantityKind quantityKind) {
+		IBeanQuantityKind beanQuantityKind = bufs.doSwitch(quantityKind);
+		beanQuantityKind.setQuantityKind(quantityKind);
+		return beanQuantityKind;
+	}
+	
+	private static class BeanQuantityKindFactorySwitch extends QudvSwitch<IBeanQuantityKind> {
+		@Override
+		public IBeanQuantityKind caseDerivedQuantityKind(DerivedQuantityKind object) {
+			return new BeanQuantityKindDerived();
+		}
+		
+		@Override
+		public IBeanQuantityKind caseSimpleQuantityKind(SimpleQuantityKind object) {
+			return new BeanQuantityKindSimple();
+		}
+	}
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/factory/BeanUnitFactory.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/factory/BeanUnitFactory.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.factory;
+
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitAffineConversion;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitDerived;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitLinearConversion;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitPrefixed;
+import de.dlr.sc.virsat.model.concept.types.qudv.BeanUnitSimple;
+import de.dlr.sc.virsat.model.concept.types.qudv.IBeanUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.AffineConversionUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.DerivedUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.LinearConversionUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.PrefixedUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.SimpleUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.util.QudvSwitch;
+
+public class BeanUnitFactory {
+
+	private BeanUnitFactorySwitch bufs = new BeanUnitFactorySwitch();
+	
+	public IBeanUnit getInstanceFor(AUnit unit) {
+		IBeanUnit beanUnit = bufs.doSwitch(unit);
+		beanUnit.setUnit(unit);
+		return beanUnit;
+	}
+	
+	private static class BeanUnitFactorySwitch extends QudvSwitch<IBeanUnit> {
+		@Override
+		public IBeanUnit caseAffineConversionUnit(AffineConversionUnit object) {
+			return new BeanUnitAffineConversion();
+		}
+		
+		@Override
+		public IBeanUnit caseDerivedUnit(DerivedUnit object) {
+			return new BeanUnitDerived();
+		}
+		
+		@Override
+		public IBeanUnit caseLinearConversionUnit(LinearConversionUnit object) {
+			return new BeanUnitLinearConversion();
+		}
+		
+		@Override
+		public IBeanUnit casePrefixedUnit(PrefixedUnit object) {
+			return new BeanUnitPrefixed();
+		}
+		
+		@Override
+		public IBeanUnit caseSimpleUnit(SimpleUnit object) {
+			return new BeanUnitSimple();
+		}
+	}
+	
+
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/factory/BeanUnitFactory.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/factory/BeanUnitFactory.java
@@ -27,35 +27,35 @@ public class BeanUnitFactory {
 
 	private BeanUnitFactorySwitch bufs = new BeanUnitFactorySwitch();
 	
-	public IBeanUnit getInstanceFor(AUnit unit) {
-		IBeanUnit beanUnit = bufs.doSwitch(unit);
-		beanUnit.setUnit(unit);
+	public IBeanUnit<? extends AUnit> getInstanceFor(AUnit unit) {
+		IBeanUnit<? extends AUnit> beanUnit = bufs.doSwitch(unit);
+		beanUnit.setAUnit(unit);
 		return beanUnit;
 	}
 	
-	private static class BeanUnitFactorySwitch extends QudvSwitch<IBeanUnit> {
+	private static class BeanUnitFactorySwitch extends QudvSwitch<IBeanUnit<? extends AUnit>> {
 		@Override
-		public IBeanUnit caseAffineConversionUnit(AffineConversionUnit object) {
+		public IBeanUnit<? extends AUnit> caseAffineConversionUnit(AffineConversionUnit object) {
 			return new BeanUnitAffineConversion();
 		}
 		
 		@Override
-		public IBeanUnit caseDerivedUnit(DerivedUnit object) {
+		public IBeanUnit<? extends AUnit> caseDerivedUnit(DerivedUnit object) {
 			return new BeanUnitDerived();
 		}
 		
 		@Override
-		public IBeanUnit caseLinearConversionUnit(LinearConversionUnit object) {
+		public IBeanUnit<? extends AUnit> caseLinearConversionUnit(LinearConversionUnit object) {
 			return new BeanUnitLinearConversion();
 		}
 		
 		@Override
-		public IBeanUnit casePrefixedUnit(PrefixedUnit object) {
+		public IBeanUnit<? extends AUnit> casePrefixedUnit(PrefixedUnit object) {
 			return new BeanUnitPrefixed();
 		}
 		
 		@Override
-		public IBeanUnit caseSimpleUnit(SimpleUnit object) {
+		public IBeanUnit<? extends AUnit> caseSimpleUnit(SimpleUnit object) {
 			return new BeanUnitSimple();
 		}
 	}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanUnitValueProperty.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/ABeanUnitValueProperty.java
@@ -13,11 +13,17 @@ import javax.xml.bind.annotation.XmlElement;
 
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.CompoundCommand;
+import org.eclipse.emf.common.command.UnexecutableCommand;
+import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 
+import de.dlr.sc.virsat.model.concept.types.factory.BeanUnitFactory;
+import de.dlr.sc.virsat.model.concept.types.qudv.IBeanUnit;
+import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.PropertyinstancesPackage;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.UnitValuePropertyInstance;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.util.PropertyInstanceHelper;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.util.PropertyInstanceValueSwitch;
+import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
@@ -72,8 +78,28 @@ public abstract class ABeanUnitValueProperty<V_TYPE> extends ABeanValueProperty<
 	}
 	
 	@Override
+	public IBeanUnit<? extends AUnit> getUnitBean() {
+		return new BeanUnitFactory().getInstanceFor(ti.getUnit());
+	}
+	
+	@Override
+	public void setUnitBean(IBeanUnit<? extends AUnit> unitBean) {
+		if (unitBean != null) {
+			ti.setUnit(unitBean.getUnit());
+		}
+	}
+	
+	@Override
+	public Command setUnitBean(EditingDomain ed, IBeanUnit<? extends AUnit> unitBean) {
+		if (unitBean != null) {
+			return SetCommand.create(ed, ti, PropertyinstancesPackage.Literals.IUNIT_PROPERTY_INSTANCE__UNIT, unitBean.getUnit());
+		}
+		return UnexecutableCommand.INSTANCE;
+	}
+	
 	@XmlElement(nillable = true)
 	@ApiModelProperty(value = "Unit of the bean")
+	@Override
 	public String getUnit() {
 		return new PropertyInstanceHelper().getUnit(ti);
 	}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyEnum.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/BeanPropertyEnum.java
@@ -12,9 +12,12 @@ package de.dlr.sc.virsat.model.concept.types.property;
 import javax.xml.bind.annotation.XmlElement;
 
 import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.command.UnexecutableCommand;
 import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 
+import de.dlr.sc.virsat.model.concept.types.factory.BeanUnitFactory;
+import de.dlr.sc.virsat.model.concept.types.qudv.IBeanUnit;
 import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.EnumProperty;
 import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.EnumPropertyHelper;
 import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.EnumValueDefinition;
@@ -102,6 +105,26 @@ public class BeanPropertyEnum extends ABeanProperty<EnumUnitPropertyInstance, St
 		return value;
 	}
 
+	@Override
+	public IBeanUnit<? extends AUnit> getUnitBean() {
+		return new BeanUnitFactory().getInstanceFor(ti.getUnit());
+	}
+	
+	@Override
+	public void setUnitBean(IBeanUnit<? extends AUnit> unitBean) {
+		if (unitBean != null) {
+			ti.setUnit(unitBean.getUnit());
+		}
+	}
+	
+	@Override
+	public Command setUnitBean(EditingDomain ed, IBeanUnit<? extends AUnit> unitBean) {
+		if (unitBean != null) {
+			return SetCommand.create(ed, ti, PropertyinstancesPackage.Literals.IUNIT_PROPERTY_INSTANCE__UNIT, unitBean.getUnit());
+		}
+		return UnexecutableCommand.INSTANCE;
+	}
+	
 	@Override
 	@XmlElement(nillable = true)
 	public String getUnit() {

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/IBeanUnitProperty.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/property/IBeanUnitProperty.java
@@ -12,6 +12,9 @@ package de.dlr.sc.virsat.model.concept.types.property;
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.edit.domain.EditingDomain;
 
+import de.dlr.sc.virsat.model.concept.types.qudv.IBeanUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
+
 /**
  * Common signature for all bean properties that support units such as INTs
  * floats and also the enumerator beans
@@ -41,4 +44,23 @@ public interface IBeanUnitProperty {
 	 */
 	Command setUnit(EditingDomain ed, String unitName);
 
+	/**
+	 * Returns a bean wrapping the unit
+	 * @return IBeanUnit
+	 */
+	IBeanUnit<? extends AUnit> getUnitBean();
+
+	/**
+	 * Set the unit wrapped in an unitBean
+	 * @param unitBean
+	 */
+	void setUnitBean(IBeanUnit<? extends AUnit> unitBean);
+	
+	/**
+	 * Set the unit wrapped in an unitBean
+	 * @param ed the editing domain to be used when creating the command
+	 * @param unitBean
+	 * @return the command that changes the unit
+	 */
+	Command setUnitBean(EditingDomain ed, IBeanUnit<? extends AUnit> unitBean);
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanConversionBasedUnit.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanConversionBasedUnit.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.AConversionBasedUnit;
+
+public class ABeanConversionBasedUnit<U_TYPE extends AConversionBasedUnit> extends ABeanUnit<U_TYPE> {
+
+	Boolean getIsInvertible() {
+		return unit.isIsInvertible();
+	}
+	
+	void setIsInvertible(Boolean isInverible) {
+		unit.setIsInvertible(isInverible);
+	}
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanConversionBasedUnit.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanConversionBasedUnit.java
@@ -13,6 +13,14 @@ import de.dlr.sc.virsat.model.dvlm.qudv.AConversionBasedUnit;
 
 public class ABeanConversionBasedUnit<U_TYPE extends AConversionBasedUnit> extends ABeanUnit<U_TYPE> {
 
+	public ABeanConversionBasedUnit() {
+		super();
+	}
+	
+	public ABeanConversionBasedUnit(U_TYPE unit) {
+		super(unit);
+	}
+	
 	Boolean getIsInvertible() {
 		return unit.isIsInvertible();
 	}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanConversionBasedUnit.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanConversionBasedUnit.java
@@ -9,9 +9,14 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.model.concept.types.qudv;
 
-import de.dlr.sc.virsat.model.dvlm.qudv.AConversionBasedUnit;
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.command.SetCommand;
+import org.eclipse.emf.edit.domain.EditingDomain;
 
-public class ABeanConversionBasedUnit<U_TYPE extends AConversionBasedUnit> extends ABeanUnit<U_TYPE> {
+import de.dlr.sc.virsat.model.dvlm.qudv.AConversionBasedUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
+
+public class ABeanConversionBasedUnit<U_TYPE extends AConversionBasedUnit> extends ABeanUnit<U_TYPE> implements IBeanConversionBasedUnit {
 
 	public ABeanConversionBasedUnit() {
 		super();
@@ -21,11 +26,18 @@ public class ABeanConversionBasedUnit<U_TYPE extends AConversionBasedUnit> exten
 		super(unit);
 	}
 	
-	Boolean getIsInvertible() {
+	@Override
+	public Boolean getIsInvertible() {
 		return unit.isIsInvertible();
 	}
 	
-	void setIsInvertible(Boolean isInverible) {
+	@Override
+	public void setIsInvertible(Boolean isInverible) {
 		unit.setIsInvertible(isInverible);
+	}
+
+	@Override
+	public Command setIsInvertible(EditingDomain ed, Boolean isInverible) {
+		return SetCommand.create(ed, unit, QudvPackage.Literals.ACONVERSION_BASED_UNIT__IS_INVERTIBLE, isInverible);
 	}
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanQuantityKind.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanQuantityKind.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.command.SetCommand;
+import org.eclipse.emf.edit.domain.EditingDomain;
+
+import de.dlr.sc.virsat.model.dvlm.general.GeneralPackage;
+import de.dlr.sc.virsat.model.dvlm.qudv.AQuantityKind;
+import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
+
+public class ABeanQuantityKind<QK_TYPE extends AQuantityKind> implements IBeanQuantityKind {
+
+	protected QK_TYPE quantityKind;
+	
+	public ABeanQuantityKind() { }
+	
+	@SuppressWarnings("unchecked")
+	public ABeanQuantityKind(AUnit quantityKind) {
+		this.quantityKind = (QK_TYPE) quantityKind;
+	}
+	
+	@Override
+	public AQuantityKind getQuantityKind() {
+		return quantityKind;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void setQuantityKind(AQuantityKind quantityKind) {
+		this.quantityKind = (QK_TYPE) quantityKind;
+
+	}
+
+	@Override
+	public String getUuid() {
+		return quantityKind.getUuid().toString();
+	}
+
+	@Override
+	public String getName() {
+		return quantityKind.getName();
+	}
+
+	@Override
+	public void setName(String name) {
+		quantityKind.setName(name);
+	}
+
+	@Override
+	public Command setName(EditingDomain ed, String name) {
+		return SetCommand.create(ed, quantityKind, GeneralPackage.Literals.INAME__NAME, name);
+	}
+
+	@Override
+	public String getSymbol() {
+		return quantityKind.getSymbol();
+	}
+
+	@Override
+	public void setSymbol(String symbol) {
+		quantityKind.getSymbol();
+	}
+
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanQuantityKind.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanQuantityKind.java
@@ -15,16 +15,16 @@ import org.eclipse.emf.edit.domain.EditingDomain;
 
 import de.dlr.sc.virsat.model.dvlm.general.GeneralPackage;
 import de.dlr.sc.virsat.model.dvlm.qudv.AQuantityKind;
-import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
 
 public class ABeanQuantityKind<QK_TYPE extends AQuantityKind> implements IBeanQuantityKind {
 
 	protected QK_TYPE quantityKind;
+	// TODO: change interface similar to unit
 	
 	public ABeanQuantityKind() { }
 	
 	@SuppressWarnings("unchecked")
-	public ABeanQuantityKind(AUnit quantityKind) {
+	public ABeanQuantityKind(AQuantityKind quantityKind) {
 		this.quantityKind = (QK_TYPE) quantityKind;
 	}
 	

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanQuantityKind.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanQuantityKind.java
@@ -15,11 +15,11 @@ import org.eclipse.emf.edit.domain.EditingDomain;
 
 import de.dlr.sc.virsat.model.dvlm.general.GeneralPackage;
 import de.dlr.sc.virsat.model.dvlm.qudv.AQuantityKind;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
 
-public class ABeanQuantityKind<QK_TYPE extends AQuantityKind> implements IBeanQuantityKind {
+public class ABeanQuantityKind<QK_TYPE extends AQuantityKind> implements IBeanQuantityKind<QK_TYPE> {
 
 	protected QK_TYPE quantityKind;
-	// TODO: change interface similar to unit
 	
 	public ABeanQuantityKind() { }
 	
@@ -29,15 +29,24 @@ public class ABeanQuantityKind<QK_TYPE extends AQuantityKind> implements IBeanQu
 	}
 	
 	@Override
-	public AQuantityKind getQuantityKind() {
+	public AQuantityKind getAQuantityKind() {
 		return quantityKind;
 	}
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public void setQuantityKind(AQuantityKind quantityKind) {
+	public void setAQuantityKind(AQuantityKind quantityKind) {
 		this.quantityKind = (QK_TYPE) quantityKind;
+	}
 
+	@Override
+	public QK_TYPE getQuantityKind() {
+		return quantityKind;
+	}
+
+	@Override
+	public void setQuantityKind(QK_TYPE quantityKind) {
+		this.quantityKind = quantityKind;
 	}
 
 	@Override
@@ -67,7 +76,12 @@ public class ABeanQuantityKind<QK_TYPE extends AQuantityKind> implements IBeanQu
 
 	@Override
 	public void setSymbol(String symbol) {
-		quantityKind.getSymbol();
+		quantityKind.setSymbol(symbol);
+	}
+
+	@Override
+	public Command setSymbol(EditingDomain ed, String symbol) {
+		return SetCommand.create(ed, quantityKind, QudvPackage.Literals.AQUANTITY_KIND__SYMBOL, symbol);
 	}
 
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanUnit.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanUnit.java
@@ -13,7 +13,9 @@ import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 
+import de.dlr.sc.virsat.model.concept.types.factory.BeanQuantityKindFactory;
 import de.dlr.sc.virsat.model.dvlm.general.GeneralPackage;
+import de.dlr.sc.virsat.model.dvlm.qudv.AQuantityKind;
 import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
 import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
 
@@ -81,6 +83,25 @@ public class ABeanUnit<U_TYPE extends AUnit> implements IBeanUnit<U_TYPE> {
 	@Override
 	public Command setSymbol(EditingDomain ed, String symbol) {
 		return SetCommand.create(ed, unit, QudvPackage.Literals.AUNIT__SYMBOL, symbol);
+	}
+
+	@Override
+	public IBeanQuantityKind<? extends AQuantityKind> getQuantityKindBean() {
+		if (unit.getQuantityKind() == null) {
+			return null;
+		}
+		
+		return new BeanQuantityKindFactory().getInstanceFor(unit.getQuantityKind());
+	}
+
+	@Override
+	public void setQuantityKindBean(IBeanQuantityKind<? extends AQuantityKind> quantityKindBean) {
+		unit.setQuantityKind(quantityKindBean.getQuantityKind());
+	}
+
+	@Override
+	public Command setQuantityKindBean(EditingDomain ed, IBeanQuantityKind<? extends AQuantityKind> quantityKindBean) {
+		return SetCommand.create(ed, unit, QudvPackage.Literals.AUNIT__QUANTITY_KIND, quantityKindBean.getQuantityKind());
 	}
 
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanUnit.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanUnit.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.command.SetCommand;
+import org.eclipse.emf.edit.domain.EditingDomain;
+
+import de.dlr.sc.virsat.model.dvlm.general.GeneralPackage;
+import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
+
+public class ABeanUnit<U_TYPE extends AUnit> implements IBeanUnit {
+
+	protected U_TYPE unit;
+	
+	public ABeanUnit() { }
+	
+	@SuppressWarnings("unchecked")
+	public ABeanUnit(AUnit unit) {
+		this.unit = (U_TYPE) unit;
+	}
+	
+	@Override
+	public AUnit getUnit() {
+		return unit;
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	public void setUnit(AUnit unit) {
+		this.unit = (U_TYPE) unit;
+	}
+	
+	@Override
+	public String getUuid() {
+		return unit.getUuid().toString();
+	}
+
+	@Override
+	public String getName() {
+		return unit.getName();
+	}
+
+	@Override
+	public void setName(String name) {
+		unit.setName(name);
+	}
+
+	@Override
+	public Command setName(EditingDomain ed, String name) {
+		return SetCommand.create(ed, unit, GeneralPackage.Literals.INAME__NAME, name);
+	}
+
+	@Override
+	public String getSymbol() {
+		return unit.getSymbol();
+	}
+
+	@Override
+	public void setSymbol(String symbol) {
+		unit.getSymbol();
+	}
+
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanUnit.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/ABeanUnit.java
@@ -15,27 +15,37 @@ import org.eclipse.emf.edit.domain.EditingDomain;
 
 import de.dlr.sc.virsat.model.dvlm.general.GeneralPackage;
 import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
 
-public class ABeanUnit<U_TYPE extends AUnit> implements IBeanUnit {
+public class ABeanUnit<U_TYPE extends AUnit> implements IBeanUnit<U_TYPE> {
 
 	protected U_TYPE unit;
 	
 	public ABeanUnit() { }
 	
+	public ABeanUnit(U_TYPE unit) {
+		this.unit = unit;
+	}
+	
+	@Override
+	public AUnit getAUnit() {
+		return unit;
+	}
+
 	@SuppressWarnings("unchecked")
-	public ABeanUnit(AUnit unit) {
+	@Override
+	public void setAUnit(AUnit unit) {
 		this.unit = (U_TYPE) unit;
 	}
 	
 	@Override
-	public AUnit getUnit() {
+	public U_TYPE getUnit() {
 		return unit;
 	}
 	
-	@SuppressWarnings("unchecked")
 	@Override
-	public void setUnit(AUnit unit) {
-		this.unit = (U_TYPE) unit;
+	public void setUnit(U_TYPE unit) {
+		this.unit = unit;
 	}
 	
 	@Override
@@ -65,7 +75,12 @@ public class ABeanUnit<U_TYPE extends AUnit> implements IBeanUnit {
 
 	@Override
 	public void setSymbol(String symbol) {
-		unit.getSymbol();
+		unit.setSymbol(symbol);
+	}
+
+	@Override
+	public Command setSymbol(EditingDomain ed, String symbol) {
+		return SetCommand.create(ed, unit, QudvPackage.Literals.AUNIT__SYMBOL, symbol);
 	}
 
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanFactorQuantityKind.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanFactorQuantityKind.java
@@ -12,12 +12,12 @@ package de.dlr.sc.virsat.model.concept.types.qudv;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanQuantityKindFactory;
 import de.dlr.sc.virsat.model.dvlm.qudv.QuantityKindFactor;
 
-public class BeanQuantityKindFactor {
+public class BeanFactorQuantityKind {
 	private QuantityKindFactor factor;
 	
-	public BeanQuantityKindFactor() { }
+	public BeanFactorQuantityKind() { }
 	
-	public BeanQuantityKindFactor(QuantityKindFactor factor) {
+	public BeanFactorQuantityKind(QuantityKindFactor factor) {
 		this.factor = factor;
 	}
 	

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanFactorQuantityKind.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanFactorQuantityKind.java
@@ -9,16 +9,27 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.model.concept.types.qudv;
 
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.command.SetCommand;
+import org.eclipse.emf.edit.domain.EditingDomain;
+
+import de.dlr.sc.virsat.model.concept.types.IBeanUuid;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanQuantityKindFactory;
 import de.dlr.sc.virsat.model.dvlm.qudv.QuantityKindFactor;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
 
-public class BeanFactorQuantityKind {
+public class BeanFactorQuantityKind implements IBeanUuid {
 	private QuantityKindFactor factor;
 	
 	public BeanFactorQuantityKind() { }
 	
 	public BeanFactorQuantityKind(QuantityKindFactor factor) {
 		this.factor = factor;
+	}
+	
+	@Override
+	public String getUuid() {
+		return factor.getUuid().toString();
 	}
 	
 	QuantityKindFactor getFactor() {
@@ -37,11 +48,19 @@ public class BeanFactorQuantityKind {
 		factor.setExponent(exponent);
 	}
 	
-	IBeanQuantityKind getQuantityKind() {
+	public Command setExponent(EditingDomain ed, Double exponent) {
+		return SetCommand.create(ed, factor, QudvPackage.Literals.QUANTITY_KIND_FACTOR__EXPONENT, exponent);
+	}
+	
+	IBeanQuantityKind getQuantityKindBean() {
 		return new BeanQuantityKindFactory().getInstanceFor(factor.getQuantityKind());
 	}
 	
-	void setQuantityKind(IBeanQuantityKind beanQuantityKind) {
+	void setQuantityKindBean(IBeanQuantityKind beanQuantityKind) {
 		factor.setQuantityKind(beanQuantityKind.getQuantityKind());
+	}
+	
+	public Command setQuantityKindBean(EditingDomain ed, IBeanQuantityKind beanQuantityKind) {
+		return SetCommand.create(ed, factor, QudvPackage.Literals.QUANTITY_KIND_FACTOR__QUANTITY_KIND, beanQuantityKind.getQuantityKind());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanFactorQuantityKind.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanFactorQuantityKind.java
@@ -15,6 +15,7 @@ import org.eclipse.emf.edit.domain.EditingDomain;
 
 import de.dlr.sc.virsat.model.concept.types.IBeanUuid;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanQuantityKindFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.AQuantityKind;
 import de.dlr.sc.virsat.model.dvlm.qudv.QuantityKindFactor;
 import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
 
@@ -52,15 +53,15 @@ public class BeanFactorQuantityKind implements IBeanUuid {
 		return SetCommand.create(ed, factor, QudvPackage.Literals.QUANTITY_KIND_FACTOR__EXPONENT, exponent);
 	}
 	
-	IBeanQuantityKind getQuantityKindBean() {
+	IBeanQuantityKind<? extends AQuantityKind> getQuantityKindBean() {
 		return new BeanQuantityKindFactory().getInstanceFor(factor.getQuantityKind());
 	}
 	
-	void setQuantityKindBean(IBeanQuantityKind beanQuantityKind) {
+	void setQuantityKindBean(IBeanQuantityKind<? extends AQuantityKind> beanQuantityKind) {
 		factor.setQuantityKind(beanQuantityKind.getQuantityKind());
 	}
 	
-	public Command setQuantityKindBean(EditingDomain ed, IBeanQuantityKind beanQuantityKind) {
+	public Command setQuantityKindBean(EditingDomain ed, IBeanQuantityKind<? extends AQuantityKind> beanQuantityKind) {
 		return SetCommand.create(ed, factor, QudvPackage.Literals.QUANTITY_KIND_FACTOR__QUANTITY_KIND, beanQuantityKind.getQuantityKind());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanFactorUnit.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanFactorUnit.java
@@ -10,15 +10,16 @@
 package de.dlr.sc.virsat.model.concept.types.qudv;
 
 import de.dlr.sc.virsat.model.concept.types.factory.BeanUnitFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
 import de.dlr.sc.virsat.model.dvlm.qudv.UnitFactor;
 
-public class BeanUnitFactor {
+public class BeanFactorUnit {
 
 	private UnitFactor factor;
 	
-	public BeanUnitFactor() { }
+	public BeanFactorUnit() { }
 	
-	public BeanUnitFactor(UnitFactor factor) {
+	public BeanFactorUnit(UnitFactor factor) {
 		this.factor = factor;
 	}
 	
@@ -38,11 +39,11 @@ public class BeanUnitFactor {
 		factor.setExponent(exponent);
 	}
 	
-	IBeanUnit getUnit() {
+	IBeanUnit<? extends AUnit> getUnit() {
 		return new BeanUnitFactory().getInstanceFor(factor.getUnit());
 	}
 	
-	void setUnit(IBeanUnit beanUnit) {
+	void setUnit(IBeanUnit<? extends AUnit> beanUnit) {
 		factor.setUnit(beanUnit.getUnit());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanFactorUnit.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanFactorUnit.java
@@ -9,11 +9,17 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.model.concept.types.qudv;
 
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.command.SetCommand;
+import org.eclipse.emf.edit.domain.EditingDomain;
+
+import de.dlr.sc.virsat.model.concept.types.IBeanUuid;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanUnitFactory;
 import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
 import de.dlr.sc.virsat.model.dvlm.qudv.UnitFactor;
 
-public class BeanFactorUnit {
+public class BeanFactorUnit implements IBeanUuid {
 
 	private UnitFactor factor;
 	
@@ -21,6 +27,11 @@ public class BeanFactorUnit {
 	
 	public BeanFactorUnit(UnitFactor factor) {
 		this.factor = factor;
+	}
+	
+	@Override
+	public String getUuid() {
+		return factor.getUuid().toString();
 	}
 	
 	UnitFactor getFactor() {
@@ -39,11 +50,19 @@ public class BeanFactorUnit {
 		factor.setExponent(exponent);
 	}
 	
-	IBeanUnit<? extends AUnit> getUnit() {
+	public Command setExponent(EditingDomain ed, Double exponent) {
+		return SetCommand.create(ed, factor, QudvPackage.Literals.UNIT_FACTOR__EXPONENT, exponent);
+	}
+	
+	IBeanUnit<? extends AUnit> getUnitBean() {
 		return new BeanUnitFactory().getInstanceFor(factor.getUnit());
 	}
 	
-	void setUnit(IBeanUnit<? extends AUnit> beanUnit) {
+	void setUnitBean(IBeanUnit<? extends AUnit> beanUnit) {
 		factor.setUnit(beanUnit.getUnit());
+	}
+	
+	public Command setUnitBean(EditingDomain ed, IBeanUnit<? extends AUnit> beanUnit) {
+		return SetCommand.create(ed, factor, QudvPackage.Literals.UNIT_FACTOR__UNIT, beanUnit.getUnit());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanPrefix.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanPrefix.java
@@ -9,9 +9,17 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.model.concept.types.qudv;
 
-import de.dlr.sc.virsat.model.dvlm.qudv.Prefix;
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.command.SetCommand;
+import org.eclipse.emf.edit.domain.EditingDomain;
 
-public class BeanPrefix {
+import de.dlr.sc.virsat.model.concept.types.IBeanName;
+import de.dlr.sc.virsat.model.concept.types.IBeanUuid;
+import de.dlr.sc.virsat.model.dvlm.general.GeneralPackage;
+import de.dlr.sc.virsat.model.dvlm.qudv.Prefix;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
+
+public class BeanPrefix implements IBeanUuid, IBeanName {
 
 	private Prefix prefix;
 	
@@ -21,6 +29,25 @@ public class BeanPrefix {
 		this.prefix = prefix;
 	}
 	
+	@Override
+	public String getUuid() {
+		return prefix.getUuid().toString();
+	}
+	
+	@Override
+	public String getName() {
+		return prefix.getName();
+	}
+	
+	@Override
+	public void setName(String name) {
+		prefix.setName(name);
+	}
+	
+	@Override
+	public Command setName(EditingDomain ed, String name) {
+		return SetCommand.create(ed, prefix, GeneralPackage.Literals.INAME__NAME, name);
+	}
 	public Prefix getPrefix() {
 		return prefix;
 	}
@@ -34,7 +61,11 @@ public class BeanPrefix {
 	}
 
 	public void setSymbol(String symbol) {
-		prefix.getSymbol();
+		prefix.setSymbol(symbol);
+	}
+	
+	public Command setSymbol(EditingDomain ed, String symbol) {
+		return SetCommand.create(ed, prefix, QudvPackage.Literals.PREFIX__SYMBOL, symbol);
 	}
 	
 	Double getFactor() {
@@ -43,5 +74,9 @@ public class BeanPrefix {
 	
 	void setFactor(Double factor) {
 		prefix.setFactor(factor);
+	}
+	
+	public Command setFactor(EditingDomain ed, Double factor) {
+		return SetCommand.create(ed, prefix, QudvPackage.Literals.PREFIX__FACTOR, factor);
 	}
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanPrefix.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanPrefix.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.Prefix;
+
+public class BeanPrefix {
+
+	private Prefix prefix;
+	
+	public BeanPrefix() { }
+	
+	public BeanPrefix(Prefix prefix) {
+		this.prefix = prefix;
+	}
+	
+	public Prefix getPrefix() {
+		return prefix;
+	}
+	
+	public void setPrefix(Prefix prefix) {
+		this.prefix = prefix;
+	}
+	
+	public String getSymbol() {
+		return prefix.getSymbol();
+	}
+
+	public void setSymbol(String symbol) {
+		prefix.getSymbol();
+	}
+	
+	Double getFactor() {
+		return prefix.getFactor();
+	}
+	
+	void setFactor(Double factor) {
+		prefix.setFactor(factor);
+	}
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindDerived.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindDerived.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.DerivedQuantityKind;
+import de.dlr.sc.virsat.model.dvlm.qudv.QuantityKindFactor;
+
+public class BeanQuantityKindDerived extends ABeanQuantityKind<DerivedQuantityKind> {
+
+	/**
+	 * Get all factors
+	 * @return List of factors
+	 */
+	List<BeanQuantityKindFactor> getFactors() {
+		List<BeanQuantityKindFactor> factors = new ArrayList<BeanQuantityKindFactor>();
+		
+		for (QuantityKindFactor factor : quantityKind.getFactor()) {
+			factors.add(new BeanQuantityKindFactor(factor));
+		}
+		
+		return factors;
+	}
+	
+	/**
+	 * Set all factors
+	 * @param newBeanFactors List of new factors
+	 */
+	void setFactors(List<BeanQuantityKindFactor> newBeanFactors) {
+		List<QuantityKindFactor> currentFactors = quantityKind.getFactor();
+
+		List<QuantityKindFactor> newFactors = new ArrayList<QuantityKindFactor>();
+		for (BeanQuantityKindFactor beanFactor : newBeanFactors) {
+			newFactors.add(beanFactor.getFactor());
+		}
+		
+		currentFactors.clear();
+		currentFactors.addAll(newFactors);
+	}
+	
+	void addFactor(BeanQuantityKindFactor beanFactor) {
+		quantityKind.getFactor().add(beanFactor.getFactor());
+	}
+	
+	void removeFactor(BeanQuantityKindFactor beanFactor) {
+		quantityKind.getFactor().remove(beanFactor.getFactor());
+	}
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindDerived.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindDerived.java
@@ -17,6 +17,14 @@ import de.dlr.sc.virsat.model.dvlm.qudv.QuantityKindFactor;
 
 public class BeanQuantityKindDerived extends ABeanQuantityKind<DerivedQuantityKind> {
 
+	public BeanQuantityKindDerived() { 
+		super();
+	}
+	
+	public BeanQuantityKindDerived(DerivedQuantityKind quantityKind) {
+		super(quantityKind);
+	}
+	
 	/**
 	 * Get all factors
 	 * @return List of factors

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindDerived.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindDerived.java
@@ -21,11 +21,11 @@ public class BeanQuantityKindDerived extends ABeanQuantityKind<DerivedQuantityKi
 	 * Get all factors
 	 * @return List of factors
 	 */
-	List<BeanQuantityKindFactor> getFactors() {
-		List<BeanQuantityKindFactor> factors = new ArrayList<BeanQuantityKindFactor>();
+	List<BeanFactorQuantityKind> getFactors() {
+		List<BeanFactorQuantityKind> factors = new ArrayList<BeanFactorQuantityKind>();
 		
 		for (QuantityKindFactor factor : quantityKind.getFactor()) {
-			factors.add(new BeanQuantityKindFactor(factor));
+			factors.add(new BeanFactorQuantityKind(factor));
 		}
 		
 		return factors;
@@ -35,11 +35,11 @@ public class BeanQuantityKindDerived extends ABeanQuantityKind<DerivedQuantityKi
 	 * Set all factors
 	 * @param newBeanFactors List of new factors
 	 */
-	void setFactors(List<BeanQuantityKindFactor> newBeanFactors) {
+	void setFactors(List<BeanFactorQuantityKind> newBeanFactors) {
 		List<QuantityKindFactor> currentFactors = quantityKind.getFactor();
 
 		List<QuantityKindFactor> newFactors = new ArrayList<QuantityKindFactor>();
-		for (BeanQuantityKindFactor beanFactor : newBeanFactors) {
+		for (BeanFactorQuantityKind beanFactor : newBeanFactors) {
 			newFactors.add(beanFactor.getFactor());
 		}
 		
@@ -47,11 +47,11 @@ public class BeanQuantityKindDerived extends ABeanQuantityKind<DerivedQuantityKi
 		currentFactors.addAll(newFactors);
 	}
 	
-	void addFactor(BeanQuantityKindFactor beanFactor) {
+	void addFactor(BeanFactorQuantityKind beanFactor) {
 		quantityKind.getFactor().add(beanFactor.getFactor());
 	}
 	
-	void removeFactor(BeanQuantityKindFactor beanFactor) {
+	void removeFactor(BeanFactorQuantityKind beanFactor) {
 		quantityKind.getFactor().remove(beanFactor.getFactor());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindDerived.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindDerived.java
@@ -12,8 +12,14 @@ package de.dlr.sc.virsat.model.concept.types.qudv;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.command.AddCommand;
+import org.eclipse.emf.edit.command.RemoveCommand;
+import org.eclipse.emf.edit.domain.EditingDomain;
+
 import de.dlr.sc.virsat.model.dvlm.qudv.DerivedQuantityKind;
 import de.dlr.sc.virsat.model.dvlm.qudv.QuantityKindFactor;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
 
 public class BeanQuantityKindDerived extends ABeanQuantityKind<DerivedQuantityKind> {
 
@@ -29,7 +35,7 @@ public class BeanQuantityKindDerived extends ABeanQuantityKind<DerivedQuantityKi
 	 * Get all factors
 	 * @return List of factors
 	 */
-	List<BeanFactorQuantityKind> getFactors() {
+	List<BeanFactorQuantityKind> getFactorBeans() {
 		List<BeanFactorQuantityKind> factors = new ArrayList<BeanFactorQuantityKind>();
 		
 		for (QuantityKindFactor factor : quantityKind.getFactor()) {
@@ -43,7 +49,7 @@ public class BeanQuantityKindDerived extends ABeanQuantityKind<DerivedQuantityKi
 	 * Set all factors
 	 * @param newBeanFactors List of new factors
 	 */
-	void setFactors(List<BeanFactorQuantityKind> newBeanFactors) {
+	void setFactorBeans(List<BeanFactorQuantityKind> newBeanFactors) {
 		List<QuantityKindFactor> currentFactors = quantityKind.getFactor();
 
 		List<QuantityKindFactor> newFactors = new ArrayList<QuantityKindFactor>();
@@ -61,5 +67,13 @@ public class BeanQuantityKindDerived extends ABeanQuantityKind<DerivedQuantityKi
 	
 	void removeFactor(BeanFactorQuantityKind beanFactor) {
 		quantityKind.getFactor().remove(beanFactor.getFactor());
+	}
+	
+	Command addFactor(EditingDomain ed, BeanFactorQuantityKind beanFactor) {
+		return AddCommand.create(ed, quantityKind, QudvPackage.Literals.DERIVED_QUANTITY_KIND__FACTOR, beanFactor.getFactor());
+	}
+	
+	Command removeFactor(EditingDomain ed, BeanFactorQuantityKind beanFactor) {
+		return RemoveCommand.create(ed, quantityKind, QudvPackage.Literals.DERIVED_QUANTITY_KIND__FACTOR, beanFactor.getFactor());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindFactor.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindFactor.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import de.dlr.sc.virsat.model.concept.types.factory.BeanQuantityKindFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.QuantityKindFactor;
+
+public class BeanQuantityKindFactor {
+	private QuantityKindFactor factor;
+	
+	public BeanQuantityKindFactor() { }
+	
+	public BeanQuantityKindFactor(QuantityKindFactor factor) {
+		this.factor = factor;
+	}
+	
+	QuantityKindFactor getFactor() {
+		return factor;
+	}
+	
+	void setFactor(QuantityKindFactor factor) {
+		this.factor = factor;
+	}
+	
+	Double getExponent() {
+		return factor.getExponent();
+	}
+	
+	void setExponent(Double exponent) {
+		factor.setExponent(exponent);
+	}
+	
+	IBeanQuantityKind getQuantityKind() {
+		return new BeanQuantityKindFactory().getInstanceFor(factor.getQuantityKind());
+	}
+	
+	void setQuantityKind(IBeanQuantityKind beanQuantityKind) {
+		factor.setQuantityKind(beanQuantityKind.getQuantityKind());
+	}
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindSimple.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindSimple.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.SimpleQuantityKind;
+
+public class BeanQuantityKindSimple extends ABeanQuantityKind<SimpleQuantityKind> {
+
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindSimple.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanQuantityKindSimple.java
@@ -13,4 +13,12 @@ import de.dlr.sc.virsat.model.dvlm.qudv.SimpleQuantityKind;
 
 public class BeanQuantityKindSimple extends ABeanQuantityKind<SimpleQuantityKind> {
 
+	public BeanQuantityKindSimple() { 
+		super();
+	}
+	
+	public BeanQuantityKindSimple(SimpleQuantityKind quantityKind) {
+		super(quantityKind);
+	}
+	
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitAffineConversion.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitAffineConversion.java
@@ -9,7 +9,12 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.model.concept.types.qudv;
 
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.command.SetCommand;
+import org.eclipse.emf.edit.domain.EditingDomain;
+
 import de.dlr.sc.virsat.model.dvlm.qudv.AffineConversionUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
 
 public class BeanUnitAffineConversion extends ABeanConversionBasedUnit<AffineConversionUnit> {
 
@@ -21,11 +26,19 @@ public class BeanUnitAffineConversion extends ABeanConversionBasedUnit<AffineCon
 		unit.setFactor(factor);
 	}
 	
+	public Command setFactor(EditingDomain ed, Double factor) {
+		return SetCommand.create(ed, unit, QudvPackage.Literals.AFFINE_CONVERSION_UNIT__FACTOR, factor);
+	}
+	
 	Double getOffset() {
 		return unit.getOffset();
 	}
 	
 	void setOffset(Double offset) {
 		unit.setOffset(offset);
+	}
+	
+	public Command setOffset(EditingDomain ed, Double offset) {
+		return SetCommand.create(ed, unit, QudvPackage.Literals.AFFINE_CONVERSION_UNIT__OFFSET, offset);
 	}
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitAffineConversion.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitAffineConversion.java
@@ -18,6 +18,14 @@ import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
 
 public class BeanUnitAffineConversion extends ABeanConversionBasedUnit<AffineConversionUnit> {
 
+	public BeanUnitAffineConversion() { 
+		super();
+	}
+	
+	public BeanUnitAffineConversion(AffineConversionUnit unit) {
+		super(unit);
+	}
+	
 	Double getFactor() {
 		return unit.getFactor();
 	}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitAffineConversion.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitAffineConversion.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.AffineConversionUnit;
+
+public class BeanUnitAffineConversion extends ABeanConversionBasedUnit<AffineConversionUnit> {
+
+	Double getFactor() {
+		return unit.getFactor();
+	}
+	
+	void setFactor(Double factor) {
+		unit.setFactor(factor);
+	}
+	
+	Double getOffset() {
+		return unit.getOffset();
+	}
+	
+	void setOffset(Double offset) {
+		unit.setOffset(offset);
+	}
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitDerived.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitDerived.java
@@ -13,7 +13,13 @@ package de.dlr.sc.virsat.model.concept.types.qudv;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.command.AddCommand;
+import org.eclipse.emf.edit.command.RemoveCommand;
+import org.eclipse.emf.edit.domain.EditingDomain;
+
 import de.dlr.sc.virsat.model.dvlm.qudv.DerivedUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
 import de.dlr.sc.virsat.model.dvlm.qudv.UnitFactor;
 
 public class BeanUnitDerived extends ABeanUnit<DerivedUnit> {
@@ -22,11 +28,11 @@ public class BeanUnitDerived extends ABeanUnit<DerivedUnit> {
 	 * Get all factors
 	 * @return List of factors
 	 */
-	List<BeanUnitFactor> getFactors() {
-		List<BeanUnitFactor> factors = new ArrayList<BeanUnitFactor>();
+	List<BeanFactorUnit> getFactorBeans() {
+		List<BeanFactorUnit> factors = new ArrayList<BeanFactorUnit>();
 		
 		for (UnitFactor factor : unit.getFactor()) {
-			factors.add(new BeanUnitFactor(factor));
+			factors.add(new BeanFactorUnit(factor));
 		}
 		
 		return factors;
@@ -36,11 +42,11 @@ public class BeanUnitDerived extends ABeanUnit<DerivedUnit> {
 	 * Set all factors
 	 * @param newBeanFactors List of new factors
 	 */
-	void setFactors(List<BeanUnitFactor> newBeanFactors) {
+	void setFactors(List<BeanFactorUnit> newBeanFactors) {
 		List<UnitFactor> currentFactors = unit.getFactor();
 
 		List<UnitFactor> newFactors = new ArrayList<UnitFactor>();
-		for (BeanUnitFactor beanFactor : newBeanFactors) {
+		for (BeanFactorUnit beanFactor : newBeanFactors) {
 			newFactors.add(beanFactor.getFactor());
 		}
 		
@@ -48,11 +54,19 @@ public class BeanUnitDerived extends ABeanUnit<DerivedUnit> {
 		currentFactors.addAll(newFactors);
 	}
 	
-	void addFactor(BeanUnitFactor beanFactor) {
+	void addFactor(BeanFactorUnit beanFactor) {
 		unit.getFactor().add(beanFactor.getFactor());
 	}
 	
-	void removeFactor(BeanUnitFactor beanFactor) {
+	void removeFactor(BeanFactorUnit beanFactor) {
 		unit.getFactor().remove(beanFactor.getFactor());
+	}
+	
+	Command addFactor(EditingDomain ed, BeanFactorUnit beanFactor) {
+		return AddCommand.create(ed, unit, QudvPackage.Literals.DERIVED_UNIT__FACTOR, beanFactor.getFactor());
+	}
+	
+	Command removeFactor(EditingDomain ed, BeanFactorUnit beanFactor) {
+		return RemoveCommand.create(ed, unit, QudvPackage.Literals.DERIVED_UNIT__FACTOR, beanFactor.getFactor());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitDerived.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitDerived.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.DerivedUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.UnitFactor;
+
+public class BeanUnitDerived extends ABeanUnit<DerivedUnit> {
+
+	/**
+	 * Get all factors
+	 * @return List of factors
+	 */
+	List<BeanUnitFactor> getFactors() {
+		List<BeanUnitFactor> factors = new ArrayList<BeanUnitFactor>();
+		
+		for (UnitFactor factor : unit.getFactor()) {
+			factors.add(new BeanUnitFactor(factor));
+		}
+		
+		return factors;
+	}
+	
+	/**
+	 * Set all factors
+	 * @param newBeanFactors List of new factors
+	 */
+	void setFactors(List<BeanUnitFactor> newBeanFactors) {
+		List<UnitFactor> currentFactors = unit.getFactor();
+
+		List<UnitFactor> newFactors = new ArrayList<UnitFactor>();
+		for (BeanUnitFactor beanFactor : newBeanFactors) {
+			newFactors.add(beanFactor.getFactor());
+		}
+		
+		currentFactors.clear();
+		currentFactors.addAll(newFactors);
+	}
+	
+	void addFactor(BeanUnitFactor beanFactor) {
+		unit.getFactor().add(beanFactor.getFactor());
+	}
+	
+	void removeFactor(BeanUnitFactor beanFactor) {
+		unit.getFactor().remove(beanFactor.getFactor());
+	}
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitDerived.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitDerived.java
@@ -24,6 +24,14 @@ import de.dlr.sc.virsat.model.dvlm.qudv.UnitFactor;
 
 public class BeanUnitDerived extends ABeanUnit<DerivedUnit> {
 
+	public BeanUnitDerived() { 
+		super();
+	}
+	
+	public BeanUnitDerived(DerivedUnit unit) {
+		super(unit);
+	}
+	
 	/**
 	 * Get all factors
 	 * @return List of factors

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitFactor.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitFactor.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import de.dlr.sc.virsat.model.concept.types.factory.BeanUnitFactory;
+import de.dlr.sc.virsat.model.dvlm.qudv.UnitFactor;
+
+public class BeanUnitFactor {
+
+	private UnitFactor factor;
+	
+	public BeanUnitFactor() { }
+	
+	public BeanUnitFactor(UnitFactor factor) {
+		this.factor = factor;
+	}
+	
+	UnitFactor getFactor() {
+		return factor;
+	}
+	
+	void setFactor(UnitFactor factor) {
+		this.factor = factor;
+	}
+	
+	Double getExponent() {
+		return factor.getExponent();
+	}
+	
+	void setExponent(Double exponent) {
+		factor.setExponent(exponent);
+	}
+	
+	IBeanUnit getUnit() {
+		return new BeanUnitFactory().getInstanceFor(factor.getUnit());
+	}
+	
+	void setUnit(IBeanUnit beanUnit) {
+		factor.setUnit(beanUnit.getUnit());
+	}
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitLinearConversion.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitLinearConversion.java
@@ -18,6 +18,14 @@ import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
 
 public class BeanUnitLinearConversion extends ABeanConversionBasedUnit<LinearConversionUnit> {
 
+	public BeanUnitLinearConversion() { 
+		super();
+	}
+	
+	public BeanUnitLinearConversion(LinearConversionUnit unit) {
+		super(unit);
+	}
+	
 	Double getFactor() {
 		return unit.getFactor();
 	}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitLinearConversion.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitLinearConversion.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.LinearConversionUnit;
+
+public class BeanUnitLinearConversion extends ABeanConversionBasedUnit<LinearConversionUnit> {
+
+	Double getFactor() {
+		return unit.getFactor();
+	}
+	
+	void setFactor(Double factor) {
+		unit.setFactor(factor);
+	}
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitLinearConversion.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitLinearConversion.java
@@ -9,7 +9,12 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.model.concept.types.qudv;
 
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.command.SetCommand;
+import org.eclipse.emf.edit.domain.EditingDomain;
+
 import de.dlr.sc.virsat.model.dvlm.qudv.LinearConversionUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
 
 public class BeanUnitLinearConversion extends ABeanConversionBasedUnit<LinearConversionUnit> {
 
@@ -19,5 +24,9 @@ public class BeanUnitLinearConversion extends ABeanConversionBasedUnit<LinearCon
 	
 	void setFactor(Double factor) {
 		unit.setFactor(factor);
+	}
+	
+	public Command setFactor(EditingDomain ed, Double factor) {
+		return SetCommand.create(ed, unit, QudvPackage.Literals.LINEAR_CONVERSION_UNIT__FACTOR, factor);
 	}
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitPrefixed.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitPrefixed.java
@@ -18,6 +18,14 @@ import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
 
 public class BeanUnitPrefixed extends ABeanConversionBasedUnit<PrefixedUnit> {
 	
+	public BeanUnitPrefixed() { 
+		super();
+	}
+	
+	public BeanUnitPrefixed(PrefixedUnit unit) {
+		super(unit);
+	}
+	
 	BeanPrefix getPrefixBean() {
 		return new BeanPrefix(unit.getPrefix());
 	}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitPrefixed.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitPrefixed.java
@@ -9,15 +9,24 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.model.concept.types.qudv;
 
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.command.SetCommand;
+import org.eclipse.emf.edit.domain.EditingDomain;
+
 import de.dlr.sc.virsat.model.dvlm.qudv.PrefixedUnit;
+import de.dlr.sc.virsat.model.dvlm.qudv.QudvPackage;
 
 public class BeanUnitPrefixed extends ABeanConversionBasedUnit<PrefixedUnit> {
 	
-	BeanPrefix getPrefix() {
+	BeanPrefix getPrefixBean() {
 		return new BeanPrefix(unit.getPrefix());
 	}
 	
 	void setPrefix(BeanPrefix beanPrefix) {
 		unit.setPrefix(beanPrefix.getPrefix());
+	}
+	
+	public Command setPrefix(EditingDomain ed, BeanPrefix beanPrefix) {
+		return SetCommand.create(ed, unit, QudvPackage.Literals.PREFIXED_UNIT__PREFIX, beanPrefix.getPrefix());
 	}
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitPrefixed.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitPrefixed.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.PrefixedUnit;
+
+public class BeanUnitPrefixed extends ABeanConversionBasedUnit<PrefixedUnit> {
+	
+	BeanPrefix getPrefix() {
+		return new BeanPrefix(unit.getPrefix());
+	}
+	
+	void setPrefix(BeanPrefix beanPrefix) {
+		unit.setPrefix(beanPrefix.getPrefix());
+	}
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitSimple.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitSimple.java
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import de.dlr.sc.virsat.model.dvlm.qudv.SimpleUnit;
+
+public class BeanUnitSimple extends ABeanUnit<SimpleUnit> {
+
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitSimple.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/BeanUnitSimple.java
@@ -13,4 +13,12 @@ import de.dlr.sc.virsat.model.dvlm.qudv.SimpleUnit;
 
 public class BeanUnitSimple extends ABeanUnit<SimpleUnit> {
 
+	public BeanUnitSimple() {
+		super();
+	}
+	
+	public BeanUnitSimple(SimpleUnit unit) {
+		super(unit);
+	}
+
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/IBeanConversionBasedUnit.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/IBeanConversionBasedUnit.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.domain.EditingDomain;
+
+public interface IBeanConversionBasedUnit {
+	
+	/**
+	 * Returns if the unit is invertible
+	 * @return Boolean
+	 */
+	Boolean getIsInvertible();
+	
+	/**
+	 * Set value of isInverible
+	 * @param isInverible
+	 */
+	void setIsInvertible(Boolean isInverible);
+	
+	/**
+	 * Set value of isInverible via EMF command
+	 * @param ed The EditingDomain in which the command should act.
+	 * @param isInverible
+	 * @return EMF command to set the quantityKind
+	 */
+	Command setIsInvertible(EditingDomain ed, Boolean isInverible);
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/IBeanQuantityKind.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/IBeanQuantityKind.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import de.dlr.sc.virsat.model.concept.types.IBeanName;
+import de.dlr.sc.virsat.model.concept.types.IBeanUuid;
+import de.dlr.sc.virsat.model.dvlm.qudv.AQuantityKind;
+
+public interface IBeanQuantityKind extends IBeanUuid, IBeanName {
+
+	/**
+	 * Get the quantityKind wrapped in this bean
+	 * @return quantityKind
+	 */
+	AQuantityKind getQuantityKind();
+	
+	/**
+	 * Set the quantityKind wrapped in this bean
+	 * @param quantityKind
+	 */
+	void setQuantityKind(AQuantityKind quantityKind);
+	
+	/**
+	 * Get the symbol of the wrapped unit
+	 * @return symbol
+	 */
+	String getSymbol();
+	
+	/**
+	 * Set the symbol of the wrapped unit
+	 * @param symbol
+	 */
+	void setSymbol(String symbol);
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/IBeanQuantityKind.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/IBeanQuantityKind.java
@@ -9,33 +9,56 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.model.concept.types.qudv;
 
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.domain.EditingDomain;
+
 import de.dlr.sc.virsat.model.concept.types.IBeanName;
 import de.dlr.sc.virsat.model.concept.types.IBeanUuid;
 import de.dlr.sc.virsat.model.dvlm.qudv.AQuantityKind;
 
-public interface IBeanQuantityKind extends IBeanUuid, IBeanName {
+public interface IBeanQuantityKind<QK_TYPE extends AQuantityKind> extends IBeanUuid, IBeanName {
 
+	/**
+	 * Get the concrete quantityKind wrapped in this bean
+	 * @return QK_TYPE
+	 */
+	QK_TYPE getQuantityKind();
+	
+	/**
+	 * Set the concrete quantityKind wrapped in this bean
+	 * @param QK_TYPE
+	 */
+	void setQuantityKind(QK_TYPE quantityKind);
+	
 	/**
 	 * Get the quantityKind wrapped in this bean
 	 * @return quantityKind
 	 */
-	AQuantityKind getQuantityKind();
+	AQuantityKind getAQuantityKind();
 	
 	/**
 	 * Set the quantityKind wrapped in this bean
 	 * @param quantityKind
 	 */
-	void setQuantityKind(AQuantityKind quantityKind);
+	void setAQuantityKind(AQuantityKind quantityKind);
 	
 	/**
-	 * Get the symbol of the wrapped unit
+	 * Get the symbol of the wrapped quantity kind
 	 * @return symbol
 	 */
 	String getSymbol();
 	
 	/**
-	 * Set the symbol of the wrapped unit
+	 * Set the symbol of the wrapped quantity kind
 	 * @param symbol
 	 */
 	void setSymbol(String symbol);
+	
+	/**
+	 * Set the symbol of the wrapped quantity kind
+	 * @param ed The EditingDomain in which the command should act.
+	 * @param symbol
+	 * @return EMF command to set the symbol
+	 */
+	Command setSymbol(EditingDomain ed, String symbol);
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/IBeanUnit.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/IBeanUnit.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 German Aerospace Center (DLR), Simulation and Software Technology, Germany.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package de.dlr.sc.virsat.model.concept.types.qudv;
+
+import de.dlr.sc.virsat.model.concept.types.IBeanName;
+import de.dlr.sc.virsat.model.concept.types.IBeanUuid;
+import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
+
+public interface IBeanUnit extends IBeanUuid, IBeanName {
+
+	/**
+	 * Get the unit wrapped in this bean
+	 * @return unit
+	 */
+	AUnit getUnit();
+	
+	/**
+	 * Set the unit wrapped in this bean
+	 * @param unit
+	 */
+	void setUnit(AUnit unit);
+	
+	/**
+	 * Get the symbol of the wrapped unit
+	 * @return symbol
+	 */
+	String getSymbol();
+	
+	/**
+	 * Set the symbol of the wrapped unit
+	 * @param symbol
+	 */
+	void setSymbol(String symbol);
+}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/IBeanUnit.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/IBeanUnit.java
@@ -14,6 +14,7 @@ import org.eclipse.emf.edit.domain.EditingDomain;
 
 import de.dlr.sc.virsat.model.concept.types.IBeanName;
 import de.dlr.sc.virsat.model.concept.types.IBeanUuid;
+import de.dlr.sc.virsat.model.dvlm.qudv.AQuantityKind;
 import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
 
 public interface IBeanUnit<U_TYPE extends AUnit> extends IBeanUuid, IBeanName {
@@ -61,4 +62,24 @@ public interface IBeanUnit<U_TYPE extends AUnit> extends IBeanUuid, IBeanName {
 	 * @return EMF command to set the symbol
 	 */
 	Command setSymbol(EditingDomain ed, String symbol);
+	
+	/**
+	 * Get the quantityKindBean
+	 * @return quantityKindBean bean wrapping a quantityKind
+	 */
+	IBeanQuantityKind<? extends AQuantityKind> getQuantityKindBean();
+	
+	/**
+	 * Set the quantityKind of the wrapped unit
+	 * @param quantityKindBean bean wrapping a quantityKind
+	 */
+	void setQuantityKindBean(IBeanQuantityKind<? extends AQuantityKind> quantityKindBean);
+	
+	/**
+	 * Set the quantityKind of the wrapped unit
+	 * @param ed The EditingDomain in which the command should act.
+	 * @param quantityKind
+	 * @return EMF command to set the quantityKind
+	 */
+	Command setQuantityKindBean(EditingDomain ed, IBeanQuantityKind<? extends AQuantityKind> quantityKindBean);
 }

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/IBeanUnit.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/qudv/IBeanUnit.java
@@ -9,23 +9,38 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.model.concept.types.qudv;
 
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.domain.EditingDomain;
+
 import de.dlr.sc.virsat.model.concept.types.IBeanName;
 import de.dlr.sc.virsat.model.concept.types.IBeanUuid;
 import de.dlr.sc.virsat.model.dvlm.qudv.AUnit;
 
-public interface IBeanUnit extends IBeanUuid, IBeanName {
+public interface IBeanUnit<U_TYPE extends AUnit> extends IBeanUuid, IBeanName {
 
 	/**
-	 * Get the unit wrapped in this bean
-	 * @return unit
+	 * Get the concrete unit wrapped in this bean
+	 * @return U_TYPE
 	 */
-	AUnit getUnit();
+	U_TYPE getUnit();
+	
+	/**
+	 * Set the concrete unit wrapped in this bean
+	 * @param U_TYPE
+	 */
+	void setUnit(U_TYPE unit);
+	
+	/**
+	 * Get the unit wrapped in this bean
+	 * @return AUnit
+	 */
+	AUnit getAUnit();
 	
 	/**
 	 * Set the unit wrapped in this bean
-	 * @param unit
+	 * @param AUnit
 	 */
-	void setUnit(AUnit unit);
+	void setAUnit(AUnit unit);
 	
 	/**
 	 * Get the symbol of the wrapped unit
@@ -38,4 +53,12 @@ public interface IBeanUnit extends IBeanUuid, IBeanName {
 	 * @param symbol
 	 */
 	void setSymbol(String symbol);
+	
+	/**
+	 * Set the symbol of the wrapped unit
+	 * @param ed The EditingDomain in which the command should act.
+	 * @param symbol
+	 * @return EMF command to set the symbol
+	 */
+	Command setSymbol(EditingDomain ed, String symbol);
 }


### PR DESCRIPTION
This is the first PR of a number of PRs to enable unit management via the server (see #980). This PR adds beans for qudv classes.

Added:
- Beans for units and quantity kinds
- Beans for factors and prefix
- Bean factories for unit and quantity kind beans
- Unit beans to existing unit property beans

Did not add beans for `Dimension`, `DimensionFactor` and `QuantityKind`, as I found no use case for these model Classes.

In a second PR these beans should be annotated and made available via the REST API.
