### PR TITLE
Use latest version of deploy ci-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -294,7 +294,7 @@ jobs:
       # Deploying to github releases
       # --------------------------------------------
       - name: Build - Deploy GH
-        uses: virtualsatellite/ci-actions/ci-deploy-gh-product-action@v3
+        uses: virtualsatellite/ci-actions/ci-deploy-gh-product-action@v4
         with:
           build_profile: ${{ steps.build_decision.outputs.build_type }}
           gh_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use the latest version of the deploy action to use latest github deploy API and also deploy documentation files to the Github Release page.

Closes #1025 