### PR TITLE
Fixing repeated conversion between UUID and String

### DIFF
--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/types/impl/VirSatUuid.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/types/impl/VirSatUuid.java
@@ -21,7 +21,7 @@ import java.util.UUID;
 public class VirSatUuid {
 	
 	public static final String UUID_NA = "VIRSAT-UUID-NO-UUID-YET-SET";
-	private String uuid;
+	private final String uuid;
 	
 	/**
 	 * COnstructor generating a random UUID

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/types/impl/VirSatUuid.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/types/impl/VirSatUuid.java
@@ -21,13 +21,13 @@ import java.util.UUID;
 public class VirSatUuid {
 	
 	public static final String UUID_NA = "VIRSAT-UUID-NO-UUID-YET-SET";
-	private UUID uuid;
+	private String uuid;
 	
 	/**
 	 * COnstructor generating a random UUID
 	 */
 	public VirSatUuid() {
-		this.uuid = UUID.randomUUID();
+		this.uuid = UUID.randomUUID().toString();
 	}
 	
 	/**
@@ -36,9 +36,9 @@ public class VirSatUuid {
 	 */
 	public VirSatUuid(String uuidString) {
 		if ((uuidString != null) && (!uuidString.isEmpty())) {
-			this.uuid = UUID.fromString(uuidString);
+			this.uuid = uuidString;
 		} else {
-			uuid = UUID.randomUUID();
+			uuid = UUID.randomUUID().toString();
 		}
 	}
 	


### PR DESCRIPTION
Improves the performance by reducing repeated conversions between instances of the UUID class and Strings.
VirSatUUIDs are now internally Strings and the UUID class is only used to generate the String.