### PR TITLE
Improved caching for getting eObjects from a DvlmXMIResource

### DIFF
--- a/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImplTest.java
+++ b/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImplTest.java
@@ -154,6 +154,13 @@ public class DvlmXMIResourceImplTest {
 		assertEquals("Found the correct concept", dynConcept, dynConceptById);
 		assertEquals("Found the correct category", dynCategory, dynCategoryById);
 		assertNull("No Object found", dynNothingById);
+		
+		// If we remove the object from the resource set,
+		// then it should no longer be found. Verifying this property
+		// to ensure that caching doesn't uncontained objects.
+		resource.getContents().remove(dynRepository);
+		dynCategoryById = resource.getEObjectByID("de.dlr.sc.virsat.test.concept.TC");
+		assertNull("No Object found", dynNothingById);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImplTest.java
+++ b/de.dlr.sc.virsat.model.test/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImplTest.java
@@ -159,7 +159,7 @@ public class DvlmXMIResourceImplTest {
 		// then it should no longer be found. Verifying this property
 		// to ensure that caching doesn't uncontained objects.
 		resource.getContents().remove(dynRepository);
-		dynCategoryById = resource.getEObjectByID("de.dlr.sc.virsat.test.concept.TC");
+		dynNothingById = resource.getEObjectByID("de.dlr.sc.virsat.test.concept.TC");
 		assertNull("No Object found", dynNothingById);
 	}
 

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImpl.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImpl.java
@@ -55,7 +55,9 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 			// There exists a cached object for this id
 			// If the object is also contained in this resource,
 			// then we can simply hand it back.
-			if (returnObject.eResource() == this) {
+			Resource containedResource = returnObject.eResource();
+			boolean isLoading = this.isLoading();
+			if (isLoading || containedResource == this) {
 				return returnObject;
 			} else {
 				// Otherwise, remove it from the cache and return null

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImpl.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImpl.java
@@ -53,7 +53,15 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 		EObject returnObject = super.getEObjectByID(id);
 		if (returnObject != null) {
 			// There exists a cached object for this id
-			return returnObject;
+			// If the object is also contained in this resource,
+			// then we can simply hand it back.
+			if (returnObject.eResource() == this) {
+				return returnObject;
+			} else {
+				// Otherwise, remove it from the cache and return null
+				getIntrinsicIDToEObjectMap().remove(id);
+				return null;
+			}
 		}
 
 		// It is possible, e.g. when migrating, that DynamicEObjects reference to another

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImpl.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImpl.java
@@ -57,24 +57,24 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 			EObject eObject = i.next();
 			// Only handle dynamic EObjects. Static EMF is handled as usual.
 			if (eObject instanceof DynamicEObjectImpl) {
-			    EClass eClass = eObject.eClass();
-			    EAttribute eIDAttribute = eClass.getEIDAttribute();
-		
-			    // if there is no ID attribute nothing more needs to be done
-			    if (eIDAttribute != null) {
-				    String fqnEAttributeCurrent = VirSatEcoreUtil.getFullQualifiedAttributeName(eIDAttribute);
-				    boolean isFqnEattributeFqn = fqnEAttributeCurrent.equals(fqnEAttributeFqn);
-		
-				    // In case the object is of type IQualifedName then we have to act as if we 
-				    // try to get the FQN using the static EMF model
-				    if (isFqnEattributeFqn) {
-				    	String eObjectId = ActiveConceptHelper.getFullQualifiedId(eObject);
-				    	if (id.equals(eObjectId)) {
-				    		setID(eObject, id);
-				    		return eObject;
-				    	}
-				    }
-			    }
+				EClass eClass = eObject.eClass();
+				EAttribute eIDAttribute = eClass.getEIDAttribute();
+
+				// if there is no ID attribute nothing more needs to be done
+				if (eIDAttribute != null) {
+					String fqnEAttributeCurrent = VirSatEcoreUtil.getFullQualifiedAttributeName(eIDAttribute);
+					boolean isFqnEattributeFqn = fqnEAttributeCurrent.equals(fqnEAttributeFqn);
+
+					// In case the object is of type IQualifedName then we have to act as if we
+					// try to get the FQN using the static EMF model
+					if (isFqnEattributeFqn) {
+						String eObjectId = ActiveConceptHelper.getFullQualifiedId(eObject);
+						if (id.equals(eObjectId)) {
+							setID(eObject, id);
+							return eObject;
+						}
+					}
+				}
 			}
 		}
 		
@@ -87,10 +87,10 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 	@Override
 	public String getURIFragment(EObject eObject) {
 		if (eObject instanceof DynamicEObjectImpl) {
-		    if (ActiveConceptHelper.isSafeAssignableFrom(GeneralPackage.Literals.IQUALIFIED_NAME, eObject)) {
-		    	String eObjectFqnId = ActiveConceptHelper.getFullQualifiedId(eObject);
-		    	return eObjectFqnId;
-		    }
+			if (ActiveConceptHelper.isSafeAssignableFrom(GeneralPackage.Literals.IQUALIFIED_NAME, eObject)) {
+				String eObjectFqnId = ActiveConceptHelper.getFullQualifiedId(eObject);
+				return eObjectFqnId;
+			}
 		}
 	
 		return super.getURIFragment(eObject);

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImpl.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImpl.java
@@ -9,6 +9,8 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.model.ecore.xmi.impl;
 
+import java.util.HashMap;
+
 import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EAttribute;
@@ -40,11 +42,12 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 	 */
 	public DvlmXMIResourceImpl(URI uri) {
 		super(uri);
+		setIntrinsicIDToEObjectMap(new HashMap<String, EObject>());
 	}
 
 	@Override
 	protected EObject getEObjectByID(String id) {
-		EObject returnObject = getIDToEObjectMap().get(id);
+		EObject returnObject = getIntrinsicIDToEObjectMap().get(id);
 		if (returnObject != null) {
 			// There exists a cached object for this id
 			return returnObject;
@@ -70,7 +73,7 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 					if (isFqnEattributeFqn) {
 						String eObjectId = ActiveConceptHelper.getFullQualifiedId(eObject);
 						if (id.equals(eObjectId)) {
-							setID(eObject, id);
+							getIntrinsicIDToEObjectMap().put(id, eObject);
 							return eObject;
 						}
 					}
@@ -80,7 +83,7 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 		
 		// All other calls are forwarded to the standard XMIResource functionality
 		returnObject = super.getEObjectByID(id);
-		setID(returnObject, id);
+		getIntrinsicIDToEObjectMap().put(id, returnObject);
 		return returnObject;
 	}
 	
@@ -94,5 +97,11 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 		}
 	
 		return super.getURIFragment(eObject);
+	}
+	
+	@Override
+	protected void doUnload() {
+		getIntrinsicIDToEObjectMap().clear();
+		super.doUnload();
 	}
 }

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImpl.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImpl.java
@@ -47,7 +47,7 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 
 	@Override
 	protected EObject getEObjectByID(String id) {
-		EObject returnObject = getIntrinsicIDToEObjectMap().get(id);
+		EObject returnObject = super.getEObjectByID(id);
 		if (returnObject != null) {
 			// There exists a cached object for this id
 			return returnObject;
@@ -56,6 +56,10 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 		final EAttribute eAttributeFqn = GeneralPackage.Literals.IQUALIFIED_NAME__FULL_QUALIFIED_NAME;
 		final String fqnEAttributeFqn = VirSatEcoreUtil.getFullQualifiedAttributeName(eAttributeFqn);
 		
+		
+		// It is possible, e.g. when migrating, that DynamicEObjects reference to another
+		// instance of the Ecore Model. Therefore even if an EObject and and DynamicEobject are
+		// of the same EClass, they will not be handled as such. Therefore we compare 
 		for (TreeIterator<EObject> i = getAllProperContents(getContents()); i.hasNext();) {			
 			EObject eObject = i.next();
 			// Only handle dynamic EObjects. Static EMF is handled as usual.
@@ -64,6 +68,8 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 				EAttribute eIDAttribute = eClass.getEIDAttribute();
 
 				// if there is no ID attribute nothing more needs to be done
+				// If the ID attribute is the same as from the interface IQualifiedName
+				// We can use it to retrieve the actual ID of the Object.
 				if (eIDAttribute != null) {
 					String fqnEAttributeCurrent = VirSatEcoreUtil.getFullQualifiedAttributeName(eIDAttribute);
 					boolean isFqnEattributeFqn = fqnEAttributeCurrent.equals(fqnEAttributeFqn);
@@ -81,9 +87,6 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 			}
 		}
 		
-		// All other calls are forwarded to the standard XMIResource functionality
-		returnObject = super.getEObjectByID(id);
-		getIntrinsicIDToEObjectMap().put(id, returnObject);
 		return returnObject;
 	}
 	

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImpl.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImpl.java
@@ -45,6 +45,9 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 		setIntrinsicIDToEObjectMap(new HashMap<String, EObject>());
 	}
 
+	private static final EAttribute E_ATTRIBUTE_FQN = GeneralPackage.Literals.IQUALIFIED_NAME__FULL_QUALIFIED_NAME;
+	private static final String FQN_E_ATTRIBUTE_FQN = VirSatEcoreUtil.getFullQualifiedAttributeName(E_ATTRIBUTE_FQN);
+	
 	@Override
 	protected EObject getEObjectByID(String id) {
 		EObject returnObject = super.getEObjectByID(id);
@@ -52,11 +55,7 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 			// There exists a cached object for this id
 			return returnObject;
 		}
-		
-		final EAttribute eAttributeFqn = GeneralPackage.Literals.IQUALIFIED_NAME__FULL_QUALIFIED_NAME;
-		final String fqnEAttributeFqn = VirSatEcoreUtil.getFullQualifiedAttributeName(eAttributeFqn);
-		
-		
+
 		// It is possible, e.g. when migrating, that DynamicEObjects reference to another
 		// instance of the Ecore Model. Therefore even if an EObject and and DynamicEobject are
 		// of the same EClass, they will not be handled as such. Therefore we compare 
@@ -72,7 +71,7 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 				// We can use it to retrieve the actual ID of the Object.
 				if (eIDAttribute != null) {
 					String fqnEAttributeCurrent = VirSatEcoreUtil.getFullQualifiedAttributeName(eIDAttribute);
-					boolean isFqnEattributeFqn = fqnEAttributeCurrent.equals(fqnEAttributeFqn);
+					boolean isFqnEattributeFqn = fqnEAttributeCurrent.equals(FQN_E_ATTRIBUTE_FQN);
 
 					// In case the object is of type IQualifedName then we have to act as if we
 					// try to get the FQN using the static EMF model

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImpl.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/ecore/xmi/impl/DvlmXMIResourceImpl.java
@@ -44,6 +44,12 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 
 	@Override
 	protected EObject getEObjectByID(String id) {
+		EObject returnObject = getIDToEObjectMap().get(id);
+		if (returnObject != null) {
+			// There exists a cached object for this id
+			return returnObject;
+		}
+		
 		final EAttribute eAttributeFqn = GeneralPackage.Literals.IQUALIFIED_NAME__FULL_QUALIFIED_NAME;
 		final String fqnEAttributeFqn = VirSatEcoreUtil.getFullQualifiedAttributeName(eAttributeFqn);
 		
@@ -64,6 +70,7 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 				    if (isFqnEattributeFqn) {
 				    	String eObjectId = ActiveConceptHelper.getFullQualifiedId(eObject);
 				    	if (id.equals(eObjectId)) {
+				    		setID(eObject, id);
 				    		return eObject;
 				    	}
 				    }
@@ -72,7 +79,9 @@ public class DvlmXMIResourceImpl extends XMIResourceImpl implements Resource {
 		}
 		
 		// All other calls are forwarded to the standard XMIResource functionality
-		return super.getEObjectByID(id);
+		returnObject = super.getEObjectByID(id);
+		setID(returnObject, id);
+		return returnObject;
 	}
 	
 	@Override


### PR DESCRIPTION
- Using the intrinsic caching map from ResourceImpl to cache all objects, including eObjects not handled by emf caching
- Moved computation of static strings into a static constant
- Applied some whitespace fixes
- Extended the test case to check that the cache is invalidated correctly when an object is removed from a resource