### PR TITLE
Deploy jakarta.activation - Task #1062

### DIFF
--- a/de.dlr.sc.virsat.model.feature/feature.xml
+++ b/de.dlr.sc.virsat.model.feature/feature.xml
@@ -120,4 +120,11 @@ by German Aerospace Center (DLR e.V.)
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="jakarta.activation"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
- Deploy jakarta.activation plugin in model.feature since it deploys jersey but jersey requires jakarta.activation
- Otherwise the concept tools cannot be installed into an IDE due to the missing jakarta.acivatation plugin, since model.edit in return requires jersey