### PR TITLE
Don't show toBeVerified UI in existenceVerification - Task #1107

### DIFF
--- a/de.dlr.sc.virsat.model.extension.requirements.ui/src/de/dlr/sc/virsat/model/extension/requirements/ui/snippet/UiSnippetSectionExistenceVerification.java
+++ b/de.dlr.sc.virsat.model.extension.requirements.ui/src/de/dlr/sc/virsat/model/extension/requirements/ui/snippet/UiSnippetSectionExistenceVerification.java
@@ -9,6 +9,16 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.model.extension.requirements.ui.snippet;
 
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.edit.domain.EditingDomain;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.forms.widgets.FormToolkit;
+
+import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.AProperty;
+import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
+import de.dlr.sc.virsat.model.extension.requirements.model.ExistenceVerification;
 import de.dlr.sc.virsat.uiengine.ui.editor.snippets.IUiSnippet;
 
 
@@ -21,4 +31,24 @@ import de.dlr.sc.virsat.uiengine.ui.editor.snippets.IUiSnippet;
  * 
  */
 public class UiSnippetSectionExistenceVerification extends AUiSnippetSectionExistenceVerification implements IUiSnippet {
+	
+	@Override
+	public void createSwt(FormToolkit toolkit, EditingDomain editingDomain, Composite composite, EObject initModel) {
+		super.createSwt(toolkit, editingDomain, composite, initModel);
+		initializeHelperForModel(initModel);
+
+		Composite sectionBody = createSectionBody(toolkit, SECTION_HEADING, null, 1);
+		sectionBody.setLayout(new GridLayout(UI_LAYOUT_NR_COLUMNS, false));
+
+		Category viewerCategory = acHelper.getCategory(conceptId, categoryId);
+
+		// Don't show property elementsToBeVerified as it is not relvant for the user (only for verification)
+		for (AProperty property : ActiveConceptHelper.getNonArrayProperties(viewerCategory)) {
+			if (!property.getName().equals(ExistenceVerification.PROPERTY_ELEMENTTOBEVERIFIED)) {
+				createCommonPropertyWidgets(toolkit, sectionBody, property);
+				createCustomPropertyWidgets(toolkit, editingDomain, sectionBody, property);
+			}
+		}
+	}
+	
 }

--- a/de.dlr.sc.virsat.model.extension.requirements.ui/src/de/dlr/sc/virsat/model/extension/requirements/ui/snippet/UiSnippetSectionExistenceVerification.java
+++ b/de.dlr.sc.virsat.model.extension.requirements.ui/src/de/dlr/sc/virsat/model/extension/requirements/ui/snippet/UiSnippetSectionExistenceVerification.java
@@ -9,15 +9,11 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.model.extension.requirements.ui.snippet;
 
-import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.edit.domain.EditingDomain;
-import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 
-import de.dlr.sc.virsat.model.dvlm.categories.Category;
 import de.dlr.sc.virsat.model.dvlm.categories.propertydefinitions.AProperty;
-import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
 import de.dlr.sc.virsat.model.extension.requirements.model.ExistenceVerification;
 import de.dlr.sc.virsat.uiengine.ui.editor.snippets.IUiSnippet;
 
@@ -33,21 +29,17 @@ import de.dlr.sc.virsat.uiengine.ui.editor.snippets.IUiSnippet;
 public class UiSnippetSectionExistenceVerification extends AUiSnippetSectionExistenceVerification implements IUiSnippet {
 	
 	@Override
-	public void createSwt(FormToolkit toolkit, EditingDomain editingDomain, Composite composite, EObject initModel) {
-		super.createSwt(toolkit, editingDomain, composite, initModel);
-		initializeHelperForModel(initModel);
-
-		Composite sectionBody = createSectionBody(toolkit, SECTION_HEADING, null, 1);
-		sectionBody.setLayout(new GridLayout(UI_LAYOUT_NR_COLUMNS, false));
-
-		Category viewerCategory = acHelper.getCategory(conceptId, categoryId);
-
-		// Don't show property elementsToBeVerified as it is not relvant for the user (only for verification)
-		for (AProperty property : ActiveConceptHelper.getNonArrayProperties(viewerCategory)) {
-			if (!property.getName().equals(ExistenceVerification.PROPERTY_ELEMENTTOBEVERIFIED)) {
-				createCommonPropertyWidgets(toolkit, sectionBody, property);
-				createCustomPropertyWidgets(toolkit, editingDomain, sectionBody, property);
-			}
+	protected void createCommonPropertyWidgets(FormToolkit toolkit, Composite sectionBody, AProperty property) {
+		if (!property.getName().equals(ExistenceVerification.PROPERTY_ELEMENTTOBEVERIFIED)) {
+			super.createCommonPropertyWidgets(toolkit, sectionBody, property);
+		}
+	}
+	
+	@Override
+	protected void createCustomPropertyWidgets(FormToolkit toolkit, EditingDomain editingDomain, Composite sectionBody,
+			AProperty property) {
+		if (!property.getName().equals(ExistenceVerification.PROPERTY_ELEMENTTOBEVERIFIED)) {
+			super.createCustomPropertyWidgets(toolkit, editingDomain, sectionBody, property);
 		}
 	}
 	

--- a/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/editor/snippets/AUiSnippetGenericPropertyInstances.java
+++ b/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/editor/snippets/AUiSnippetGenericPropertyInstances.java
@@ -261,7 +261,7 @@ public abstract class AUiSnippetGenericPropertyInstances extends AUiCategorySect
 	 * @param property
 	 *            the property on which these widgets should act
 	 */
-	private void createCommonPropertyWidgets(FormToolkit toolkit, Composite sectionBody, AProperty property) {
+	protected void createCommonPropertyWidgets(FormToolkit toolkit, Composite sectionBody, AProperty property) {
 		Label labelPropertyIcon = toolkit.createLabel(sectionBody, "");
 		labelPropertyIcon.setLayoutData(new GridData());
 		Image dummyImage = mip.getOkImage();


### PR DESCRIPTION
Don't show property elementsToBeVerified as it is not relvant for the user (only for verification engine)

Closes #1107 