### PR TITLE
Enable creation of self-loops in state machines

### DIFF
--- a/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/StateMachineDiagramToolBehaviorProvider.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/StateMachineDiagramToolBehaviorProvider.java
@@ -9,9 +9,12 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.model.extension.statemachines.ui.diagram;
 
+import org.eclipse.graphiti.datatypes.ILocation;
 import org.eclipse.graphiti.dt.IDiagramTypeProvider;
 import org.eclipse.graphiti.features.context.IDoubleClickContext;
 import org.eclipse.graphiti.features.custom.ICustomFeature;
+import org.eclipse.graphiti.mm.algorithms.GraphicsAlgorithm;
+import org.eclipse.graphiti.mm.algorithms.styles.Point;
 import org.eclipse.graphiti.tb.DefaultToolBehaviorProvider;
 import org.eclipse.graphiti.tb.IToolBehaviorProvider;
 
@@ -37,6 +40,22 @@ public class StateMachineDiagramToolBehaviorProvider extends DefaultToolBehavior
 			return customFeature;
 		}
 		return super.getDoubleClickFeature(context);
+	}
+	
+	/**
+	 * Transform a relative point to an absolute point by placing it relative to the
+	 * given element.
+	 * @param point
+	 * @param ga
+	 */
+	public void placeRelativeTo(Point point, GraphicsAlgorithm ga) {
+		ILocation peLocation = getAbsoluteLocation(ga);
+		
+		int relX = point.getX();
+		int relY = point.getY();
+		
+		point.setX(peLocation.getX() + relX);
+		point.setY(peLocation.getY() + relY);
 	}
 
 }

--- a/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/abstractConnection/AbstractConnectionCreateFeature.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/abstractConnection/AbstractConnectionCreateFeature.java
@@ -80,7 +80,7 @@ public abstract class AbstractConnectionCreateFeature  extends AbstractCreateCon
 			return false;
 		}
 		boolean candDraw = canDraw(state1, state2);
-		if (source instanceof State && target instanceof State && source != target && candDraw) {	
+		if (source instanceof State && target instanceof State && candDraw) {	
 			State s = (State) source;
 			return DiagramHelper.hasBothWritePermission(s.getTypeInstance(), sourceAnchor);
 		}


### PR DESCRIPTION
- When creating transitions using the state-machine diagram editor, a state can now be select both as source state and as target state of a transition (by clicking on the same state twice), resulting in a self-loop.
- Bend points are automatically created on a loop transition to improve visibility and usability.