### PR TITLE
Feature/1146 change default drag drop behavior for product structures

### DIFF
--- a/de.dlr.sc.virsat.model.extension.ps.ui/src/de/dlr/sc/virsat/model/extension/ps/ui/dropAdapter/ProductStructureInheritanceDropAdapterAssistant.java
+++ b/de.dlr.sc.virsat.model.extension.ps.ui/src/de/dlr/sc/virsat/model/extension/ps/ui/dropAdapter/ProductStructureInheritanceDropAdapterAssistant.java
@@ -45,8 +45,7 @@ public class ProductStructureInheritanceDropAdapterAssistant extends DVLMDefault
 	@Override
 	protected Command createDropCommand(VirSatTransactionalEditingDomain ed, Collection<Object> dragObjects, int operation, EObject dropObject) {
 		try {
-			// Product Structure DND Operations only if ALT is pressed with drag and drop
-			if ((operation == DND.DROP_LINK) && (dropObject instanceof StructuralElementInstance)) {
+			if ((operation == DND.DROP_MOVE || operation == DND.DROP_COPY) && (dropObject instanceof StructuralElementInstance)) {
 				StructuralElementInstance dropSei = (StructuralElementInstance) dropObject;
 				IBeanStructuralElementInstance dopBeanSei = bsf.getInstanceFor(dropSei);
 				Command createSeiAndAddInheritanceCommand = psDndCommandHelper.createDropCommand(ed, dragObjects, dopBeanSei);

--- a/de.dlr.sc.virsat.project.test/src/de/dlr/sc/virsat/project/editingDomain/commands/dnd/VirSatDragAndDropInheritanceCommandHelperTest.java
+++ b/de.dlr.sc.virsat.project.test/src/de/dlr/sc/virsat/project/editingDomain/commands/dnd/VirSatDragAndDropInheritanceCommandHelperTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import de.dlr.sc.virsat.model.dvlm.structural.StructuralElement;
 import de.dlr.sc.virsat.model.dvlm.structural.StructuralElementInstance;
 import de.dlr.sc.virsat.model.dvlm.structural.StructuralFactory;
-import de.dlr.sc.virsat.project.editingDomain.commands.dnd.VirSatDragAndDropInheritanceCommandHelper.DndOperation;
 import de.dlr.sc.virsat.project.test.AProjectTestCase;
 
 public class VirSatDragAndDropInheritanceCommandHelperTest extends AProjectTestCase {
@@ -65,7 +64,6 @@ public class VirSatDragAndDropInheritanceCommandHelperTest extends AProjectTestC
 		VirSatDragAndDropInheritanceCommandHelper.createDropCommand(
 				editingDomain,
 				Collections.singleton(seiTypeA1),
-				DndOperation.REPLACE_INHERITANCE,
 				seiTypeC
 		).execute();
 		
@@ -75,7 +73,6 @@ public class VirSatDragAndDropInheritanceCommandHelperTest extends AProjectTestC
 		VirSatDragAndDropInheritanceCommandHelper.createDropCommand(
 				editingDomain,
 				Collections.singleton(seiTypeB1),
-				DndOperation.REPLACE_INHERITANCE,
 				seiTypeC
 		).execute();
 		
@@ -85,7 +82,6 @@ public class VirSatDragAndDropInheritanceCommandHelperTest extends AProjectTestC
 		VirSatDragAndDropInheritanceCommandHelper.createDropCommand(
 				editingDomain,
 				Collections.singleton(seiTypeA2),
-				DndOperation.REPLACE_INHERITANCE,
 				seiTypeC
 		).execute();
 		
@@ -95,44 +91,10 @@ public class VirSatDragAndDropInheritanceCommandHelperTest extends AProjectTestC
 		VirSatDragAndDropInheritanceCommandHelper.createDropCommand(
 				editingDomain,
 				Collections.singleton(seiTypeB2),
-				DndOperation.REPLACE_INHERITANCE,
 				seiTypeC
 		).execute();
 		
 		assertThat("List of inheritance objects is correct", seiTypeC.getSuperSeis(), contains(seiTypeA2, seiTypeB2));
-	}
-	
-	@Test
-	public void testCreateDropCommandAddInheritance() {
-		// Adding A1 as first one		
-		VirSatDragAndDropInheritanceCommandHelper.createDropCommand(
-				editingDomain,
-				Collections.singleton(seiTypeA1),
-				DndOperation.ADD_INHERITANCE,
-				seiTypeC
-		).execute();
-		
-		assertThat("List of inheritance objects is correct", seiTypeC.getSuperSeis(), contains(seiTypeA1));
-		
-		// Adding B1 as second one
-		VirSatDragAndDropInheritanceCommandHelper.createDropCommand(
-				editingDomain,
-				Collections.singleton(seiTypeB1),
-				DndOperation.ADD_INHERITANCE,
-				seiTypeC
-		).execute();
-		
-		assertThat("List of inheritance objects is correct", seiTypeC.getSuperSeis(), contains(seiTypeA1, seiTypeB1));
-		
-		// Adding A2 as third one, should not replace A1
-		VirSatDragAndDropInheritanceCommandHelper.createDropCommand(
-				editingDomain,
-				Collections.singleton(seiTypeA2),
-				DndOperation.ADD_INHERITANCE,
-				seiTypeC
-		).execute();
-	
-		assertThat("List of inheritance objects is correct", seiTypeC.getSuperSeis(), contains(seiTypeA1, seiTypeB1, seiTypeA2));
 	}
 	
 	@Test
@@ -141,7 +103,6 @@ public class VirSatDragAndDropInheritanceCommandHelperTest extends AProjectTestC
 		Command invalidInheritanceDropCommand = VirSatDragAndDropInheritanceCommandHelper.createDropCommand(
 				editingDomain,
 				Collections.singleton(seiTypeA1),
-				DndOperation.ADD_INHERITANCE,
 				seiTypeB1
 		);
 				

--- a/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/navigator/dropAssist/DVLMDefaultInheritanceDropAdapterAssistant.java
+++ b/de.dlr.sc.virsat.project.ui/src/de/dlr/sc/virsat/project/ui/navigator/dropAssist/DVLMDefaultInheritanceDropAdapterAssistant.java
@@ -21,7 +21,6 @@ import org.eclipse.swt.dnd.DND;
 
 import de.dlr.sc.virsat.project.editingDomain.VirSatTransactionalEditingDomain;
 import de.dlr.sc.virsat.project.editingDomain.commands.dnd.VirSatDragAndDropInheritanceCommandHelper;
-import de.dlr.sc.virsat.project.editingDomain.commands.dnd.VirSatDragAndDropInheritanceCommandHelper.DndOperation;
 import de.dlr.sc.virsat.project.ui.navigator.util.VirSatSelectionHelper;
 
 /**
@@ -39,15 +38,8 @@ public class DVLMDefaultInheritanceDropAdapterAssistant extends ADVLMDropAdapate
 	
 	@Override
 	protected Command createDropCommand(VirSatTransactionalEditingDomain ed, Collection<Object> dragObjects, int operation, EObject dropObject) {
-		if (operation == DND.DROP_COPY || operation == DND.DROP_MOVE) {
-			return VirSatDragAndDropInheritanceCommandHelper.createDropCommand(
-					ed,
-					dragObjects,
-					(operation == DND.DROP_COPY)
-						? DndOperation.ADD_INHERITANCE
-						: DndOperation.REPLACE_INHERITANCE,
-					dropObject
-			);
+		if (operation == DND.DROP_LINK) {
+			return VirSatDragAndDropInheritanceCommandHelper.createDropCommand(ed, dragObjects, dropObject);
 		} else {
 			return UnexecutableCommand.INSTANCE;
 		}

--- a/de.dlr.sc.virsat.project/src/de/dlr/sc/virsat/project/editingDomain/commands/dnd/VirSatDragAndDropInheritanceCommandHelper.java
+++ b/de.dlr.sc.virsat.project/src/de/dlr/sc/virsat/project/editingDomain/commands/dnd/VirSatDragAndDropInheritanceCommandHelper.java
@@ -35,7 +35,6 @@ public class VirSatDragAndDropInheritanceCommandHelper {
 	 * Call this method to create a command to add or replace the SEI in the list of superSEIs
 	 * @param ed The editing domain for which the command should be created
 	 * @param dragObjects the object which is dragged and shall be used for replacing
-	 * @param dropOperation the kind of operation
 	 * @param dropObject the SEI where the superSEIs should be changed
 	 * @return The command to add or replace a superSEI
 	 */

--- a/de.dlr.sc.virsat.project/src/de/dlr/sc/virsat/project/editingDomain/commands/dnd/VirSatDragAndDropInheritanceCommandHelper.java
+++ b/de.dlr.sc.virsat.project/src/de/dlr/sc/virsat/project/editingDomain/commands/dnd/VirSatDragAndDropInheritanceCommandHelper.java
@@ -31,11 +31,6 @@ public class VirSatDragAndDropInheritanceCommandHelper {
 	private VirSatDragAndDropInheritanceCommandHelper() {
 	}
 	
-	public enum DndOperation {
-		REPLACE_INHERITANCE,
-		ADD_INHERITANCE
-	}
-	
 	/**
 	 * Call this method to create a command to add or replace the SEI in the list of superSEIs
 	 * @param ed The editing domain for which the command should be created
@@ -44,7 +39,7 @@ public class VirSatDragAndDropInheritanceCommandHelper {
 	 * @param dropObject the SEI where the superSEIs should be changed
 	 * @return The command to add or replace a superSEI
 	 */
-	public static Command createDropCommand(EditingDomain ed, Collection<Object> dragObjects, DndOperation dropOperation, Object dropObject) {
+	public static Command createDropCommand(EditingDomain ed, Collection<Object> dragObjects, Object dropObject) {
 		Object dragObject = dragObjects.iterator().next();
 		if (dragObject instanceof StructuralElementInstance && dropObject instanceof StructuralElementInstance) {
 			StructuralElementInstance dragSei = (StructuralElementInstance) dragObject;
@@ -53,40 +48,35 @@ public class VirSatDragAndDropInheritanceCommandHelper {
 			// Get type of drop object
 			StructuralElement dragSeType = dragSei.getType();
 
-			switch (dropOperation) {
-				case REPLACE_INHERITANCE:
-					// When replacing the rule is as follows:
-					// 1. Identify the type of the object to be dropped as new type
-					// 2. See if there is an inheritance to a SEI of the identified type.
-					// 3. If yes replace it.
-					// 4. If not than add the drop object as new inheritance.
-					
-					// try to identify Type of drop object in the given list of superSeis.
-					for (StructuralElementInstance dropSuperSei : dropSei.getSuperSeis()) {
-						if (dropSuperSei.getType().equals(dragSeType)) {
-							Command replaceCommand = ReplaceCommand.create(
-								ed,
-								dropSei,
-								InheritancePackage.eINSTANCE.getIInheritsFrom_SuperSeis(),
-								dropSuperSei,
-								Collections.singleton(dragSei)
-							);
-							return replaceCommand;
-						}
-					}
-				// if there is no SEI found that can be replaced continue with adding the dependency
-				case ADD_INHERITANCE:
-					// None found, then add it
-					Command addCommand = AddCommand.create(
+			// When replacing the rule is as follows:
+			// 1. Identify the type of the object to be dropped as new type
+			// 2. See if there is an inheritance to a SEI of the identified type.
+			// 3. If yes replace it.
+			// 4. If not than add the drop object as new inheritance.
+			
+			// try to identify Type of drop object in the given list of superSeis.
+			for (StructuralElementInstance dropSuperSei : dropSei.getSuperSeis()) {
+				if (dropSuperSei.getType().equals(dragSeType)) {
+					Command replaceCommand = ReplaceCommand.create(
 						ed,
 						dropSei,
-						InheritancePackage.Literals.IINHERITS_FROM__SUPER_SEIS,
+						InheritancePackage.eINSTANCE.getIInheritsFrom_SuperSeis(),
+						dropSuperSei,
 						Collections.singleton(dragSei)
 					);
-					return addCommand;
-				default:
-					break;
+					return replaceCommand;
+				}
 			}
+			
+			// if there is no SEI found that can be replaced continue with adding the dependency
+			// None found, then add it
+			Command addCommand = AddCommand.create(
+				ed,
+				dropSei,
+				InheritancePackage.Literals.IINHERITS_FROM__SUPER_SEIS,
+				Collections.singleton(dragSei)
+			);
+			return addCommand;
 		} 
 		return UnexecutableCommand.INSTANCE;
 	}	

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ASwtBotTestCase.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/ASwtBotTestCase.java
@@ -601,7 +601,13 @@ public class ASwtBotTestCase {
 	protected void openCorePerspective() {
 		bot.menu("Window").menu("Perspective").menu("Open Perspective").menu("Other...").click();
 		waitForEditingDomainAndUiThread();
-		bot.table().select("VirSat - Core (default)");
+
+		try {
+			bot.table().select("VirSat - Core (default)");
+		} catch (IllegalArgumentException e) {
+			bot.table().select("VirSat - Core");
+		}
+		
 		bot.button("Open").click();
 		waitForEditingDomainAndUiThread(); 
 	}

--- a/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/InheritanceTest.java
+++ b/de.dlr.sc.virsat.swtbot.test/src/de/dlr/sc/virsat/swtbot/test/InheritanceTest.java
@@ -11,8 +11,6 @@ package de.dlr.sc.virsat.swtbot.test;
 
 import static org.eclipse.swtbot.swt.finder.SWTBotAssert.assertNotEnabled;
 import static org.eclipse.swtbot.swt.finder.SWTBotAssert.assertText;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.collection.IsArrayWithSize.arrayWithSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -190,36 +188,17 @@ public class InheritanceTest extends ASwtBotTestCase {
 	}
 	
 	@Test
-	public void inheritanceTypingDragAndDrop() {
-		rename(elementConfiguration, "ec_1");
-		SWTBotTreeItem elementConfiguration2 = addElement(ElementConfiguration.class, conceptPs, configurationTree);
-		rename(elementConfiguration2, "ec_2");
-		
-		SWTBotTreeItem documentEc1 = addElement(Document.class, conceptPs, elementConfiguration);
-		SWTBotTreeItem documentEc2 = addElement(Document.class, conceptPs, elementConfiguration2);
-
-		openEditor(documentEc1);  
-		setText(Document.PROPERTY_DOCUMENTNAME, "docFromEc1");
-
-		openEditor(documentEc2);
-		setText(Document.PROPERTY_DOCUMENTNAME, "docFromEc2");
-		
-		// There are no documents yet with the ElementOccurrence
-		assertThat("There is only the documents folder", elementOccurence.getItems(), arrayWithSize(1));
-		
-		// Now drag the first inheritance
-		elementConfiguration.dragAndDrop(elementOccurence);
+	public void inheritingInstanceDragAndDrop() {
+		openEditor(document);
+		setText(Document.PROPERTY_DOCUMENTNAME, "docFromEd");
 		buildCounter.executeInterlocked(() -> bot.saveAllEditors());
 		
-		openEditor(elementOccurence);
-		assertEquals("Received override from EC1", "docFromEc1", bot.tableWithId("tableDocument").cell(0, Document.PROPERTY_DOCUMENTNAME));
-		
-		// now drag the other and verify
-		elementConfiguration2.dragAndDrop(elementOccurence);
+		elementDefinition.dragAndDrop(configurationTree);
 		buildCounter.executeInterlocked(() -> bot.saveAllEditors());
 		
-		openEditor(elementOccurence);
-		assertEquals("Received override from EC2", "docFromEc2", bot.tableWithId("tableDocument").cell(0, Document.PROPERTY_DOCUMENTNAME));
+		var newElementConfiguration = configurationTree.getNode("EC: ElementDefinition");
+		openEditor(newElementConfiguration);
+		assertEquals("Received override from ED", "docFromEd", bot.tableWithId("tableDocument").cell(0, Document.PROPERTY_DOCUMENTNAME));
 	}
 	
 	@Test


### PR DESCRIPTION
This change swaps the standard drag-and-drop behavior and the modified behavior.

Dragging an element from one tree to another now creates a new instance that inherits from the dragged element. The creation of inheritance links is now accomplished by dragging and dropping while holding the ALT-key.

Closes #1146 