### PR TITLE
Bug fix: Equations do not open if element is inherited and equations cannot be overwritten

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -6,6 +6,7 @@ andriikovalov-dlr <andrii.kovalov@dlr.de>		kova_an <kova_an@SC-010213.intra.dlr.
 
 franzTobiasDLR <tobias.franz@dlr.de>			franzTobiasDLR <49645871+franzTobiasDLR@users.noreply.github.com>
 franzTobiasDLR <tobias.franz@dlr.de>			Tobias Franz <tobias.franz@dlr.de>
+franzTobiasDLR <tobias.franz@dlr.de>			fran_tb <fran_tb@SC-010209.intra.dlr.de>
 
 SaMuellerDLR <sa.mueller@dlr.de>				Müller, Sascha ( SC-SRV ) <sa.mueller@dlr.de>
 SaMuellerDLR <sa.mueller@dlr.de>				SaMuellerDLR <48356419+SaMuellerDLR@users.noreply.github.com>

--- a/de.dlr.sc.virsat.model.calculation.ui/META-INF/MANIFEST.MF
+++ b/de.dlr.sc.virsat.model.calculation.ui/META-INF/MANIFEST.MF
@@ -23,7 +23,10 @@ Require-Bundle: de.dlr.sc.virsat.model,
  org.eclipse.compare,
  org.eclipse.core.expressions,
  org.eclipse.xtend.lib;bundle-version="2.14.0";resolution:=optional,
- org.eclipse.ui.editors
+ org.eclipse.ui.editors,
+ org.eclipse.emf.databinding.edit,
+ org.eclipse.core.databinding.property,
+ org.eclipse.jface.databinding
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: de.dlr.sc.virsat.model.calculation.ui.contentassist,

--- a/de.dlr.sc.virsat.model.calculation.ui/src/de/dlr/sc/virsat/model/calculation/ui/editor/EquationSectionUriEditorInput.java
+++ b/de.dlr.sc.virsat.model.calculation.ui/src/de/dlr/sc/virsat/model/calculation/ui/editor/EquationSectionUriEditorInput.java
@@ -40,6 +40,7 @@ import de.dlr.sc.virsat.model.dvlm.calculation.CalculationPackage;
 import de.dlr.sc.virsat.model.dvlm.calculation.EquationSection;
 import de.dlr.sc.virsat.model.dvlm.calculation.IEquationSectionContainer;
 import de.dlr.sc.virsat.model.dvlm.general.IName;
+import de.dlr.sc.virsat.model.dvlm.inheritance.IInheritanceLink;
 import de.dlr.sc.virsat.project.editingDomain.VirSatEditingDomainRegistry;
 import de.dlr.sc.virsat.project.editingDomain.VirSatTransactionalEditingDomain;
 import de.dlr.sc.virsat.project.resources.VirSatResourceSet;
@@ -351,6 +352,14 @@ public class EquationSectionUriEditorInput extends FileEditorInput implements IP
 		try {
 			this.equationSection = equationSection;
 			this.equationSection.setSerializedStatements(serializedEquations);
+			
+			// If the equation editor was opened & saved on a inherited CA, set the overwrite flag so that the equations are not overwritten by the inheritance builder 
+			if (equationSectionContainer instanceof IInheritanceLink) {
+				if (!((IInheritanceLink) equationSectionContainer).getSuperTis().isEmpty()) {
+					this.equationSection.setOverride(true);
+				}
+			}
+
 			Command setEquationSection = SetCommand.create(editingDomain, equationSectionContainer, CalculationPackage.Literals.IEQUATION_SECTION_CONTAINER__EQUATION_SECTION, equationSection);
 			editingDomain.getCommandStack().execute(setEquationSection);
 			

--- a/de.dlr.sc.virsat.model.calculation.ui/src/de/dlr/sc/virsat/model/calculation/ui/editor/snippet/UiSnippetEquations.java
+++ b/de.dlr.sc.virsat.model.calculation.ui/src/de/dlr/sc/virsat/model/calculation/ui/editor/snippet/UiSnippetEquations.java
@@ -229,9 +229,7 @@ public class UiSnippetEquations extends AUiSnippetEStructuralFeatureTable implem
 				Command addCommand = AddCommand.create(editingDomain, equationSectionContainer, CalculationPackage.eINSTANCE.getEquationSection_Equations(), newEquation);
 				editingDomain.getCommandStack().execute(addCommand);
 				setTableViewerInput(editingDomain);
-				//new WizardDialog(PlatformUI.getWorkbench().getDisplay().getActiveShell(), new QudvUnitSetupWizard((UnitManagement) model)).open();
-				// the wizard guides the user through the possible steps to add a unit
-				// at the end, on the performFinish() method it executes a cmd over the commandStack which ends the new unit in the proper way.
+				OpenEquationSectionHandler.openXtextEquationEditor(model);
 			}
 
 			@Override

--- a/de.dlr.sc.virsat.model.calculation.ui/src/de/dlr/sc/virsat/model/calculation/ui/editor/snippet/UiSnippetEquations.java
+++ b/de.dlr.sc.virsat.model.calculation.ui/src/de/dlr/sc/virsat/model/calculation/ui/editor/snippet/UiSnippetEquations.java
@@ -318,7 +318,8 @@ public class UiSnippetEquations extends AUiSnippetEStructuralFeatureTable implem
 				@Override
 				public void widgetSelected(SelectionEvent e) {
 					IEquationSectionContainer container = (IEquationSectionContainer) model;
-					Command cmd = SetCommand.create(editingDomain, container.getEquationSection(), InheritancePackage.Literals.IOVERRIDABLE_INHERITANCE_LINK__OVERRIDE, buttonPropertyOverride.getSelection());
+					Command cmd = SetCommand.create(editingDomain, container.getEquationSection(), 
+							InheritancePackage.Literals.IOVERRIDABLE_INHERITANCE_LINK__OVERRIDE, buttonPropertyOverride.getSelection());
 					editingDomain.getCommandStack().execute(cmd);
 				} 
 					
@@ -392,6 +393,9 @@ public class UiSnippetEquations extends AUiSnippetEStructuralFeatureTable implem
 		}
 	}
 	
+	/**
+	 * Update the state of the overwrite flag from any model change that might happen when equations are changed
+	 */
 	private void updateState() {
 		IEquationSectionContainer container = (IEquationSectionContainer) this.model;
 		if (buttonPropertyOverride != null && !buttonPropertyOverride.isDisposed()) {

--- a/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/serializer/EquationTransientValueService.java
+++ b/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/serializer/EquationTransientValueService.java
@@ -51,7 +51,9 @@ public class EquationTransientValueService extends DefaultTransientValueService 
 		}
 		
 		// We do not serialize the superTIs reference.
-		if (feature.equals(InheritancePackage.Literals.IINHERITANCE_LINK__SUPER_TIS) || feature.equals(InheritancePackage.Literals.IINHERITANCE_LINK__IS_INHERITED)) {
+		if (feature.equals(InheritancePackage.Literals.IINHERITANCE_LINK__SUPER_TIS) 
+				|| feature.equals(InheritancePackage.Literals.IINHERITANCE_LINK__IS_INHERITED)
+				|| feature.equals(InheritancePackage.Literals.IOVERRIDABLE_INHERITANCE_LINK__OVERRIDE)) {
 			return true;
 		}
 		

--- a/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/serializer/EquationTransientValueService.java
+++ b/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/serializer/EquationTransientValueService.java
@@ -50,7 +50,7 @@ public class EquationTransientValueService extends DefaultTransientValueService 
 			return true;
 		}
 		
-		// We do not serialize the superTIs reference.
+		// We do not serialize any of the inheritance related attributes
 		if (feature.equals(InheritancePackage.Literals.IINHERITANCE_LINK__SUPER_TIS) 
 				|| feature.equals(InheritancePackage.Literals.IINHERITANCE_LINK__IS_INHERITED)
 				|| feature.equals(InheritancePackage.Literals.IOVERRIDABLE_INHERITANCE_LINK__OVERRIDE)) {

--- a/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/serializer/EquationTransientValueService.java
+++ b/de.dlr.sc.virsat.model.calculation/src/de/dlr/sc/virsat/model/calculation/serializer/EquationTransientValueService.java
@@ -17,6 +17,7 @@ import org.eclipse.xtext.parsetree.reconstr.impl.DefaultTransientValueService;
 import de.dlr.sc.virsat.model.dvlm.calculation.CalculationPackage;
 import de.dlr.sc.virsat.model.dvlm.calculation.EquationSection;
 import de.dlr.sc.virsat.model.dvlm.general.GeneralPackage;
+import de.dlr.sc.virsat.model.dvlm.inheritance.InheritancePackage;
 
 /**
  * This class implements the Transient Value Service. It handles for example the UUID
@@ -46,6 +47,11 @@ public class EquationTransientValueService extends DefaultTransientValueService 
 		// From the Equations Section we do not serialize the serializedEquations attribute
 		// it is only intended for backup purposes. in case the equations cannot be deserialized.
 		if (owner instanceof EquationSection && feature.equals(CalculationPackage.Literals.EQUATION_SECTION__SERIALIZED_STATEMENTS)) {
+			return true;
+		}
+		
+		// We do not serialize the superTIs reference.
+		if (feature.equals(InheritancePackage.Literals.IINHERITANCE_LINK__SUPER_TIS) || feature.equals(InheritancePackage.Literals.IINHERITANCE_LINK__IS_INHERITED)) {
 			return true;
 		}
 		

--- a/de.dlr.sc.virsat.model.edit/src-gen/de/dlr/sc/virsat/model/dvlm/calculation/provider/EquationSectionItemProvider.java
+++ b/de.dlr.sc.virsat.model.edit/src-gen/de/dlr/sc/virsat/model/dvlm/calculation/provider/EquationSectionItemProvider.java
@@ -89,6 +89,7 @@ public class EquationSectionItemProvider
 
 			addSuperTisPropertyDescriptor(object);
 			addIsInheritedPropertyDescriptor(object);
+			addOverridePropertyDescriptor(object);
 			addSerializedStatementsPropertyDescriptor(object);
 		}
 		return itemPropertyDescriptors;
@@ -131,6 +132,28 @@ public class EquationSectionItemProvider
 				 getString("_UI_PropertyDescriptor_description", "_UI_IInheritanceLink_isInherited_feature", "_UI_IInheritanceLink_type"),
 				 InheritancePackage.Literals.IINHERITANCE_LINK__IS_INHERITED,
 				 false,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
+				 null,
+				 null));
+	}
+
+	/**
+	 * This adds a property descriptor for the Override feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addOverridePropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_IOverridableInheritanceLink_override_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_IOverridableInheritanceLink_override_feature", "_UI_IOverridableInheritanceLink_type"),
+				 InheritancePackage.Literals.IOVERRIDABLE_INHERITANCE_LINK__OVERRIDE,
+				 true,
 				 false,
 				 false,
 				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
@@ -236,6 +259,7 @@ public class EquationSectionItemProvider
 
 		switch (notification.getFeatureID(EquationSection.class)) {
 			case CalculationPackage.EQUATION_SECTION__IS_INHERITED:
+			case CalculationPackage.EQUATION_SECTION__OVERRIDE:
 			case CalculationPackage.EQUATION_SECTION__SERIALIZED_STATEMENTS:
 				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
 				return;

--- a/de.dlr.sc.virsat.model/model/dvlm.ecore
+++ b/de.dlr.sc.virsat.model/model/dvlm.ecore
@@ -515,7 +515,7 @@
       <eStructuralFeatures xsi:type="ecore:EReference" name="equationSection" eType="#//calculation/EquationSection"
           containment="true"/>
     </eClassifiers>
-    <eClassifiers xsi:type="ecore:EClass" name="EquationSection" eSuperTypes="#//calculation/IEquationSectionContainer #//inheritance/IInheritanceLink">
+    <eClassifiers xsi:type="ecore:EClass" name="EquationSection" eSuperTypes="#//calculation/IEquationSectionContainer #//inheritance/IOverridableInheritanceLink">
       <eStructuralFeatures xsi:type="ecore:EReference" name="imports" upperBound="-1"
           eType="#//calculation/Import" containment="true"/>
       <eStructuralFeatures xsi:type="ecore:EReference" name="equations" upperBound="-1"

--- a/de.dlr.sc.virsat.model/model/dvlm.history
+++ b/de.dlr.sc.virsat.model/model/dvlm.history
@@ -5493,5 +5493,14 @@
       <element href="dvlm.ecore#//dmf"/>
     </changes>
   </releases>
-  <releases xmi:id="_hIDhkPxDEey3JZ32do51VQ"/>
+  <releases xmi:id="_hIDhkPxDEey3JZ32do51VQ">
+    <changes xsi:type="history:Remove" xmi:id="_xYn24DzjEe6QffNyXiIMCA" featureName="eSuperTypes">
+      <element href="dvlm.ecore#//calculation/EquationSection"/>
+      <referenceValue href="dvlm.ecore#//inheritance/IInheritanceLink"/>
+    </changes>
+    <changes xsi:type="history:Add" xmi:id="_xYpFADzjEe6QffNyXiIMCA" featureName="eSuperTypes">
+      <element href="dvlm.ecore#//calculation/EquationSection"/>
+      <referenceValue href="dvlm.ecore#//inheritance/IOverridableInheritanceLink"/>
+    </changes>
+  </releases>
 </history:History>

--- a/de.dlr.sc.virsat.model/src-gen/de/dlr/sc/virsat/model/dvlm/calculation/CalculationPackage.java
+++ b/de.dlr.sc.virsat.model/src-gen/de/dlr/sc/virsat/model/dvlm/calculation/CalculationPackage.java
@@ -179,13 +179,22 @@ public interface CalculationPackage extends EPackage {
 	int EQUATION_SECTION__IS_INHERITED = IEQUATION_SECTION_CONTAINER_FEATURE_COUNT + 1;
 
 	/**
+	 * The feature id for the '<em><b>Override</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int EQUATION_SECTION__OVERRIDE = IEQUATION_SECTION_CONTAINER_FEATURE_COUNT + 2;
+
+	/**
 	 * The feature id for the '<em><b>Imports</b></em>' containment reference list.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int EQUATION_SECTION__IMPORTS = IEQUATION_SECTION_CONTAINER_FEATURE_COUNT + 2;
+	int EQUATION_SECTION__IMPORTS = IEQUATION_SECTION_CONTAINER_FEATURE_COUNT + 3;
 
 	/**
 	 * The feature id for the '<em><b>Equations</b></em>' containment reference list.
@@ -194,7 +203,7 @@ public interface CalculationPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int EQUATION_SECTION__EQUATIONS = IEQUATION_SECTION_CONTAINER_FEATURE_COUNT + 3;
+	int EQUATION_SECTION__EQUATIONS = IEQUATION_SECTION_CONTAINER_FEATURE_COUNT + 4;
 
 	/**
 	 * The feature id for the '<em><b>Serialized Statements</b></em>' attribute.
@@ -203,7 +212,7 @@ public interface CalculationPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int EQUATION_SECTION__SERIALIZED_STATEMENTS = IEQUATION_SECTION_CONTAINER_FEATURE_COUNT + 4;
+	int EQUATION_SECTION__SERIALIZED_STATEMENTS = IEQUATION_SECTION_CONTAINER_FEATURE_COUNT + 5;
 
 	/**
 	 * The number of structural features of the '<em>Equation Section</em>' class.
@@ -212,7 +221,7 @@ public interface CalculationPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int EQUATION_SECTION_FEATURE_COUNT = IEQUATION_SECTION_CONTAINER_FEATURE_COUNT + 5;
+	int EQUATION_SECTION_FEATURE_COUNT = IEQUATION_SECTION_CONTAINER_FEATURE_COUNT + 6;
 
 	/**
 	 * The number of operations of the '<em>Equation Section</em>' class.

--- a/de.dlr.sc.virsat.model/src-gen/de/dlr/sc/virsat/model/dvlm/calculation/EquationSection.java
+++ b/de.dlr.sc.virsat.model/src-gen/de/dlr/sc/virsat/model/dvlm/calculation/EquationSection.java
@@ -10,7 +10,7 @@
 package de.dlr.sc.virsat.model.dvlm.calculation;
 
 
-import de.dlr.sc.virsat.model.dvlm.inheritance.IInheritanceLink;
+import de.dlr.sc.virsat.model.dvlm.inheritance.IOverridableInheritanceLink;
 import org.eclipse.emf.common.util.EList;
 
 /**
@@ -31,7 +31,7 @@ import org.eclipse.emf.common.util.EList;
  * @model
  * @generated
  */
-public interface EquationSection extends IEquationSectionContainer, IInheritanceLink {
+public interface EquationSection extends IEquationSectionContainer, IOverridableInheritanceLink {
 	/**
 	 * Returns the value of the '<em><b>Imports</b></em>' containment reference list.
 	 * The list contents are of type {@link de.dlr.sc.virsat.model.dvlm.calculation.Import}.

--- a/de.dlr.sc.virsat.model/src-gen/de/dlr/sc/virsat/model/dvlm/calculation/impl/CalculationPackageImpl.java
+++ b/de.dlr.sc.virsat.model/src-gen/de/dlr/sc/virsat/model/dvlm/calculation/impl/CalculationPackageImpl.java
@@ -1146,7 +1146,7 @@ public class CalculationPackageImpl extends EPackageImpl implements CalculationP
 
 		// Add supertypes to classes
 		equationSectionEClass.getESuperTypes().add(this.getIEquationSectionContainer());
-		equationSectionEClass.getESuperTypes().add(theInheritancePackage.getIInheritanceLink());
+		equationSectionEClass.getESuperTypes().add(theInheritancePackage.getIOverridableInheritanceLink());
 		importEClass.getESuperTypes().add(theInheritancePackage.getIInheritanceLink());
 		equationEClass.getESuperTypes().add(theInheritancePackage.getIOverridableInheritanceLink());
 		equationDefinitionEClass.getESuperTypes().add(this.getIQualifiedEquationObject());

--- a/de.dlr.sc.virsat.model/src-gen/de/dlr/sc/virsat/model/dvlm/calculation/impl/EquationSectionImpl.java
+++ b/de.dlr.sc.virsat.model/src-gen/de/dlr/sc/virsat/model/dvlm/calculation/impl/EquationSectionImpl.java
@@ -16,6 +16,7 @@ import de.dlr.sc.virsat.model.dvlm.calculation.EquationSection;
 import de.dlr.sc.virsat.model.dvlm.calculation.Import;
 
 import de.dlr.sc.virsat.model.dvlm.inheritance.IInheritanceLink;
+import de.dlr.sc.virsat.model.dvlm.inheritance.IOverridableInheritanceLink;
 import de.dlr.sc.virsat.model.dvlm.inheritance.InheritancePackage;
 import de.dlr.sc.virsat.model.dvlm.util.DVLMUnresolvedReferenceException;
 import java.util.Collection;
@@ -47,6 +48,7 @@ import org.eclipse.emf.ecore.util.InternalEList;
  *   <li>{@link de.dlr.sc.virsat.model.dvlm.calculation.impl.EquationSectionImpl#getEquationSection <em>Equation Section</em>}</li>
  *   <li>{@link de.dlr.sc.virsat.model.dvlm.calculation.impl.EquationSectionImpl#getSuperTis <em>Super Tis</em>}</li>
  *   <li>{@link de.dlr.sc.virsat.model.dvlm.calculation.impl.EquationSectionImpl#isIsInherited <em>Is Inherited</em>}</li>
+ *   <li>{@link de.dlr.sc.virsat.model.dvlm.calculation.impl.EquationSectionImpl#isOverride <em>Override</em>}</li>
  *   <li>{@link de.dlr.sc.virsat.model.dvlm.calculation.impl.EquationSectionImpl#getImports <em>Imports</em>}</li>
  *   <li>{@link de.dlr.sc.virsat.model.dvlm.calculation.impl.EquationSectionImpl#getEquations <em>Equations</em>}</li>
  *   <li>{@link de.dlr.sc.virsat.model.dvlm.calculation.impl.EquationSectionImpl#getSerializedStatements <em>Serialized Statements</em>}</li>
@@ -94,6 +96,26 @@ public class EquationSectionImpl extends MinimalEObjectImpl.Container implements
 	 * @ordered
 	 */
 	protected boolean isInherited = IS_INHERITED_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #isOverride() <em>Override</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isOverride()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final boolean OVERRIDE_EDEFAULT = false;
+
+	/**
+	 * The cached value of the '{@link #isOverride() <em>Override</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isOverride()
+	 * @generated
+	 * @ordered
+	 */
+	protected boolean override = OVERRIDE_EDEFAULT;
 
 	/**
 	 * The cached value of the '{@link #getImports() <em>Imports</em>}' containment reference list.
@@ -291,6 +313,28 @@ public class EquationSectionImpl extends MinimalEObjectImpl.Container implements
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
+	 * @return value or object of type '{@code boolean}'.
+	 * @generated
+	 */
+	public boolean isOverride() {
+		return override;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setOverride(boolean newOverride) {
+		boolean oldOverride = override;
+		override = newOverride;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, CalculationPackage.EQUATION_SECTION__OVERRIDE, oldOverride, override));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
 	 * @return value or object of type '{@code EList<Import>}'.
 	 * @generated
 	 */
@@ -373,6 +417,8 @@ public class EquationSectionImpl extends MinimalEObjectImpl.Container implements
 				return getSuperTis();
 			case CalculationPackage.EQUATION_SECTION__IS_INHERITED:
 				return isIsInherited();
+			case CalculationPackage.EQUATION_SECTION__OVERRIDE:
+				return isOverride();
 			case CalculationPackage.EQUATION_SECTION__IMPORTS:
 				return getImports();
 			case CalculationPackage.EQUATION_SECTION__EQUATIONS:
@@ -401,6 +447,9 @@ public class EquationSectionImpl extends MinimalEObjectImpl.Container implements
 				return;
 			case CalculationPackage.EQUATION_SECTION__IS_INHERITED:
 				setIsInherited((Boolean)newValue);
+				return;
+			case CalculationPackage.EQUATION_SECTION__OVERRIDE:
+				setOverride((Boolean)newValue);
 				return;
 			case CalculationPackage.EQUATION_SECTION__IMPORTS:
 				getImports().clear();
@@ -434,6 +483,9 @@ public class EquationSectionImpl extends MinimalEObjectImpl.Container implements
 			case CalculationPackage.EQUATION_SECTION__IS_INHERITED:
 				setIsInherited(IS_INHERITED_EDEFAULT);
 				return;
+			case CalculationPackage.EQUATION_SECTION__OVERRIDE:
+				setOverride(OVERRIDE_EDEFAULT);
+				return;
 			case CalculationPackage.EQUATION_SECTION__IMPORTS:
 				getImports().clear();
 				return;
@@ -461,6 +513,8 @@ public class EquationSectionImpl extends MinimalEObjectImpl.Container implements
 				return superTis != null && !superTis.isEmpty();
 			case CalculationPackage.EQUATION_SECTION__IS_INHERITED:
 				return isInherited != IS_INHERITED_EDEFAULT;
+			case CalculationPackage.EQUATION_SECTION__OVERRIDE:
+				return override != OVERRIDE_EDEFAULT;
 			case CalculationPackage.EQUATION_SECTION__IMPORTS:
 				return imports != null && !imports.isEmpty();
 			case CalculationPackage.EQUATION_SECTION__EQUATIONS:
@@ -485,6 +539,12 @@ public class EquationSectionImpl extends MinimalEObjectImpl.Container implements
 				default: return -1;
 			}
 		}
+		if (baseClass == IOverridableInheritanceLink.class) {
+			switch (derivedFeatureID) {
+				case CalculationPackage.EQUATION_SECTION__OVERRIDE: return InheritancePackage.IOVERRIDABLE_INHERITANCE_LINK__OVERRIDE;
+				default: return -1;
+			}
+		}
 		return super.eBaseStructuralFeatureID(derivedFeatureID, baseClass);
 	}
 
@@ -499,6 +559,12 @@ public class EquationSectionImpl extends MinimalEObjectImpl.Container implements
 			switch (baseFeatureID) {
 				case InheritancePackage.IINHERITANCE_LINK__SUPER_TIS: return CalculationPackage.EQUATION_SECTION__SUPER_TIS;
 				case InheritancePackage.IINHERITANCE_LINK__IS_INHERITED: return CalculationPackage.EQUATION_SECTION__IS_INHERITED;
+				default: return -1;
+			}
+		}
+		if (baseClass == IOverridableInheritanceLink.class) {
+			switch (baseFeatureID) {
+				case InheritancePackage.IOVERRIDABLE_INHERITANCE_LINK__OVERRIDE: return CalculationPackage.EQUATION_SECTION__OVERRIDE;
 				default: return -1;
 			}
 		}
@@ -517,6 +583,8 @@ public class EquationSectionImpl extends MinimalEObjectImpl.Container implements
 		StringBuffer result = new StringBuffer(super.toString());
 		result.append(" (isInherited: ");
 		result.append(isInherited);
+		result.append(", override: ");
+		result.append(override);
 		result.append(", serializedStatements: ");
 		result.append(serializedStatements);
 		result.append(')');

--- a/de.dlr.sc.virsat.model/src-gen/de/dlr/sc/virsat/model/dvlm/calculation/util/CalculationSwitch.java
+++ b/de.dlr.sc.virsat.model/src-gen/de/dlr/sc/virsat/model/dvlm/calculation/util/CalculationSwitch.java
@@ -92,6 +92,7 @@ public class CalculationSwitch<T> extends Switch<T> {
 				EquationSection equationSection = (EquationSection)theEObject;
 				T result = caseEquationSection(equationSection);
 				if (result == null) result = caseIEquationSectionContainer(equationSection);
+				if (result == null) result = caseIOverridableInheritanceLink(equationSection);
 				if (result == null) result = caseIInheritanceLink(equationSection);
 				if (result == null) result = defaultCase(theEObject);
 				return result;

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopier.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopier.java
@@ -252,7 +252,7 @@ public class InheritanceCopier implements IInheritanceCopier {
 		protected void copyReference(EReference eReference, EObject superEobject, EObject subEObject) {
 			
 			// No reliinking of the inheritance link should happen with the call to the cross referencer
-			if (InheritancePackage.Literals.IINHERITANCE_LINK__SUPER_TIS == eReference  || eReference == CalculationPackage.Literals.IEQUATION_SECTION_CONTAINER__EQUATION_SECTION) {
+			if (InheritancePackage.Literals.IINHERITANCE_LINK__SUPER_TIS == eReference) {
 				return;
 			}
 			
@@ -294,6 +294,10 @@ public class InheritanceCopier implements IInheritanceCopier {
 		
 		@Override
 		protected void copyContainment(EReference eReference, EObject eObject, EObject copyEObject) {
+			// Do not copy the override flag :-D aaaaaaaahr
+			if (InheritancePackage.Literals.IOVERRIDABLE_INHERITANCE_LINK__OVERRIDE == eReference) {
+				return;
+			}
 			if (eReference == CalculationPackage.Literals.IEQUATION_SECTION_CONTAINER__EQUATION_SECTION 
 					&& copyEObject instanceof IEquationSectionContainer) {
 				if (((IEquationSectionContainer) copyEObject).getEquationSection() != null 
@@ -303,30 +307,7 @@ public class InheritanceCopier implements IInheritanceCopier {
 			}
 			super.copyContainment(eReference, eObject, copyEObject);
 		}
-		
-//		@Override
-//		protected void copyContainment(EReference eReference, EObject eObject, EObject copyEObject) {
-//			if (eObject.eIsSet(eReference))
-//		      {
-//		        EStructuralFeature.Setting setting = getTarget(eReference, eObject, copyEObject);
-//		        if (setting != null)
-//		        {
-//		          Object value = eObject.eGet(eReference);
-//		          if (eReference.isMany())
-//		          {
-//		            @SuppressWarnings("unchecked")
-//		            List<EObject> source = (List<EObject>)setting;
-//		            List<EObject> target = (List<EObject>)value;
-//		            Collection<EObject> result = copyAll(target);
-//		            setting.set(copyAll(target));
-//		          }
-//		          else
-//		          {
-//		            setting.set(copy((EObject)value));
-//		          }
-//		        }
-//		      }
-//		}
+
 		
 		@Override
 		protected EObject createCopy(EObject superEObject) {

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopier.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopier.java
@@ -31,6 +31,7 @@ import org.eclipse.emf.ecore.util.EcoreUtil.UsageCrossReferencer;
 import de.dlr.sc.virsat.model.dvlm.Repository;
 import de.dlr.sc.virsat.model.dvlm.calculation.CalculationPackage;
 import de.dlr.sc.virsat.model.dvlm.calculation.EquationSection;
+import de.dlr.sc.virsat.model.dvlm.calculation.IEquationSectionContainer;
 import de.dlr.sc.virsat.model.dvlm.categories.ATypeInstance;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.PropertyinstancesPackage;
@@ -293,8 +294,12 @@ public class InheritanceCopier implements IInheritanceCopier {
 		
 		@Override
 		protected void copyContainment(EReference eReference, EObject eObject, EObject copyEObject) {
-			if (eReference == CalculationPackage.Literals.IEQUATION_SECTION_CONTAINER__EQUATION_SECTION) {
-				return;
+			if (eReference == CalculationPackage.Literals.IEQUATION_SECTION_CONTAINER__EQUATION_SECTION 
+					&& copyEObject instanceof IEquationSectionContainer) {
+				if (((IEquationSectionContainer) copyEObject).getEquationSection() != null 
+						&& ((IEquationSectionContainer) copyEObject).getEquationSection().isOverride()) {
+					return;
+				}
 			}
 			super.copyContainment(eReference, eObject, copyEObject);
 		}

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopier.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopier.java
@@ -29,6 +29,8 @@ import org.eclipse.emf.ecore.util.EcoreUtil.EqualityHelper;
 import org.eclipse.emf.ecore.util.EcoreUtil.UsageCrossReferencer;
 
 import de.dlr.sc.virsat.model.dvlm.Repository;
+import de.dlr.sc.virsat.model.dvlm.calculation.CalculationPackage;
+import de.dlr.sc.virsat.model.dvlm.calculation.EquationSection;
 import de.dlr.sc.virsat.model.dvlm.categories.ATypeInstance;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
 import de.dlr.sc.virsat.model.dvlm.categories.propertyinstances.PropertyinstancesPackage;
@@ -249,7 +251,7 @@ public class InheritanceCopier implements IInheritanceCopier {
 		protected void copyReference(EReference eReference, EObject superEobject, EObject subEObject) {
 			
 			// No reliinking of the inheritance link should happen with the call to the cross referencer
-			if (InheritancePackage.Literals.IINHERITANCE_LINK__SUPER_TIS == eReference) {
+			if (InheritancePackage.Literals.IINHERITANCE_LINK__SUPER_TIS == eReference  || eReference == CalculationPackage.Literals.IEQUATION_SECTION_CONTAINER__EQUATION_SECTION) {
 				return;
 			}
 			
@@ -259,6 +261,10 @@ public class InheritanceCopier implements IInheritanceCopier {
 				if (overidableInheritanceLinkSubObject.isOverride()) {
 					return;
 				}
+			}
+			
+			if (subEObject instanceof EquationSection) {
+				return;
 			}
 			
 			super.copyReference(eReference, superEobject, subEObject);
@@ -283,7 +289,39 @@ public class InheritanceCopier implements IInheritanceCopier {
 			if (eAttribute != GeneralPackage.Literals.IUUID__UUID) {
 				super.copyAttribute(eAttribute, superEobject, subEObject);
 			}
-		}			
+		}	
+		
+		@Override
+		protected void copyContainment(EReference eReference, EObject eObject, EObject copyEObject) {
+			if (eReference == CalculationPackage.Literals.IEQUATION_SECTION_CONTAINER__EQUATION_SECTION) {
+				return;
+			}
+			super.copyContainment(eReference, eObject, copyEObject);
+		}
+		
+//		@Override
+//		protected void copyContainment(EReference eReference, EObject eObject, EObject copyEObject) {
+//			if (eObject.eIsSet(eReference))
+//		      {
+//		        EStructuralFeature.Setting setting = getTarget(eReference, eObject, copyEObject);
+//		        if (setting != null)
+//		        {
+//		          Object value = eObject.eGet(eReference);
+//		          if (eReference.isMany())
+//		          {
+//		            @SuppressWarnings("unchecked")
+//		            List<EObject> source = (List<EObject>)setting;
+//		            List<EObject> target = (List<EObject>)value;
+//		            Collection<EObject> result = copyAll(target);
+//		            setting.set(copyAll(target));
+//		          }
+//		          else
+//		          {
+//		            setting.set(copy((EObject)value));
+//		          }
+//		        }
+//		      }
+//		}
 		
 		@Override
 		protected EObject createCopy(EObject superEObject) {

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopier.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopier.java
@@ -289,10 +289,10 @@ public class InheritanceCopier implements IInheritanceCopier {
 		
 		@Override
 		protected void copyContainment(EReference eReference, EObject eObject, EObject copyEObject) {
-			// Do not copy the override flag :-D aaaaaaaahr
-			if (InheritancePackage.Literals.IOVERRIDABLE_INHERITANCE_LINK__OVERRIDE == eReference) {
-				return;
-			}
+			
+			// Do not copy equation section with overwrite flag set. 
+			// Need to grap equation section from container element, because when this method is called 
+			// from the EMFCopier, the copy objects are still on CA level
 			if (eReference == CalculationPackage.Literals.IEQUATION_SECTION_CONTAINER__EQUATION_SECTION 
 					&& copyEObject instanceof IEquationSectionContainer) {
 				if (((IEquationSectionContainer) copyEObject).getEquationSection() != null 

--- a/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopier.java
+++ b/de.dlr.sc.virsat.model/src/de/dlr/sc/virsat/model/dvlm/inheritance/InheritanceCopier.java
@@ -30,7 +30,6 @@ import org.eclipse.emf.ecore.util.EcoreUtil.UsageCrossReferencer;
 
 import de.dlr.sc.virsat.model.dvlm.Repository;
 import de.dlr.sc.virsat.model.dvlm.calculation.CalculationPackage;
-import de.dlr.sc.virsat.model.dvlm.calculation.EquationSection;
 import de.dlr.sc.virsat.model.dvlm.calculation.IEquationSectionContainer;
 import de.dlr.sc.virsat.model.dvlm.categories.ATypeInstance;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
@@ -262,10 +261,6 @@ public class InheritanceCopier implements IInheritanceCopier {
 				if (overidableInheritanceLinkSubObject.isOverride()) {
 					return;
 				}
-			}
-			
-			if (subEObject instanceof EquationSection) {
-				return;
 			}
 			
 			super.copyReference(eReference, superEobject, subEObject);


### PR DESCRIPTION
Fix that equations were not opening if the containing CA was inherited.
-> superSei wasn*t defined as transiend, so XText couldn't handle its values

Fixed that equations have always been overwritten from the inheritance copier. The Inheritance copier actually always replaced every EMF containment.
-> Add overwrite flag to equation section
-> Changed copyContainment behavior of EMFCopier in our InheritanceCopier to not copy if there is an overwrite flag set.
-> Added UI to set and unset Overwrite-Flag in equation section
-> Automatically set overwrite flag if equations are edited 