### PR TITLE
Minor fixes to concept generators

### DIFF
--- a/de.dlr.sc.virsat.model.concept.test/resources/expectedOutputFilesForGenerators/ConceptFragmentTestManifest.MF
+++ b/de.dlr.sc.virsat.model.concept.test/resources/expectedOutputFilesForGenerators/ConceptFragmentTestManifest.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: VirSat Model Extension Concept Tests
-Bundle-SymbolicName: de.dlr.sc.virsat.concept.example;singleton:=true
+Bundle-SymbolicName: de.dlr.sc.virsat.concept.example.test;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Fragment-Host: de.dlr.sc.virsat.concept.example;bundle-version="0.0.1"
 Bundle-ClassPath: .
@@ -14,5 +14,5 @@ Require-Bundle: org.junit,
  de.dlr.sc.virsat.model,
  de.dlr.sc.virsat.model.edit,
  de.dlr.sc.virsat.concept.unittest.util
-Export-Package: de.dlr.sc.virsat.concept.example
-
+Export-Package: de.dlr.sc.virsat.concept.example.test
+Automatic-Module-Name: de.dlr.sc.virsat.concept.example.test

--- a/de.dlr.sc.virsat.model.concept.test/resources/expectedOutputFilesForGenerators/ConceptPluginManifest.MF
+++ b/de.dlr.sc.virsat.model.concept.test/resources/expectedOutputFilesForGenerators/ConceptPluginManifest.MF
@@ -9,10 +9,12 @@ Require-Bundle: org.eclipse.ui,
  de.dlr.sc.virsat.model,
  de.dlr.sc.virsat.model.edit,
  de.dlr.sc.virsat.project,
+ javax.annotation,
+ jakarta.xml.bind,
  de.dlr.sc.virsat.model.ext.core;visibility:=reexport
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
 Eclipse-ExtensibleAPI: true
 Export-Package: de.dlr.sc.virsat.concept.example.model,
  de.dlr.sc.virsat.concept.example.validator
-
+Automatic-Module-Name: de.dlr.sc.virsat.concept.example

--- a/de.dlr.sc.virsat.model.concept.test/resources/expectedOutputFilesForGenerators/ConceptPluginUiManifest.MF
+++ b/de.dlr.sc.virsat.model.concept.test/resources/expectedOutputFilesForGenerators/ConceptPluginUiManifest.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: VirSat Model Extension Concept UI
-Bundle-SymbolicName: de.dlr.sc.virsat.concept.example;singleton:=true
+Bundle-SymbolicName: de.dlr.sc.virsat.concept.example.ui;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Require-Bundle: de.dlr.sc.virsat.concept.example,
  org.eclipse.ui,
@@ -16,4 +16,4 @@ Require-Bundle: de.dlr.sc.virsat.concept.example,
  de.dlr.sc.virsat.uiengine.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ActivationPolicy: lazy
-
+Automatic-Module-Name: de.dlr.sc.virsat.concept.example.ui

--- a/de.dlr.sc.virsat.model.concept.test/resources/expectedOutputFilesForGenerators/TestConceptValidator.java
+++ b/de.dlr.sc.virsat.model.concept.test/resources/expectedOutputFilesForGenerators/TestConceptValidator.java
@@ -10,7 +10,7 @@
 package de.dlr.sc.virsat.model.extension.testConcept.validator;
 
 import de.dlr.sc.virsat.model.dvlm.structural.StructuralElementInstance;
-import de.dlr.sc.virsat.build.validator.external.IStructuralElementInstanceValidator;
+import de.dlr.sc.virsat.model.dvlm.validator.IStructuralElementInstanceValidator;
 
 
 // *****************************************************************

--- a/de.dlr.sc.virsat.model.concept.test/resources/expectedOutputFilesForResourceAccessBuilder/MANIFEST.MF
+++ b/de.dlr.sc.virsat.model.concept.test/resources/expectedOutputFilesForResourceAccessBuilder/MANIFEST.MF
@@ -28,4 +28,4 @@ Export-Package: de.dlr.sc.virsat.model.extension.testResource,
  de.dlr.sc.virsat.model.extension.testResource.model,
  de.dlr.sc.virsat.model.extension.testResource.model.util,
  de.dlr.sc.virsat.model.extension.testResource.validator
-
+Automatic-Module-Name: de.dlr.sc.virsat.model.extension.testResource

--- a/de.dlr.sc.virsat.model.concept.test/resources/expectedOutputFilesForResourceAccessBuilder/ManifestMF.java
+++ b/de.dlr.sc.virsat.model.concept.test/resources/expectedOutputFilesForResourceAccessBuilder/ManifestMF.java
@@ -22,4 +22,6 @@ public class ManifestMf {
 	public static final String ECLIPSE_EXTENSIBLEAPI = "true";
 	public static final String BUNDLE_ACTIVATOR = "de.dlr.sc.virsat.model.extension.testResource.Activator";
 	public static final String EXPORT_PACKAGE = "de.dlr.sc.virsat.model.extension.testResource,de.dlr.sc.virsat.model.extension.testResource.html,de.dlr.sc.virsat.model.extension.testResource.model,de.dlr.sc.virsat.model.extension.testResource.model.util,de.dlr.sc.virsat.model.extension.testResource.validator";
+	public static final String AUTOMATIC_MODULE_NAME = "de.dlr.sc.virsat.model.extension.testResource";
 }
+

--- a/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/AFileContentGeneratorTest.java
+++ b/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/AFileContentGeneratorTest.java
@@ -30,12 +30,15 @@ public abstract class AFileContentGeneratorTest {
 
 	private IProjectBuilderInfo projectBuilderInfo;
 	
+	abstract String getTestProjectName();
+	public static final String TEST_PROJECT_NAME = "de.dlr.sc.virsat.concept.example";
+	
 	@Before
 	public void setUp() throws Exception {
 		projectBuilderInfo = new IProjectBuilderInfo() {
 			@Override
 			public String getProjectName() {
-				return TEST_PROJECT_NAME;
+				return getTestProjectName();
 			}
 
 			@Override
@@ -79,7 +82,6 @@ public abstract class AFileContentGeneratorTest {
 	public void tearDown() throws Exception {
 	}
 
-	public static final String TEST_PROJECT_NAME = "de.dlr.sc.virsat.concept.example";
 	protected IFileContentGenerator fileContentGenerator;
 	protected String expectedContentFilePath;
 	

--- a/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptFeatureBuildPropertiesGeneratorTest.java
+++ b/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptFeatureBuildPropertiesGeneratorTest.java
@@ -31,4 +31,9 @@ public class ConceptFeatureBuildPropertiesGeneratorTest extends AFileContentGene
 		super.tearDown();
 	}
 
+	@Override
+	String getTestProjectName() {
+		return TEST_PROJECT_NAME;
+	}
+
 }

--- a/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptFeatureXmlGeneratorTest.java
+++ b/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptFeatureXmlGeneratorTest.java
@@ -30,5 +30,10 @@ public class ConceptFeatureXmlGeneratorTest extends AFileContentGeneratorTest {
 	public void tearDown() throws Exception {
 		super.tearDown();
 	}
+	
+	@Override
+	String getTestProjectName() {
+		return TEST_PROJECT_NAME;
+	}
 
 }

--- a/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptFragmentTestBuildPropertiesGeneratorTest.java
+++ b/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptFragmentTestBuildPropertiesGeneratorTest.java
@@ -30,5 +30,10 @@ public class ConceptFragmentTestBuildPropertiesGeneratorTest extends AFileConten
 	public void tearDown() throws Exception {
 		super.tearDown();
 	}
+	
+	@Override
+	String getTestProjectName() {
+		return TEST_PROJECT_NAME;
+	}
 
 }

--- a/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptFragmentTestManifestGeneratorTest.java
+++ b/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptFragmentTestManifestGeneratorTest.java
@@ -30,5 +30,11 @@ public class ConceptFragmentTestManifestGeneratorTest extends AFileContentGenera
 	public void tearDown() throws Exception {
 		super.tearDown();
 	}
+	
+	@Override
+	String getTestProjectName() {
+		return TEST_PROJECT_NAME + ".test";
+	}
+
 
 }

--- a/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginBuildPropertiesGeneratorTest.java
+++ b/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginBuildPropertiesGeneratorTest.java
@@ -30,5 +30,10 @@ public class ConceptPluginBuildPropertiesGeneratorTest extends AFileContentGener
 	public void tearDown() throws Exception {
 		super.tearDown();
 	}
+	
+	@Override
+	String getTestProjectName() {
+		return TEST_PROJECT_NAME;
+	}
 
 }

--- a/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginExampleConceptGeneratorTest.java
+++ b/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginExampleConceptGeneratorTest.java
@@ -30,5 +30,10 @@ public class ConceptPluginExampleConceptGeneratorTest extends AFileContentGenera
 	public void tearDown() throws Exception {
 		super.tearDown();
 	}
+	
+	@Override
+	String getTestProjectName() {
+		return TEST_PROJECT_NAME;
+	}
 
 }

--- a/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginManifestGeneratorTest.java
+++ b/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginManifestGeneratorTest.java
@@ -30,5 +30,10 @@ public class ConceptPluginManifestGeneratorTest extends AFileContentGeneratorTes
 	public void tearDown() throws Exception {
 		super.tearDown();
 	}
+	
+	@Override
+	String getTestProjectName() {
+		return TEST_PROJECT_NAME;
+	}
 
 }

--- a/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginUiBuildPropertiesGeneratorTest.java
+++ b/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginUiBuildPropertiesGeneratorTest.java
@@ -30,5 +30,10 @@ public class ConceptPluginUiBuildPropertiesGeneratorTest extends AFileContentGen
 	public void tearDown() throws Exception {
 		super.tearDown();
 	}
+	
+	@Override
+	String getTestProjectName() {
+		return TEST_PROJECT_NAME;
+	}
 
 }

--- a/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginUiManifestGeneratorTest.java
+++ b/de.dlr.sc.virsat.model.concept.test/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginUiManifestGeneratorTest.java
@@ -30,5 +30,10 @@ public class ConceptPluginUiManifestGeneratorTest extends AFileContentGeneratorT
 	public void tearDown() throws Exception {
 		super.tearDown();
 	}
+	
+	@Override
+	String getTestProjectName() {
+		return TEST_PROJECT_NAME + ".ui";
+	}
 
 }

--- a/de.dlr.sc.virsat.model.concept/src/de/dlr/sc/virsat/model/concept/generator/ConceptLanguageGenerator.xtend
+++ b/de.dlr.sc.virsat.model.concept/src/de/dlr/sc/virsat/model/concept/generator/ConceptLanguageGenerator.xtend
@@ -43,6 +43,9 @@ import org.eclipse.xtext.generator.IFileSystemAccess2
 import org.eclipse.xtext.generator.IGenerator2
 import org.eclipse.xtext.generator.IGeneratorContext
 import de.dlr.sc.virsat.model.concept.generator.snippets.GenerateRequirementsVerificationUiSnippet
+import org.eclipse.core.resources.ResourcesPlugin
+import org.eclipse.core.runtime.CoreException
+import org.eclipse.core.resources.IResource
 
 /**
  * Generates code from your model files on save.
@@ -120,6 +123,13 @@ class ConceptLanguageGenerator implements IGenerator2 {
 				new GenerateDeprecatedValidator().serializeModel(dataModel, fsa);
 				new GeneratePluginXml().serializeModelDeprecatedValidator(dataModel, new PluginXmlReader(), fsa);
 				
+			}
+			
+			// Update workspace to make sure all files are shown in the editors - Otherwise user might get warnings
+			try {
+				ResourcesPlugin.getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
+			} catch (CoreException e) {
+				e.printStackTrace();
 			}
 		}
 	}

--- a/de.dlr.sc.virsat.model.concept/src/de/dlr/sc/virsat/model/concept/generator/validator/GenerateValidator.xtend
+++ b/de.dlr.sc.virsat.model.concept/src/de/dlr/sc/virsat/model/concept/generator/validator/GenerateValidator.xtend
@@ -119,7 +119,7 @@ class GenerateValidator extends AGeneratorGapGenerator<EObject> {
 	 */
 	override protected declareClass(Concept concept, EObject conceptPart, ImportManager importManager) '''
 	«importManager.register(StructuralElementInstance)»
-	«importManager.register("de.dlr.sc.virsat.build.validator.external.IStructuralElementInstanceValidator")»
+	«importManager.register("de.dlr.sc.virsat.model.dvlm.validator.IStructuralElementInstanceValidator")»
 	
 	// *****************************************************************
 	// * Class Declaration

--- a/de.dlr.sc.virsat.model.concept/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptFragmentTestManifestGenerator.xtend
+++ b/de.dlr.sc.virsat.model.concept/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptFragmentTestManifestGenerator.xtend
@@ -22,7 +22,7 @@ class ConceptFragmentTestManifestGenerator implements IFileContentGenerator {
 	}
 	
 	def getProjectNameForTestPlugin(IProjectBuilderInfo builderInfo) {
-		builderInfo.projectName.replace(".test", "");
+		builderInfo.projectName.substring(0, builderInfo.projectName.lastIndexOf("."))
 	}
 	
 	def manifestContent(IProjectBuilderInfo builderInfo) '''
@@ -43,5 +43,6 @@ class ConceptFragmentTestManifestGenerator implements IFileContentGenerator {
 	 de.dlr.sc.virsat.model.edit,
 	 de.dlr.sc.virsat.concept.unittest.util
 	Export-Package: «builderInfo.projectName»
+	Automatic-Module-Name: «builderInfo.projectName»
 	'''
 }

--- a/de.dlr.sc.virsat.model.concept/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginManifestGenerator.xtend
+++ b/de.dlr.sc.virsat.model.concept/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginManifestGenerator.xtend
@@ -35,11 +35,14 @@ class ConceptPluginManifestGenerator implements IFileContentGenerator {
 	 de.dlr.sc.virsat.model,
 	 de.dlr.sc.virsat.model.edit,
 	 de.dlr.sc.virsat.project,
+	 javax.annotation,
+	 jakarta.xml.bind,
 	 de.dlr.sc.virsat.model.ext.core;visibility:=reexport
 	Bundle-RequiredExecutionEnvironment: JavaSE-11
 	Bundle-ActivationPolicy: lazy
 	Eclipse-ExtensibleAPI: true
 	Export-Package: «builderInfo.projectName».«GenerateCategoryBeans.PACKAGE_FOLDER»,
 	 «builderInfo.projectName».«GenerateValidator.PACKAGE_FOLDER»
+	Automatic-Module-Name: «builderInfo.projectName»
 	'''
 }

--- a/de.dlr.sc.virsat.model.concept/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginUiManifestGenerator.xtend
+++ b/de.dlr.sc.virsat.model.concept/src/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginUiManifestGenerator.xtend
@@ -22,7 +22,7 @@ class ConceptPluginUiManifestGenerator implements IFileContentGenerator {
 	}
 	
 	def getProjectNameForUiPlugin(IProjectBuilderInfo builderInfo) {
-		builderInfo.projectName.replace(".ui", "");
+		builderInfo.projectName.substring(0, builderInfo.projectName.lastIndexOf("."))
 	}
 	
 	def manifestContent(IProjectBuilderInfo builderInfo) '''
@@ -44,5 +44,6 @@ class ConceptPluginUiManifestGenerator implements IFileContentGenerator {
 	 de.dlr.sc.virsat.uiengine.ui
 	Bundle-RequiredExecutionEnvironment: JavaSE-11
 	Bundle-ActivationPolicy: lazy
+	Automatic-Module-Name: «builderInfo.projectName»
 	'''
 }

--- a/de.dlr.sc.virsat.model.concept/xtend-gen/de/dlr/sc/virsat/model/concept/generator/ConceptLanguageGenerator.java
+++ b/de.dlr.sc.virsat.model.concept/xtend-gen/de/dlr/sc/virsat/model/concept/generator/ConceptLanguageGenerator.java
@@ -34,6 +34,9 @@ import de.dlr.sc.virsat.model.concept.generator.tests.GenerateValidatorTests;
 import de.dlr.sc.virsat.model.concept.generator.validator.GenerateDeprecatedValidator;
 import de.dlr.sc.virsat.model.concept.generator.validator.GenerateValidator;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.Platform;
@@ -116,6 +119,16 @@ public class ConceptLanguageGenerator implements IGenerator2 {
           GeneratePluginXml _generatePluginXml_1 = new GeneratePluginXml();
           PluginXmlReader _pluginXmlReader_2 = new PluginXmlReader();
           _generatePluginXml_1.serializeModelDeprecatedValidator(dataModel, _pluginXmlReader_2, fsa);
+        }
+        try {
+          ResourcesPlugin.getWorkspace().getRoot().refreshLocal(IResource.DEPTH_INFINITE, null);
+        } catch (final Throwable _t) {
+          if (_t instanceof CoreException) {
+            final CoreException e = (CoreException)_t;
+            e.printStackTrace();
+          } else {
+            throw Exceptions.sneakyThrow(_t);
+          }
         }
       }
     } catch (Throwable _e) {

--- a/de.dlr.sc.virsat.model.concept/xtend-gen/de/dlr/sc/virsat/model/concept/generator/validator/GenerateValidator.java
+++ b/de.dlr.sc.virsat.model.concept/xtend-gen/de/dlr/sc/virsat/model/concept/generator/validator/GenerateValidator.java
@@ -173,7 +173,7 @@ public class GenerateValidator extends AGeneratorGapGenerator<EObject> {
     StringConcatenation _builder = new StringConcatenation();
     importManager.register(StructuralElementInstance.class);
     _builder.newLineIfNotEmpty();
-    importManager.register("de.dlr.sc.virsat.build.validator.external.IStructuralElementInstanceValidator");
+    importManager.register("de.dlr.sc.virsat.model.dvlm.validator.IStructuralElementInstanceValidator");
     _builder.newLineIfNotEmpty();
     _builder.newLine();
     _builder.append("// *****************************************************************");

--- a/de.dlr.sc.virsat.model.concept/xtend-gen/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptFragmentTestManifestGenerator.java
+++ b/de.dlr.sc.virsat.model.concept/xtend-gen/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptFragmentTestManifestGenerator.java
@@ -23,7 +23,7 @@ public class ConceptFragmentTestManifestGenerator implements IFileContentGenerat
   }
   
   public String getProjectNameForTestPlugin(final IProjectBuilderInfo builderInfo) {
-    return builderInfo.getProjectName().replace(".test", "");
+    return builderInfo.getProjectName().substring(0, builderInfo.getProjectName().lastIndexOf("."));
   }
   
   public CharSequence manifestContent(final IProjectBuilderInfo builderInfo) {
@@ -74,6 +74,10 @@ public class ConceptFragmentTestManifestGenerator implements IFileContentGenerat
     _builder.append("Export-Package: ");
     String _projectName_1 = builderInfo.getProjectName();
     _builder.append(_projectName_1);
+    _builder.newLineIfNotEmpty();
+    _builder.append("Automatic-Module-Name: ");
+    String _projectName_2 = builderInfo.getProjectName();
+    _builder.append(_projectName_2);
     _builder.newLineIfNotEmpty();
     return _builder;
   }

--- a/de.dlr.sc.virsat.model.concept/xtend-gen/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginManifestGenerator.java
+++ b/de.dlr.sc.virsat.model.concept/xtend-gen/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginManifestGenerator.java
@@ -56,6 +56,12 @@ public class ConceptPluginManifestGenerator implements IFileContentGenerator {
     _builder.append("de.dlr.sc.virsat.project,");
     _builder.newLine();
     _builder.append(" ");
+    _builder.append("javax.annotation,");
+    _builder.newLine();
+    _builder.append(" ");
+    _builder.append("jakarta.xml.bind,");
+    _builder.newLine();
+    _builder.append(" ");
     _builder.append("de.dlr.sc.virsat.model.ext.core;visibility:=reexport");
     _builder.newLine();
     _builder.append("Bundle-RequiredExecutionEnvironment: JavaSE-11");
@@ -76,6 +82,10 @@ public class ConceptPluginManifestGenerator implements IFileContentGenerator {
     _builder.append(_projectName_2, " ");
     _builder.append(".");
     _builder.append(GenerateValidator.PACKAGE_FOLDER, " ");
+    _builder.newLineIfNotEmpty();
+    _builder.append("Automatic-Module-Name: ");
+    String _projectName_3 = builderInfo.getProjectName();
+    _builder.append(_projectName_3);
     _builder.newLineIfNotEmpty();
     return _builder;
   }

--- a/de.dlr.sc.virsat.model.concept/xtend-gen/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginUiManifestGenerator.java
+++ b/de.dlr.sc.virsat.model.concept/xtend-gen/de/dlr/sc/virsat/model/concept/project/filecontent/ConceptPluginUiManifestGenerator.java
@@ -23,7 +23,7 @@ public class ConceptPluginUiManifestGenerator implements IFileContentGenerator {
   }
   
   public String getProjectNameForUiPlugin(final IProjectBuilderInfo builderInfo) {
-    return builderInfo.getProjectName().replace(".ui", "");
+    return builderInfo.getProjectName().substring(0, builderInfo.getProjectName().lastIndexOf("."));
   }
   
   public CharSequence manifestContent(final IProjectBuilderInfo builderInfo) {
@@ -80,6 +80,10 @@ public class ConceptPluginUiManifestGenerator implements IFileContentGenerator {
     _builder.newLine();
     _builder.append("Bundle-ActivationPolicy: lazy");
     _builder.newLine();
+    _builder.append("Automatic-Module-Name: ");
+    String _projectName_1 = builderInfo.getProjectName();
+    _builder.append(_projectName_1);
+    _builder.newLineIfNotEmpty();
     return _builder;
   }
 }


### PR DESCRIPTION
Closes #879 
Closes #1130 

Updates the concept generator:
- Add server depenencies to new concept proejcts
- Update package location of SEIValidator
- Add java 11 automatic module header (we had a warning before)
- Changed way how the main-project name is derived from test & ui projects... before all 'ui' and 'test' strings were simply replaced... This was quite problemativ because it caused errors when the concept hat something with 'test' / 'ui' in its name
- Do a workspace refresh after generation is compelted to make sure icons are shown in the project explorer (also there we had a warning before that icons could not be found although they were generated)

No new concept project do not have warnings anymore. :)