### PR TITLE
Fix hierarchy level checker and their tests

### DIFF
--- a/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/concept/types/structural/level/HierarchyLevelCheckerTest.java
+++ b/de.dlr.sc.virsat.model.extension.tests.test/src/de/dlr/sc/virsat/model/concept/types/structural/level/HierarchyLevelCheckerTest.java
@@ -288,9 +288,9 @@ public class HierarchyLevelCheckerTest extends AConceptTestCase {
 		child1.add(child11);
 		child2.add(child21);
 
-		assertEquals(expectedApplicableLevels(an, bn), checker.getApplicableLevels(parent));
+		assertEquals(expectedApplicableLevels(an), checker.getApplicableLevels(parent));
 		assertEquals(expectedApplicableLevels(an, bn), checker.getApplicableLevels(child1));
-		assertEquals(expectedApplicableLevels(bn, cn), checker.getApplicableLevels(child2));
+		assertEquals(expectedApplicableLevels(bn), checker.getApplicableLevels(child2));
 	}
 
 	@Test


### PR DESCRIPTION
The old level checker was only evaluating the distance to the root when a child existed... which didn't make sense.
-> Fixed that

-> Fixed optional levels beeing ignored.

-> Fixed tests that didn't consider the distance to root