### PR TITLE
Improve data access via virtual satellite headless

### DIFF
--- a/de.dlr.sc.virsat.docs.feature/src/docs/VirSat_Core_Server_Manual.adoc
+++ b/de.dlr.sc.virsat.docs.feature/src/docs/VirSat_Core_Server_Manual.adoc
@@ -192,7 +192,7 @@ TIP: Instead you can also use the Management API of the running Server.
 |Start the Server executable with:
 [subs=+quotes]
 ....
-*"-configFile {path to server.properties}"*
+*"-configFile {path to server.properties}" -port {port}*
 ....
 
 The Server will start and try to load the repositories defined in 

--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/jetty/VirSatJettyServerTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/jetty/VirSatJettyServerTest.java
@@ -78,7 +78,7 @@ public class VirSatJettyServerTest {
 				.sslContext(ctx)
 				.build();
 		
-		URI uriHttp = UriBuilder.fromUri(HttpScheme.HTTP.asString() + "://localhost:" + VirSatJettyServer.VIRSAT_JETTY_PORT).build();
+		URI uriHttp = UriBuilder.fromUri(HttpScheme.HTTP.asString() + "://localhost:" + Activator.VIRSAT_JETTY_PORT).build();
 		httpTarget = httpClient.target(uriHttp).path("/status");
 		
 		URI uriHttps = UriBuilder.fromUri(HttpScheme.HTTPS.asString() + "://localhost:" + VirSatJettyServer.VIRSAT_JETTY_PORT_HTTPS).build();

--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/AModelAccessResourceTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/AModelAccessResourceTest.java
@@ -471,6 +471,10 @@ public abstract class AModelAccessResourceTest extends AServerRepositoryTest {
 		assertBadRequestResponse(response, ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT);
 	}
 	
+	protected void assertForbiddenResponse(Response response) {
+		assertEquals(Status.FORBIDDEN.getStatusCode(), response.getStatus());
+	}
+	
 	protected void assertInternalErrorResponse(Response response, String expectedMessage) {
 		assertErrorResponse(response, Status.INTERNAL_SERVER_ERROR, ApiErrorHelper.INTERNAL_SERVER_ERROR + ": " + expectedMessage);
 	}

--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/AModelAccessResourceTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/AModelAccessResourceTest.java
@@ -17,9 +17,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.List;
 
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.core.HttpHeaders;
@@ -493,9 +497,11 @@ public abstract class AModelAccessResourceTest extends AServerRepositoryTest {
 		Repository repository = ed.getResourceSet().getRepository();
 		
 		assertEquals(HttpStatus.OK_200, response.getStatus());
-		String uuid = response.readEntity(String.class);
-		
-		IUuid obj = RepositoryUtility.findObjectById(uuid, repository);
+		String entityString = response.readEntity(String.class);
+		JsonReader reader = Json.createReader(new StringReader(entityString));
+		JsonObject repsonseObject = reader.readObject();
+
+		IUuid obj = RepositoryUtility.findObjectById(repsonseObject.getString("uuid"), repository);
 		assertNotNull(obj);
 		
 		// Assert correctly typed

--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResourceTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResourceTest.java
@@ -141,13 +141,13 @@ public class CategoryAssignmentResourceTest extends AModelAccessResourceTest {
 		
 		// Assert check ca discipline via sei
 		setDiscipline(tSei.getStructuralElementInstance(), anotherDiscipline);
-		assertCommandNotExecuteableErrorResponse(getTestRequestBuilder(ModelAccessResource.CA + "/" + tcAllProperty.getUuid()).delete());
+		assertForbiddenResponse(getTestRequestBuilder(ModelAccessResource.CA + "/" + tcAllProperty.getUuid()).delete());
 		
 		setDiscipline(tSei.getStructuralElementInstance(), anotherDiscipline);
 		String wantedTypeFqn = tcBeanA.getFullQualifiedCategoryName();
 		
 		Response response = getTestRequestBuilderWithQueryParam(ModelAccessResource.CA + "/" + tSei.getUuid(), 
 				ModelAccessResource.QP_FULL_QUALIFIED_NAME, wantedTypeFqn).post(Entity.json(null));
-		assertCommandNotExecuteableErrorResponse(response);
+		assertForbiddenResponse(response);
 	}
 }

--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResourceTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResourceTest.java
@@ -72,12 +72,12 @@ public class StructuralElementInstanceResourceTest extends AModelAccessResourceT
 		
 		// Assert check sei discipline
 		setDiscipline(tSei.getStructuralElementInstance(), anotherDiscipline);
-		assertCommandNotExecuteableErrorResponse(getTestRequestBuilder(ModelAccessResource.SEI + "/" + tSei.getUuid()).delete());
+		assertForbiddenResponse(getTestRequestBuilder(ModelAccessResource.SEI + "/" + tSei.getUuid()).delete());
 		
 		// Assert check sei children discipline
 		setDiscipline(tSei.getStructuralElementInstance(), discipline);
 		setDiscipline(tSeiChild.getStructuralElementInstance(), anotherDiscipline);
-		assertCommandNotExecuteableErrorResponse(getTestRequestBuilder(ModelAccessResource.SEI + "/" + tSei.getUuid()).delete());
+		assertForbiddenResponse(getTestRequestBuilder(ModelAccessResource.SEI + "/" + tSei.getUuid()).delete());
 
 		// Assert implicit parent discipline rights check
 		setDiscipline(tSei.getStructuralElementInstance(), anotherDiscipline);
@@ -85,6 +85,6 @@ public class StructuralElementInstanceResourceTest extends AModelAccessResourceT
 		
 		Response response = getTestRequestBuilderWithQueryParam(ModelAccessResource.SEI + "/" + tSei.getUuid(), 
 				ModelAccessResource.QP_FULL_QUALIFIED_NAME, wantedTypeFqn).post(Entity.json(null));
-		assertCommandNotExecuteableErrorResponse(response);
+		assertForbiddenResponse(response);
 	}
 }

--- a/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/test/AJettyServerTest.java
+++ b/de.dlr.sc.virsat.server.test/src/de/dlr/sc/virsat/server/test/AJettyServerTest.java
@@ -77,7 +77,7 @@ public abstract class AJettyServerTest extends AConceptTestCase {
 		ClientConfig config = new ClientConfig();
 		Client client = ClientBuilder.newClient(config);
 		
-		URI uri = UriBuilder.fromUri(HttpScheme.HTTP.asString() + "://localhost:" + VirSatJettyServer.VIRSAT_JETTY_PORT).build();
+		URI uri = UriBuilder.fromUri(HttpScheme.HTTP.asString() + "://localhost:" + Activator.VIRSAT_JETTY_PORT).build();
 		webTarget = client.target(uri).path("/rest");
 	}
 

--- a/de.dlr.sc.virsat.server/plugin.xml
+++ b/de.dlr.sc.virsat.server/plugin.xml
@@ -20,6 +20,7 @@
             command="configFile">
      </clArgs>
      <clArgs
+            attribute="number"
             command="port">
      </clArgs>
    </extension>

--- a/de.dlr.sc.virsat.server/plugin.xml
+++ b/de.dlr.sc.virsat.server/plugin.xml
@@ -19,5 +19,9 @@
             attribute="file"
             command="configFile">
      </clArgs>
+     <clArgs
+            attribute="test"
+            command="port">
+     </clArgs>
    </extension>
 </plugin>

--- a/de.dlr.sc.virsat.server/plugin.xml
+++ b/de.dlr.sc.virsat.server/plugin.xml
@@ -20,7 +20,6 @@
             command="configFile">
      </clArgs>
      <clArgs
-            attribute="test"
             command="port">
      </clArgs>
    </extension>

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/Activator.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/Activator.java
@@ -34,8 +34,12 @@ public class Activator extends Plugin {
 	private static Activator plugin;
 	// The CLI command line option for specifying a configuration file
 	private static final String CONFIG_FILE_CLI_PARAM = "configFile";
+	// The CLI command line option for setting the port
+	private static final String PORT_CLI_PARAM = "port";
 	// The configuration file path and its default value
 	private String propertiesFilePath = "resources/server.properties";
+	// The default port for our server
+	public static final int VIRSAT_JETTY_PORT = 8000;
 	
 	@Override
 	public void start(BundleContext context) throws Exception {
@@ -71,6 +75,20 @@ public class Activator extends Plugin {
 			return new FileInputStream(propertiesFilePath);
 		} else {
 			return FileLocator.openStream(getBundle(), new Path(propertiesFilePath), false); 
+		}
+	}
+	
+	/**
+	 * Get the specified jetty server port or default
+	 * @return the port as int
+	 */
+	public int getServerPort() {
+		CommandLineManager cliManager = de.dlr.sc.virsat.external.lib.commons.cli.Activator.getCommandLineManager();
+		boolean isCustomPathSet = cliManager.isCommandLineOptionSet(PORT_CLI_PARAM);
+		if (isCustomPathSet) {
+			return Integer.parseInt(cliManager.getCommandLineOptionParameter(PORT_CLI_PARAM));
+		} else {
+			return VIRSAT_JETTY_PORT;
 		}
 	}
 

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/VirSatServerApplication.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/VirSatServerApplication.java
@@ -61,11 +61,8 @@ public class VirSatServerApplication implements IApplication {
 		}
 		
 		System.out.println("About to start the Jetty Server instance...");
-		int port = Activator.getDefault().getServerPort();
-		System.out.println("Using port: " + String.format("%04d", port));
 		
 		jettyServer = new VirSatJettyServer();
-		jettyServer.setServerPort(port);
 		jettyServer.init();
 		jettyServer.start().join();
 		

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/VirSatServerApplication.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/VirSatServerApplication.java
@@ -61,8 +61,11 @@ public class VirSatServerApplication implements IApplication {
 		}
 		
 		System.out.println("About to start the Jetty Server instance...");
+		int port = Activator.getDefault().getServerPort();
+		System.out.println("Using port: " + String.format("%04d", port));
 		
 		jettyServer = new VirSatJettyServer();
+		jettyServer.setServerPort(port);
 		jettyServer.init();
 		jettyServer.start().join();
 		

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/jetty/VirSatJettyServer.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/jetty/VirSatJettyServer.java
@@ -41,13 +41,13 @@ public class VirSatJettyServer {
 
 	public VirSatJettyServer() { }
 	
-	public static final int VIRSAT_JETTY_PORT = 8000;
 	public static final int VIRSAT_JETTY_PORT_HTTPS = 8443;
 	public static final String PATH = "/rest";
 	public static final String STATUS = "/status";
 	private static final String SUFFIX = "/*";
 	
 	private LoginService loginService = null;
+	private int serverPort;
 
 	/**
 	 * Main entry point for Virtual Satellite Jetty Server
@@ -102,6 +102,10 @@ public class VirSatJettyServer {
 		setupSecurity(server, servletContextHandler);
 	}
 	
+	public void setServerPort(int port) {
+		this.serverPort = port;
+	}
+	
 	/**
 	 * Setup and add HTTP connector to the server
 	 * @param server the Server
@@ -153,7 +157,7 @@ public class VirSatJettyServer {
 		// Simple HTTP connector
 		final ServerConnector http = new ServerConnector(server,
 				new HttpConnectionFactory(httpConfiguration));
-		http.setPort(VIRSAT_JETTY_PORT);
+		http.setPort(serverPort);
 		server.addConnector(http);
 	}
 

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/jetty/VirSatJettyServer.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/jetty/VirSatJettyServer.java
@@ -41,13 +41,14 @@ public class VirSatJettyServer {
 
 	public VirSatJettyServer() { }
 	
+	public static final int VIRSAT_JETTY_PORT = 8000;
 	public static final int VIRSAT_JETTY_PORT_HTTPS = 8443;
 	public static final String PATH = "/rest";
 	public static final String STATUS = "/status";
 	private static final String SUFFIX = "/*";
 	
 	private LoginService loginService = null;
-	private int serverPort;
+	private int serverPort = -1;
 
 	/**
 	 * Main entry point for Virtual Satellite Jetty Server
@@ -135,8 +136,12 @@ public class VirSatJettyServer {
 		ServerConnector httpsConnector = new ServerConnector(server,
 			new SslConnectionFactory(sslContextFactory, HttpVersion.HTTP_1_1.asString()),
 			new HttpConnectionFactory(httpsConf));
-		httpsConnector.setPort(VIRSAT_JETTY_PORT_HTTPS);
-
+		if (serverPort != -1) {
+			httpsConnector.setPort(serverPort);
+		} else {
+			httpsConnector.setPort(VIRSAT_JETTY_PORT_HTTPS);
+		}
+		
 		server.addConnector(httpsConnector);
 	}
 
@@ -157,7 +162,11 @@ public class VirSatJettyServer {
 		// Simple HTTP connector
 		final ServerConnector http = new ServerConnector(server,
 				new HttpConnectionFactory(httpConfiguration));
-		http.setPort(serverPort);
+		if (serverPort != -1) {
+			http.setPort(serverPort);
+		} else {
+			http.setPort(VIRSAT_JETTY_PORT);
+		}
 		server.addConnector(http);
 	}
 

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ApiErrorHelper.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ApiErrorHelper.java
@@ -46,7 +46,7 @@ public class ApiErrorHelper {
 		if (ed.getVirSatCommandStack().canExecute(command, iUserContext)) {
 			ed.getVirSatCommandStack().executeNoUndo(command, iUserContext, false);
 		} else {
-			throw new RuntimeException(NOT_EXECUTEABLE);
+			throw new IllegalArgumentException(NOT_EXECUTEABLE);
 		}
 	}
 

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ModelAccessResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ModelAccessResource.java
@@ -40,6 +40,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanStructuralElementInstanceFactory;
 import de.dlr.sc.virsat.model.concept.types.roles.BeanDiscipline;
 import de.dlr.sc.virsat.model.concept.types.structural.ABeanStructuralElementInstance;
+import de.dlr.sc.virsat.model.concept.types.structural.BeanStructuralElementInstance;
 import de.dlr.sc.virsat.model.dvlm.Repository;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
 import de.dlr.sc.virsat.model.dvlm.concepts.registry.ActiveConceptConfigurationElement;
@@ -363,10 +364,10 @@ public class ModelAccessResource {
 			try {
 				serverRepository.syncRepository();
 				
-				String newSeiUuid = createSeiFromFqn(fullQualifiedName, repository, ed, userContext);
+				BeanStructuralElementInstance newSeiBean = createSeiFromFqn(fullQualifiedName, repository, ed, userContext);
 				
 				serverRepository.syncRepository();
-				return Response.ok(newSeiUuid).build();
+				return Response.ok(newSeiBean).build();
 			} catch (Exception e) {
 				return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 			}
@@ -551,7 +552,7 @@ public class ModelAccessResource {
 	 * @param iUserContext the user context
 	 * @return uuid of the created sei
 	 */
-	public static String createSeiFromFqn(String fullQualifiedName, EObject owner, VirSatTransactionalEditingDomain editingDomain, IUserContext iUserContext) {
+	public static BeanStructuralElementInstance createSeiFromFqn(String fullQualifiedName, EObject owner, VirSatTransactionalEditingDomain editingDomain, IUserContext iUserContext) {
 		ActiveConceptHelper helper = new ActiveConceptHelper(editingDomain.getResourceSet().getRepository());
 		StructuralElement se = helper.getStructuralElement(fullQualifiedName);
 		StructuralElementInstance newSei = new StructuralInstantiator().generateInstance(se, null);
@@ -564,6 +565,6 @@ public class ModelAccessResource {
 		Command createCommand = CreateAddSeiWithFileStructureCommand.create(editingDomain, owner, newSei);
 		ApiErrorHelper.executeCommandIffCanExecute(createCommand, editingDomain, iUserContext);
 		
-		return newSei.getUuid().toString();
+		return new BeanStructuralElementInstance(newSei);
 	}
 }

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/CategoryAssignmentResource.java
@@ -26,6 +26,7 @@ import org.eclipse.emf.edit.command.AddCommand;
 import org.eclipse.jetty.http.HttpStatus;
 
 import de.dlr.sc.virsat.model.concept.types.category.ABeanCategoryAssignment;
+import de.dlr.sc.virsat.model.concept.types.category.BeanCategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanCategoryAssignmentFactory;
 import de.dlr.sc.virsat.model.dvlm.categories.CategoriesPackage;
@@ -105,6 +106,9 @@ public class CategoryAssignmentResource {
 				code = HttpStatus.OK_200,
 				message = ApiErrorHelper.SUCCESSFUL_OPERATION),
 		@ApiResponse(
+				code = HttpStatus.FORBIDDEN_403, 
+				message = ApiErrorHelper.NOT_EXECUTEABLE),
+		@ApiResponse(
 				code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 				message = ApiErrorHelper.INTERNAL_SERVER_ERROR)})
 	public Response putCa(@ApiParam(value = "CA to put", required = true) ABeanCategoryAssignment bean) {
@@ -134,6 +138,9 @@ public class CategoryAssignmentResource {
 				code = HttpStatus.BAD_REQUEST_400, 
 				message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
 		@ApiResponse(
+				code = HttpStatus.FORBIDDEN_403, 
+				message = ApiErrorHelper.NOT_EXECUTEABLE),
+		@ApiResponse(
 				code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 				message = ApiErrorHelper.NOT_EXECUTEABLE),
 		@ApiResponse(
@@ -159,7 +166,12 @@ public class CategoryAssignmentResource {
 			ApiErrorHelper.executeCommandIffCanExecute(createCommand, parentResource.getEd(), parentResource.getUser());
 			
 			parentResource.synchronize();
-			return Response.ok(newCa.getUuid().toString()).build();
+			
+			BeanCategoryAssignment newCaBean = new BeanCategoryAssignment();
+			newCaBean.setTypeInstance(newCa);
+			return Response.ok(newCaBean).build();
+		} catch (IllegalArgumentException e) {
+			return Response.status(Response.Status.FORBIDDEN).entity("Forbidden").build();
 		} catch (Exception e) {
 			return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 		}
@@ -181,6 +193,9 @@ public class CategoryAssignmentResource {
 		@ApiResponse(
 				code = HttpStatus.BAD_REQUEST_400,
 				message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
+		@ApiResponse(
+				code = HttpStatus.FORBIDDEN_403, 
+				message = ApiErrorHelper.NOT_EXECUTEABLE),
 		@ApiResponse(
 				code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 				message = ApiErrorHelper.NOT_EXECUTEABLE),
@@ -204,6 +219,8 @@ public class CategoryAssignmentResource {
 			// Sync after delete
 			parentResource.synchronize();
 			return Response.ok().build();
+		} catch (IllegalArgumentException e) {
+			return Response.status(Response.Status.FORBIDDEN).entity("Forbidden").build();
 		} catch (Exception e) {
 			return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 		}

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResource.java
@@ -134,6 +134,9 @@ public class StructuralElementInstanceResource {
 				code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 				message = ApiErrorHelper.NOT_EXECUTEABLE),
 		@ApiResponse(
+				code = HttpStatus.FORBIDDEN_403, 
+				message = ApiErrorHelper.NOT_EXECUTEABLE),
+		@ApiResponse(
 				code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 				message = ApiErrorHelper.INTERNAL_SERVER_ERROR)})
 	public Response createSei(@PathParam("seiUuid") @ApiParam(value = "parent uuid", required = true) String parentUuid,
@@ -151,6 +154,8 @@ public class StructuralElementInstanceResource {
 			
 			parentResource.synchronize();
 			return Response.ok(newSeiBean).build();
+		} catch (IllegalArgumentException e) {
+			return Response.status(Response.Status.FORBIDDEN).entity("Forbidden").build();
 		} catch (Exception e) {
 			return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 		}
@@ -176,6 +181,9 @@ public class StructuralElementInstanceResource {
 				code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 				message = ApiErrorHelper.NOT_EXECUTEABLE),
 		@ApiResponse(
+				code = HttpStatus.FORBIDDEN_403, 
+				message = ApiErrorHelper.NOT_EXECUTEABLE),
+		@ApiResponse(
 				code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
 				message = ApiErrorHelper.INTERNAL_SERVER_ERROR)})
 	public Response deleteSei(@PathParam("seiUuid") @ApiParam(value = "Uuid of the SEI", required = true)  String seiUuid) {
@@ -195,6 +203,8 @@ public class StructuralElementInstanceResource {
 			// Sync after delete
 			parentResource.synchronize();
 			return Response.ok().build();
+		} catch (IllegalArgumentException e) {
+			return Response.status(Response.Status.FORBIDDEN).entity("Forbidden").build();
 		} catch (Exception e) {
 			return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 		}

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResource.java
@@ -26,6 +26,7 @@ import org.eclipse.jetty.http.HttpStatus;
 
 import de.dlr.sc.virsat.model.concept.types.factory.BeanStructuralElementInstanceFactory;
 import de.dlr.sc.virsat.model.concept.types.structural.ABeanStructuralElementInstance;
+import de.dlr.sc.virsat.model.concept.types.structural.BeanStructuralElementInstance;
 import de.dlr.sc.virsat.model.concept.types.structural.IBeanStructuralElementInstance;
 import de.dlr.sc.virsat.model.dvlm.structural.StructuralElementInstance;
 import de.dlr.sc.virsat.project.structure.command.CreateRemoveSeiWithFileStructureCommand;
@@ -146,10 +147,10 @@ public class StructuralElementInstanceResource {
 			if (parentSei == null) {
 				return ApiErrorHelper.createNotFoundErrorResponse();
 			}
-			String newSeiUuid = ModelAccessResource.createSeiFromFqn(fullQualifiedName, parentSei, parentResource.getEd(), parentResource.getUser());
+			BeanStructuralElementInstance newSeiBean = ModelAccessResource.createSeiFromFqn(fullQualifiedName, parentSei, parentResource.getEd(), parentResource.getUser());
 			
 			parentResource.synchronize();
-			return Response.ok(newSeiUuid).build();
+			return Response.ok(newSeiBean).build();
 		} catch (Exception e) {
 			return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 		}


### PR DESCRIPTION
In this PR, we imrpove the generall usage and data access of our Virtual Satellite Headless Server.

Includes
- Enable customization of Port (and prints activated port)
- Return new objects instead of only their UUID on POST requests
- Improves error response if user does not have rights to modify data model (as specified in the Rolemanagement)