### PR TITLE
Task #1196 - Use the provided query parameter name when creating a SEI

### DIFF
--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/VirSatServerApplication.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/VirSatServerApplication.java
@@ -67,8 +67,9 @@ public class VirSatServerApplication implements IApplication {
 		jettyServer = new VirSatJettyServer();
 		jettyServer.setServerPort(port);
 		jettyServer.init();
-		jettyServer.start().join();
+		jettyServer.start();
 		System.out.println("Jetty Server started.");
+		jettyServer.join();
 		System.out.println("--------------------------------------------------");
 		System.out.println("The server stopped, I am about to shut down.");
 		System.out.println("Bye Bye, see you on the launch pad...");

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/VirSatServerApplication.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/VirSatServerApplication.java
@@ -68,7 +68,7 @@ public class VirSatServerApplication implements IApplication {
 		jettyServer.setServerPort(port);
 		jettyServer.init();
 		jettyServer.start().join();
-		
+		System.out.println("Jetty Server started.");
 		System.out.println("--------------------------------------------------");
 		System.out.println("The server stopped, I am about to shut down.");
 		System.out.println("Bye Bye, see you on the launch pad...");

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ModelAccessResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ModelAccessResource.java
@@ -9,7 +9,6 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.server.resources;
 
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -78,31 +77,23 @@ import io.swagger.annotations.SwaggerDefinition;
 import io.swagger.annotations.Tag;
 
 /**
- * The resource to access the VirSat data model of a server repository
- * Provides an endpoint to access a repository
+ * The resource to access the VirSat data model of a server repository Provides
+ * an endpoint to access a repository
  */
-@Api(authorizations = {@Authorization(value = "basic")})
-@SwaggerDefinition(
-	info = @Info(
-		version = VirSatModelAccessServlet.MODEL_API_VERSION,
-		title = "The Model API",
-		description = "API to access the Virtual Satellite data model"
-	),
-	basePath = VirSatJettyServer.PATH + VirSatModelAccessServlet.MODEL_API,
-	tags = {
+@Api(authorizations = { @Authorization(value = "basic") })
+@SwaggerDefinition(info = @Info(version = VirSatModelAccessServlet.MODEL_API_VERSION, title = "The Model API", description = "API to access the Virtual Satellite data model"), basePath = VirSatJettyServer.PATH
+		+ VirSatModelAccessServlet.MODEL_API, tags = {
 			@Tag(name = ModelAccessResource.TAG_QUDV, description = "Quantity Kinds and Units"),
 			@Tag(name = ModelAccessResource.TAG_SEI, description = "Structural Element Instances"),
 			@Tag(name = ModelAccessResource.TAG_CA, description = "Category Assignments"),
 			@Tag(name = ModelAccessResource.TAG_PROPERTY, description = "Properties of Category Assignments"),
-			@Tag(name = ModelAccessResource.TAG_DISCIPLINE, description = "Disciplines for Rolemanagement")
-	}
-)
+			@Tag(name = ModelAccessResource.TAG_DISCIPLINE, description = "Disciplines for Rolemanagement") })
 @Path(ModelAccessResource.PATH)
 public class ModelAccessResource {
 
 	@Inject
 	TransactionalJsonProvider provider;
-	
+
 	public static final String PATH = "/repository";
 
 	public static final String ROOT_SEIS = "seis";
@@ -117,7 +108,7 @@ public class ModelAccessResource {
 	public static final String PROPERTY = "property";
 	public static final String FORCE_SYNC = "forceSync";
 	public static final String QUDV = "qudv";
-	
+
 	public static final String QP_ONLY_ACTIVE_CONCEPTS = "onlyActiveConcepts";
 	public static final String QP_FULL_QUALIFIED_NAME = "fullQualifiedName";
 	public static final String QP_NAME = "name";
@@ -132,65 +123,57 @@ public class ModelAccessResource {
 
 	// List of all resource classes used in this class
 	// Used to register model specific filters
-	public static final List<?> RESOURCE_CLASSES = Arrays.asList(
-			RepoModelAccessResource.class,
-			StructuralElementInstanceResource.class,
-			CategoryAssignmentResource.class,
-			PropertyResource.class,
-			DisciplineResource.class,
-			QudvResource.class);
-	
-	public ModelAccessResource() { }
-	
-	
+	public static final List<?> RESOURCE_CLASSES = Arrays.asList(RepoModelAccessResource.class,
+			StructuralElementInstanceResource.class, CategoryAssignmentResource.class, PropertyResource.class,
+			DisciplineResource.class, QudvResource.class);
+
+	public ModelAccessResource() {
+	}
+
 	/**
-	 * Get the ServerRepository corresponding to the repoName and create a new RepoModelAccessResource
-	 * @param repoName of the repository to be accessed by the request
+	 * Get the ServerRepository corresponding to the repoName and create a new
+	 * RepoModelAccessResource
+	 * 
+	 * @param repoName    of the repository to be accessed by the request
 	 * @param synchronize if synchronization is requested
-	 * @param build if building is requested
-	 * @param sc the security context
+	 * @param build       if building is requested
+	 * @param sc          the security context
 	 * @return RepoModelAccessResource or null if the repo is not found
 	 */
 	@Path("{repoName}")
 	public RepoModelAccessResource getConcreteResource(
 			@PathParam("repoName") @ApiParam(value = "Name of the repository", required = true) String repoName,
-			
-			@ApiParam(value = "Synchronize with the repository on this request", required = false)
-			@QueryParam(ModelAccessResource.QP_SYNC) @DefaultValue("true") boolean synchronize,
-			
-			@ApiParam(value = "Build when synchronizing on this request", required = false)
-			@QueryParam(ModelAccessResource.QP_BUILD) @DefaultValue("true") boolean build,
+
+			@ApiParam(value = "Synchronize with the repository on this request", required = false) @QueryParam(ModelAccessResource.QP_SYNC) @DefaultValue("true") boolean synchronize,
+
+			@ApiParam(value = "Build when synchronizing on this request", required = false) @QueryParam(ModelAccessResource.QP_BUILD) @DefaultValue("true") boolean build,
 			@Context SecurityContext sc) {
-		
+
 		ServerRepository repo = RepoRegistry.getInstance().getRepository(repoName);
 		if (repo != null) {
 			provider.setServerRepository(repo);
-			
+
 			// Override current user with a custom user context
 			IUserContext userContext = new ServerUserContext(sc);
 			provider.setContext(userContext);
-			
+
 			return new RepoModelAccessResource(repo, synchronize, build, userContext);
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * The resource to access the VirSat data model of a specific server repository
-	 * Provides the following endpoints:
-	 *   - Get roots seis
-	 *   - Get and update sei by uuid
-	 *   - Get disciplines
-	 *   - Get concepts
-	 *   - Get and update ca (with property uuids) by uuid
-	 *   - Get and update ca with properties by uuid
-	 *   - Get and update properties by uuid
+	 * Provides the following endpoints: - Get roots seis - Get and update sei by
+	 * uuid - Get disciplines - Get concepts - Get and update ca (with property
+	 * uuids) by uuid - Get and update ca with properties by uuid - Get and update
+	 * properties by uuid
 	 */
-	@Api(hidden = true, authorizations = {@Authorization(value = "basic")})
-	@RolesAllowed({ServerRoles.ADMIN, ServerRoles.USER})
+	@Api(hidden = true, authorizations = { @Authorization(value = "basic") })
+	@RolesAllowed({ ServerRoles.ADMIN, ServerRoles.USER })
 	public static class RepoModelAccessResource {
-		
+
 		private Repository repository;
 		private VirSatTransactionalEditingDomain ed;
 		private ServerRepository serverRepository;
@@ -200,12 +183,14 @@ public class ModelAccessResource {
 
 		/**
 		 * Constructor that holds all information of the request
+		 * 
 		 * @param serverRepository of this concrete resource
-		 * @param synchronize if synchronization is requested
-		 * @param build if building is requested
-		 * @param userContext the authenticated user
+		 * @param synchronize      if synchronization is requested
+		 * @param build            if building is requested
+		 * @param userContext      the authenticated user
 		 */
-		public RepoModelAccessResource(ServerRepository serverRepository, boolean synchronize, boolean build, IUserContext userContext) {
+		public RepoModelAccessResource(ServerRepository serverRepository, boolean synchronize, boolean build,
+				IUserContext userContext) {
 			this.serverRepository = serverRepository;
 			this.synchronize = synchronize;
 			this.build = build;
@@ -216,6 +201,7 @@ public class ModelAccessResource {
 
 		/**
 		 * Synchronize depending on the synchronize and build query parameter
+		 * 
 		 * @throws Exception thrown if the synchronization fails
 		 */
 		public void synchronize() throws Exception {
@@ -229,12 +215,12 @@ public class ModelAccessResource {
 		public Repository getRepository() {
 			return repository;
 		}
-		
+
 		@ApiOperation(hidden = true, value = "")
 		public VirSatTransactionalEditingDomain getEd() {
 			return ed;
 		}
-		
+
 		@ApiOperation(hidden = true, value = "")
 		public IUserContext getUser() {
 			return userContext;
@@ -250,40 +236,33 @@ public class ModelAccessResource {
 		public CategoryAssignmentResource getCategoryAssignmentResource() {
 			return new CategoryAssignmentResource(this);
 		}
-		
+
 		@Path(SEI)
 		public StructuralElementInstanceResource getStructuralElementInstanceResource() {
 			return new StructuralElementInstanceResource(this);
 		}
-		
+
 		@Path(DISCIPLINE)
 		public DisciplineResource getDisciplineResource() {
 			return new DisciplineResource(this);
 		}
-		
+
 		@Path(QUDV)
 		public QudvResource getQudvResource() {
 			return new QudvResource(this);
 		}
-		
+
 		// Actual resources
 		/**
 		 * This service forces a synchronization with the backend.
+		 * 
 		 * @return ok iff no exception occurred during synchronization
 		 */
 		@GET
 		@Path(FORCE_SYNC)
-		@ApiOperation(
-				value = "Trigger synchronization with the backend",
-				httpMethod = "GET",
-				notes = "This service forces a synchronization with the backend.")
-		@ApiResponses(value = { 
-			@ApiResponse(
-					code = HttpStatus.OK_200,
-					message = ApiErrorHelper.SUCCESSFUL_OPERATION),
-			@ApiResponse(
-					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
-					message = ApiErrorHelper.INTERNAL_SERVER_ERROR)})
+		@ApiOperation(value = "Trigger synchronization with the backend", httpMethod = "GET", notes = "This service forces a synchronization with the backend.")
+		@ApiResponses(value = { @ApiResponse(code = HttpStatus.OK_200, message = ApiErrorHelper.SUCCESSFUL_OPERATION),
+			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
 		public Response forceSynchronize() {
 			try {
 				serverRepository.syncRepository(build);
@@ -292,82 +271,67 @@ public class ModelAccessResource {
 			}
 			return Response.ok().build();
 		}
-		
+
 		/**
-		 * This service fetches the root StructuralElementInstances.
-		 * It can be used as an entry point into the data model.
+		 * This service fetches the root StructuralElementInstances. It can be used as
+		 * an entry point into the data model.
+		 * 
 		 * @return the fetched root structural element instances
 		 */
 		@GET
 		@Path(ROOT_SEIS)
 		@Produces(MediaType.APPLICATION_JSON)
-		@ApiOperation(
-				produces = "application/json",
-				value = "Fetch a list of root SEIs",
-				httpMethod = "GET",
-				notes = "This service fetches the root StructuralElementInstances. "
-						+ "It can be used as an entry point into the data model.")
-		@ApiResponses(value = { 
-			@ApiResponse(
-					code = HttpStatus.OK_200,
-					response = ABeanStructuralElementInstance.class,
-					responseContainer = "List",
-					message = ApiErrorHelper.SUCCESSFUL_OPERATION),
-			@ApiResponse(
-					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
-					message = ApiErrorHelper.INTERNAL_SERVER_ERROR)})
+		@ApiOperation(produces = "application/json", value = "Fetch a list of root SEIs", httpMethod = "GET", notes = "This service fetches the root StructuralElementInstances. "
+				+ "It can be used as an entry point into the data model.")
+		@ApiResponses(value = {
+			@ApiResponse(code = HttpStatus.OK_200, response = ABeanStructuralElementInstance.class, responseContainer = "List", message = ApiErrorHelper.SUCCESSFUL_OPERATION),
+			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
 		public Response getRootSeis() {
 			try {
 				synchronize();
-				
+
 				List<StructuralElementInstance> rootSeis = repository.getRootEntities();
 				List<ABeanStructuralElementInstance> beans = new ArrayList<ABeanStructuralElementInstance>();
-				
+
 				for (StructuralElementInstance sei : rootSeis) {
-					beans.add((ABeanStructuralElementInstance) new BeanStructuralElementInstanceFactory().getInstanceFor(sei));
+					beans.add((ABeanStructuralElementInstance) new BeanStructuralElementInstanceFactory()
+							.getInstanceFor(sei));
 				}
-				
-				GenericEntity<List<ABeanStructuralElementInstance>> genericEntityList =
-						new GenericEntity<List<ABeanStructuralElementInstance>>(beans) { };
-				
+
+				GenericEntity<List<ABeanStructuralElementInstance>> genericEntityList = new GenericEntity<List<ABeanStructuralElementInstance>>(
+						beans) {
+				};
+
 				return Response.ok(genericEntityList).build();
 			} catch (Exception e) {
 				return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 			}
 		}
-		
+
 		/**
-		 * This service creates a new root StructuralElementInstance and returns its uuid
+		 * This service creates a new root StructuralElementInstance and returns its
+		 * uuid
+		 * 
 		 * @param fullQualifiedName the full qualified name of the SEI type
 		 * @return the created root sei
 		 */
 		@POST
 		@Path(ROOT_SEIS)
 		@Consumes(MediaType.APPLICATION_JSON)
-		@ApiOperation(
-				consumes = "application/json",
-				value = "Create root SEI",
-				httpMethod = "POST",
-				notes = "This service creates a new root StructuralElementInstance and returns its uuid")
-		@ApiResponses(value = { 
-			@ApiResponse(
-					code = HttpStatus.OK_200,
-					response = String.class,
-					message = ApiErrorHelper.SUCCESSFUL_OPERATION),
-			@ApiResponse(
-					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
-					message = ApiErrorHelper.NOT_EXECUTEABLE),
-			@ApiResponse(
-					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
-					message = ApiErrorHelper.INTERNAL_SERVER_ERROR)})
-		public Response createRootSei(@QueryParam(value = ModelAccessResource.QP_FULL_QUALIFIED_NAME) 
-			@ApiParam(value = "Full qualified name of the SEI type", required = true) String fullQualifiedName,
-			@QueryParam(value = ModelAccessResource.QP_NAME) @ApiParam(value = "name of the new SEI", required = false) String name) {
+		@ApiOperation(consumes = "application/json", value = "Create root SEI", httpMethod = "POST", notes = "This service creates a new root StructuralElementInstance and returns its uuid")
+		@ApiResponses(value = {
+			@ApiResponse(code = HttpStatus.OK_200, response = String.class, message = ApiErrorHelper.SUCCESSFUL_OPERATION),
+			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.NOT_EXECUTEABLE),
+			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
+		public Response createRootSei(
+				@QueryParam(value = ModelAccessResource.QP_FULL_QUALIFIED_NAME) @ApiParam(value = "Full qualified name of the SEI type", required = true) String fullQualifiedName,
+				@QueryParam(value = ModelAccessResource.QP_NAME) @ApiParam(value = "name of the new SEI", required = false) String name) {
 			try {
 				serverRepository.syncRepository();
-				
-				IBeanStructuralElementInstance newSeiBean = createSeiFromFqn(fullQualifiedName, repository, ed, userContext, name);
-				
+
+				IBeanStructuralElementInstance newSeiBean = createSeiFromFqn(fullQualifiedName, repository, ed,
+						userContext, name);
+
 				serverRepository.syncRepository();
 				return Response.ok(newSeiBean).build();
 			} catch (Exception e) {
@@ -377,33 +341,25 @@ public class ModelAccessResource {
 
 		/**
 		 * This service fetches the active Concepts
+		 * 
 		 * @param onlyActiveConcepts only fetch the active concepts
 		 * @return fetched list of concepts
 		 */
 		@GET
 		@Path(CONCEPTS)
 		@Produces(MediaType.APPLICATION_JSON)
-		@ApiOperation(
-				produces = "application/json",
-				value = "Fetch a list of active Concepts",
-				httpMethod = "GET",
-				notes = "This service fetches the active Concepts")
-		@ApiResponses(value = { 
-			@ApiResponse(
-					code = HttpStatus.OK_200,
-					response = ServerConcept.class,
-					responseContainer = "List",
-					message = ApiErrorHelper.SUCCESSFUL_OPERATION),
-			@ApiResponse(
-					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
-					message = ApiErrorHelper.INTERNAL_SERVER_ERROR)})
-		public Response getConcepts(@DefaultValue("true") @QueryParam(QP_ONLY_ACTIVE_CONCEPTS) boolean onlyActiveConcepts) {
+		@ApiOperation(produces = "application/json", value = "Fetch a list of active Concepts", httpMethod = "GET", notes = "This service fetches the active Concepts")
+		@ApiResponses(value = {
+			@ApiResponse(code = HttpStatus.OK_200, response = ServerConcept.class, responseContainer = "List", message = ApiErrorHelper.SUCCESSFUL_OPERATION),
+			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
+		public Response getConcepts(
+				@DefaultValue("true") @QueryParam(QP_ONLY_ACTIVE_CONCEPTS) boolean onlyActiveConcepts) {
 			try {
 				synchronize();
-				
+
 				List<ServerConcept> pojos = new ArrayList<ServerConcept>();
 				List<Concept> concepts;
-				
+
 				if (onlyActiveConcepts) {
 					concepts = repository.getActiveConcepts();
 				} else {
@@ -411,163 +367,146 @@ public class ModelAccessResource {
 					concepts = new ArrayList<Concept>();
 					IExtensionRegistry registry = Platform.getExtensionRegistry();
 					String extensionPoint = ActiveConceptConfigurationElement.EXTENSION_POINT_ID_CONCEPT;
-					
+
 					// Get the concept configuration elements
-					IConfigurationElement[] configurationElementsArray = registry.getConfigurationElementsFor(extensionPoint);
-					
+					IConfigurationElement[] configurationElementsArray = registry
+							.getConfigurationElementsFor(extensionPoint);
+
 					// For each configuration element load the concept
 					for (IConfigurationElement configurationElement : configurationElementsArray) {
-						ActiveConceptConfigurationElement acce = new ActiveConceptConfigurationElement(configurationElement);
+						ActiveConceptConfigurationElement acce = new ActiveConceptConfigurationElement(
+								configurationElement);
 						concepts.add(acce.loadConceptFromPlugin());
 					}
 				}
-				
+
 				for (Concept concept : concepts) {
 					pojos.add(new ServerConcept(concept));
 				}
-				
-				GenericEntity<List<ServerConcept>> entity = new GenericEntity<List<ServerConcept>>(pojos) { };
-				
+
+				GenericEntity<List<ServerConcept>> entity = new GenericEntity<List<ServerConcept>>(pojos) {
+				};
+
 				return Response.ok(entity).build();
 			} catch (Exception e) {
 				return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 			}
 		}
-		
+
 		/**
 		 * This service fetches the existing Disciplines
+		 * 
 		 * @return the fetched disciplines
 		 */
 		@GET
 		@Path(DISCIPLINES)
 		@Produces(MediaType.APPLICATION_JSON)
-		@ApiOperation(
-				produces = "application/json",
-				value = "Fetch a list of all Disciplines",
-				httpMethod = "GET",
-				notes = "This service fetches the existing Disciplines")
-		@ApiResponses(value = { 
-			@ApiResponse(
-					code = HttpStatus.OK_200,
-					response = BeanDiscipline.class,
-					responseContainer = "List",
-					message = ApiErrorHelper.SUCCESSFUL_OPERATION),
-			@ApiResponse(
-					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
-					message = ApiErrorHelper.INTERNAL_SERVER_ERROR)})
+		@ApiOperation(produces = "application/json", value = "Fetch a list of all Disciplines", httpMethod = "GET", notes = "This service fetches the existing Disciplines")
+		@ApiResponses(value = {
+			@ApiResponse(code = HttpStatus.OK_200, response = BeanDiscipline.class, responseContainer = "List", message = ApiErrorHelper.SUCCESSFUL_OPERATION),
+			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
 		public Response getDisciplines() {
 			try {
 				synchronize();
-				
+
 				List<BeanDiscipline> pojos = new ArrayList<BeanDiscipline>();
 				List<Discipline> disciplines = repository.getRoleManagement().getDisciplines();
-				
+
 				for (Discipline discipline : disciplines) {
 					pojos.add(new BeanDiscipline(discipline));
 				}
-				
-				GenericEntity<List<BeanDiscipline>> entity = new GenericEntity<List<BeanDiscipline>>(pojos) { };
-				
+
+				GenericEntity<List<BeanDiscipline>> entity = new GenericEntity<List<BeanDiscipline>>(pojos) {
+				};
+
 				return Response.ok(entity).build();
 			} catch (Exception e) {
 				return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 			}
 		}
-		
+
 		/**
 		 * This service fetches the discipline of the rolemanagement
+		 * 
 		 * @return the fetched discipline
 		 */
 		@GET
 		@Path(ROLEMANAGEMENT)
 		@Produces(MediaType.APPLICATION_JSON)
-		@ApiOperation(
-				produces = "application/json",
-				value = "Fetch discipline of the rolemanagement",
-				httpMethod = "GET",
-				notes = "This service fetches the discipline of the rolemanagement")
-		@ApiResponses(value = { 
-			@ApiResponse(
-					code = HttpStatus.OK_200,
-					response = BeanDiscipline.class,
-					message = ApiErrorHelper.SUCCESSFUL_OPERATION),
-			@ApiResponse(
-					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
-					message = ApiErrorHelper.INTERNAL_SERVER_ERROR)})
+		@ApiOperation(produces = "application/json", value = "Fetch discipline of the rolemanagement", httpMethod = "GET", notes = "This service fetches the discipline of the rolemanagement")
+		@ApiResponses(value = {
+			@ApiResponse(code = HttpStatus.OK_200, response = BeanDiscipline.class, message = ApiErrorHelper.SUCCESSFUL_OPERATION),
+			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
 		public Response getRolemanagementDiscipline() {
 			try {
 				synchronize();
-				
+
 				Discipline discipline = repository.getRoleManagement().getAssignedDiscipline();
 				if (discipline == null) {
 					return Response.ok(null).build();
 				}
-				
+
 				return Response.ok(new BeanDiscipline(discipline)).build();
 			} catch (Exception e) {
 				return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 			}
 		}
-		
+
 		/**
 		 * This service fetches the discipline of the repository
+		 * 
 		 * @return the fetched discipline
 		 */
 		@GET
 		@Path(REPOSITORY)
 		@Produces(MediaType.APPLICATION_JSON)
-		@ApiOperation(
-				produces = "application/json",
-				value = "Fetch discipline of the repository",
-				httpMethod = "GET",
-				notes = "This service fetches the discipline of the repository")
-		@ApiResponses(value = { 
-			@ApiResponse(
-					code = HttpStatus.OK_200,
-					response = BeanDiscipline.class,
-					message = ApiErrorHelper.SUCCESSFUL_OPERATION),
-			@ApiResponse(
-					code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
-					message = ApiErrorHelper.INTERNAL_SERVER_ERROR)})
+		@ApiOperation(produces = "application/json", value = "Fetch discipline of the repository", httpMethod = "GET", notes = "This service fetches the discipline of the repository")
+		@ApiResponses(value = {
+			@ApiResponse(code = HttpStatus.OK_200, response = BeanDiscipline.class, message = ApiErrorHelper.SUCCESSFUL_OPERATION),
+			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
 		public Response getRepositpryDiscipline() {
 			try {
 				synchronize();
-				
+
 				Discipline discipline = repository.getAssignedDiscipline();
 				if (discipline == null) {
 					return Response.ok(null).build();
 				}
-				
+
 				return Response.ok(new BeanDiscipline(discipline)).build();
 			} catch (Exception e) {
 				return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 			}
 		}
-	
+
 	}
-	
+
 	/**
 	 * Create a new Sei typed by the Se identified by the fullQualifiedName
+	 * 
 	 * @param fullQualifiedName of the sei type (se)
-	 * @param owner of the sei (either another sei or the repository for root seis)
-	 * @param editingDomain the editing domain
-	 * @param iUserContext the user context
+	 * @param owner             of the sei (either another sei or the repository for
+	 *                          root seis)
+	 * @param editingDomain     the editing domain
+	 * @param iUserContext      the user context
 	 * @return uuid of the created sei
-	 * @throws CoreException 
+	 * @throws CoreException
 	 */
-	public static IBeanStructuralElementInstance createSeiFromFqn(String fullQualifiedName, EObject owner, VirSatTransactionalEditingDomain editingDomain, IUserContext iUserContext, String name) throws CoreException {
+	public static IBeanStructuralElementInstance createSeiFromFqn(String fullQualifiedName, EObject owner,
+			VirSatTransactionalEditingDomain editingDomain, IUserContext iUserContext, String name)
+			throws CoreException {
 		ActiveConceptHelper helper = new ActiveConceptHelper(editingDomain.getResourceSet().getRepository());
 		StructuralElement se = helper.getStructuralElement(fullQualifiedName);
 		StructuralElementInstance newSei = new StructuralInstantiator().generateInstance(se, name);
-				
+
 		if (owner instanceof IAssignedDiscipline) {
 			Discipline parentDiscipline = ((IAssignedDiscipline) owner).getAssignedDiscipline();
 			newSei.setAssignedDiscipline(parentDiscipline);
 		}
-		
+
 		Command createCommand = CreateAddSeiWithFileStructureCommand.create(editingDomain, owner, newSei);
 		ApiErrorHelper.executeCommandIffCanExecute(createCommand, editingDomain, iUserContext);
-		
+
 		return new BeanStructuralElementInstanceFactory().getInstanceFor(newSei);
 	}
 }

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ModelAccessResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/ModelAccessResource.java
@@ -41,7 +41,6 @@ import org.eclipse.jetty.http.HttpStatus;
 import de.dlr.sc.virsat.model.concept.types.factory.BeanStructuralElementInstanceFactory;
 import de.dlr.sc.virsat.model.concept.types.roles.BeanDiscipline;
 import de.dlr.sc.virsat.model.concept.types.structural.ABeanStructuralElementInstance;
-import de.dlr.sc.virsat.model.concept.types.structural.BeanStructuralElementInstance;
 import de.dlr.sc.virsat.model.concept.types.structural.IBeanStructuralElementInstance;
 import de.dlr.sc.virsat.model.dvlm.Repository;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResource.java
@@ -26,7 +26,6 @@ import org.eclipse.jetty.http.HttpStatus;
 
 import de.dlr.sc.virsat.model.concept.types.factory.BeanStructuralElementInstanceFactory;
 import de.dlr.sc.virsat.model.concept.types.structural.ABeanStructuralElementInstance;
-import de.dlr.sc.virsat.model.concept.types.structural.BeanStructuralElementInstance;
 import de.dlr.sc.virsat.model.concept.types.structural.IBeanStructuralElementInstance;
 import de.dlr.sc.virsat.model.dvlm.structural.StructuralElementInstance;
 import de.dlr.sc.virsat.project.structure.command.CreateRemoveSeiWithFileStructureCommand;
@@ -57,9 +56,9 @@ public class StructuralElementInstanceResource {
 	@Produces(MediaType.APPLICATION_JSON)
 	@ApiOperation(produces = "application/json", value = "Fetch SEI", httpMethod = "GET", notes = "This service fetches a StructuralElementInstance.")
 	@ApiResponses(value = {
-			@ApiResponse(code = HttpStatus.OK_200, response = ABeanStructuralElementInstance.class, message = ApiErrorHelper.SUCCESSFUL_OPERATION),
-			@ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
-			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
+		@ApiResponse(code = HttpStatus.OK_200, response = ABeanStructuralElementInstance.class, message = ApiErrorHelper.SUCCESSFUL_OPERATION),
+		@ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
+		@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
 	public Response getSei(@PathParam("seiUuid") @ApiParam(value = "Uuid of the SEI", required = true) String seiUuid) {
 		try {
 			parentResource.synchronize();
@@ -83,7 +82,7 @@ public class StructuralElementInstanceResource {
 	@Consumes(MediaType.APPLICATION_JSON)
 	@ApiOperation(consumes = "application/json", value = "Put SEI", httpMethod = "PUT", notes = "This service updates an existing StructuralElementInstance")
 	@ApiResponses(value = { @ApiResponse(code = HttpStatus.OK_200, message = ApiErrorHelper.SUCCESSFUL_OPERATION),
-			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
+		@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
 	public Response putSei(@ApiParam(value = "SEI to put", required = true) ABeanStructuralElementInstance bean) {
 		try {
 			parentResource.synchronize();
@@ -135,10 +134,10 @@ public class StructuralElementInstanceResource {
 	@Produces(MediaType.APPLICATION_JSON)
 	@ApiOperation(produces = "application/json", value = "Delete SEI", httpMethod = "DELETE", notes = "This service deletes a StructuralElementInstance.")
 	@ApiResponses(value = { @ApiResponse(code = HttpStatus.OK_200, message = ApiErrorHelper.SUCCESSFUL_OPERATION),
-			@ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
-			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.NOT_EXECUTEABLE),
-			@ApiResponse(code = HttpStatus.FORBIDDEN_403, message = ApiErrorHelper.NOT_EXECUTEABLE),
-			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
+		@ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
+		@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.NOT_EXECUTEABLE),
+		@ApiResponse(code = HttpStatus.FORBIDDEN_403, message = ApiErrorHelper.NOT_EXECUTEABLE),
+		@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
 	public Response deleteSei(
 			@PathParam("seiUuid") @ApiParam(value = "Uuid of the SEI", required = true) String seiUuid) {
 		try {

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/StructuralElementInstanceResource.java
@@ -42,11 +42,11 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 
-@Api(hidden = true, authorizations = {@Authorization(value = "basic")}, tags = {ModelAccessResource.TAG_SEI})
+@Api(hidden = true, authorizations = { @Authorization(value = "basic") }, tags = { ModelAccessResource.TAG_SEI })
 public class StructuralElementInstanceResource {
-	
+
 	private RepoModelAccessResource parentResource;
-	
+
 	public StructuralElementInstanceResource(RepoModelAccessResource parentResource) {
 		this.parentResource = parentResource;
 	}
@@ -55,32 +55,21 @@ public class StructuralElementInstanceResource {
 	@GET
 	@Path("/{seiUuid}")
 	@Produces(MediaType.APPLICATION_JSON)
-	@ApiOperation(
-			produces = "application/json",
-			value = "Fetch SEI",
-			httpMethod = "GET",
-			notes = "This service fetches a StructuralElementInstance.")
-	@ApiResponses(value = { 
-		@ApiResponse(
-				code = HttpStatus.OK_200,
-				response = ABeanStructuralElementInstance.class,
-				message = ApiErrorHelper.SUCCESSFUL_OPERATION),
-		@ApiResponse(
-				code = HttpStatus.BAD_REQUEST_400, 
-				message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
-		@ApiResponse(
-				code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
-				message = ApiErrorHelper.INTERNAL_SERVER_ERROR)})
+	@ApiOperation(produces = "application/json", value = "Fetch SEI", httpMethod = "GET", notes = "This service fetches a StructuralElementInstance.")
+	@ApiResponses(value = {
+			@ApiResponse(code = HttpStatus.OK_200, response = ABeanStructuralElementInstance.class, message = ApiErrorHelper.SUCCESSFUL_OPERATION),
+			@ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
+			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
 	public Response getSei(@PathParam("seiUuid") @ApiParam(value = "Uuid of the SEI", required = true) String seiUuid) {
 		try {
 			parentResource.synchronize();
-			
+
 			StructuralElementInstance sei = RepositoryUtility.findSei(seiUuid, parentResource.getRepository());
-			
+
 			if (sei == null) {
 				return ApiErrorHelper.createNotFoundErrorResponse();
 			}
-			
+
 			IBeanStructuralElementInstance beanSei = new BeanStructuralElementInstanceFactory().getInstanceFor(sei);
 			return Response.ok(beanSei).build();
 		} catch (Exception e) {
@@ -92,18 +81,9 @@ public class StructuralElementInstanceResource {
 	@PUT
 	@Path("/")
 	@Consumes(MediaType.APPLICATION_JSON)
-	@ApiOperation(
-			consumes = "application/json",
-			value = "Put SEI",
-			httpMethod = "PUT",
-			notes = "This service updates an existing StructuralElementInstance")
-	@ApiResponses(value = { 
-		@ApiResponse(
-				code = HttpStatus.OK_200,
-				message = ApiErrorHelper.SUCCESSFUL_OPERATION),
-		@ApiResponse(
-				code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
-				message = ApiErrorHelper.INTERNAL_SERVER_ERROR)})
+	@ApiOperation(consumes = "application/json", value = "Put SEI", httpMethod = "PUT", notes = "This service updates an existing StructuralElementInstance")
+	@ApiResponses(value = { @ApiResponse(code = HttpStatus.OK_200, message = ApiErrorHelper.SUCCESSFUL_OPERATION),
+			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
 	public Response putSei(@ApiParam(value = "SEI to put", required = true) ABeanStructuralElementInstance bean) {
 		try {
 			parentResource.synchronize();
@@ -112,46 +92,34 @@ public class StructuralElementInstanceResource {
 			return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 		}
 	}
-	
+
 	/** **/
 	@POST
 	@Path("/{seiUuid}")
 	@Consumes(MediaType.APPLICATION_JSON)
-	@ApiOperation(
-			consumes = "application/json",
-			value = "Create SEI",
-			httpMethod = "POST",
-			notes = "This service creates a new StructuralElementInstance and returns it")
-	@ApiResponses(value = { 
-		@ApiResponse(
-				code = HttpStatus.OK_200,
-				response = String.class,
-				message = ApiErrorHelper.SUCCESSFUL_OPERATION),
-		@ApiResponse(
-				code = HttpStatus.BAD_REQUEST_400, 
-				message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
-		@ApiResponse(
-				code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
-				message = ApiErrorHelper.NOT_EXECUTEABLE),
-		@ApiResponse(
-				code = HttpStatus.FORBIDDEN_403, 
-				message = ApiErrorHelper.NOT_EXECUTEABLE),
-		@ApiResponse(
-				code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
-				message = ApiErrorHelper.INTERNAL_SERVER_ERROR)})
+	@ApiOperation(consumes = "application/json", value = "Create SEI", httpMethod = "POST", notes = "This service creates a new StructuralElementInstance and returns it")
+	@ApiResponses(value = {
+		@ApiResponse(code = HttpStatus.OK_200, response = String.class, message = ApiErrorHelper.SUCCESSFUL_OPERATION),
+		@ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
+		@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.NOT_EXECUTEABLE),
+		@ApiResponse(code = HttpStatus.FORBIDDEN_403, message = ApiErrorHelper.NOT_EXECUTEABLE),
+		@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
 	public Response createSei(@PathParam("seiUuid") @ApiParam(value = "parent uuid", required = true) String parentUuid,
-			@QueryParam(value = ModelAccessResource.QP_FULL_QUALIFIED_NAME)
-			@ApiParam(value = "Full qualified name of the SEI type", required = true) String fullQualifiedName) {
+
+			@QueryParam(value = ModelAccessResource.QP_FULL_QUALIFIED_NAME) @ApiParam(value = "Full qualified name of the SEI type", required = true) String fullQualifiedName,
+
+			@QueryParam(value = ModelAccessResource.QP_NAME) @ApiParam(value = "name of the new SEI", required = false) String name) {
 		try {
 			parentResource.synchronize();
-			
+
 			StructuralElementInstance parentSei = RepositoryUtility.findSei(parentUuid, parentResource.getRepository());
-			
+
 			if (parentSei == null) {
 				return ApiErrorHelper.createNotFoundErrorResponse();
 			}
-			BeanStructuralElementInstance newSeiBean = ModelAccessResource.createSeiFromFqn(fullQualifiedName, parentSei, parentResource.getEd(), parentResource.getUser());
-			
+			IBeanStructuralElementInstance newSeiBean = ModelAccessResource.createSeiFromFqn(fullQualifiedName,
+					parentSei, parentResource.getEd(), parentResource.getUser(), name);
+
 			parentResource.synchronize();
 			return Response.ok(newSeiBean).build();
 		} catch (IllegalArgumentException e) {
@@ -160,46 +128,31 @@ public class StructuralElementInstanceResource {
 			return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 		}
 	}
-	
+
 	/** **/
 	@DELETE
 	@Path("/{seiUuid}")
 	@Produces(MediaType.APPLICATION_JSON)
-	@ApiOperation(
-			produces = "application/json",
-			value = "Delete SEI",
-			httpMethod = "DELETE",
-			notes = "This service deletes a StructuralElementInstance.")
-	@ApiResponses(value = { 
-		@ApiResponse(
-				code = HttpStatus.OK_200,
-				message = ApiErrorHelper.SUCCESSFUL_OPERATION),
-		@ApiResponse(
-				code = HttpStatus.BAD_REQUEST_400,
-				message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
-		@ApiResponse(
-				code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
-				message = ApiErrorHelper.NOT_EXECUTEABLE),
-		@ApiResponse(
-				code = HttpStatus.FORBIDDEN_403, 
-				message = ApiErrorHelper.NOT_EXECUTEABLE),
-		@ApiResponse(
-				code = HttpStatus.INTERNAL_SERVER_ERROR_500, 
-				message = ApiErrorHelper.INTERNAL_SERVER_ERROR)})
-	public Response deleteSei(@PathParam("seiUuid") @ApiParam(value = "Uuid of the SEI", required = true)  String seiUuid) {
+	@ApiOperation(produces = "application/json", value = "Delete SEI", httpMethod = "DELETE", notes = "This service deletes a StructuralElementInstance.")
+	@ApiResponses(value = { @ApiResponse(code = HttpStatus.OK_200, message = ApiErrorHelper.SUCCESSFUL_OPERATION),
+			@ApiResponse(code = HttpStatus.BAD_REQUEST_400, message = ApiErrorHelper.COULD_NOT_FIND_REQUESTED_ELEMENT),
+			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.NOT_EXECUTEABLE),
+			@ApiResponse(code = HttpStatus.FORBIDDEN_403, message = ApiErrorHelper.NOT_EXECUTEABLE),
+			@ApiResponse(code = HttpStatus.INTERNAL_SERVER_ERROR_500, message = ApiErrorHelper.INTERNAL_SERVER_ERROR) })
+	public Response deleteSei(
+			@PathParam("seiUuid") @ApiParam(value = "Uuid of the SEI", required = true) String seiUuid) {
 		try {
 			// Sync before delete
 			parentResource.synchronize();
-			
+
 			// Delete Sei
 			StructuralElementInstance sei = RepositoryUtility.findSei(seiUuid, parentResource.getRepository());
 			if (sei == null) {
 				return ApiErrorHelper.createNotFoundErrorResponse();
 			}
-			
-			Command deleteCommand = CreateRemoveSeiWithFileStructureCommand.create(sei, RemoveFileStructureCommand.DELETE_RESOURCE_OPERATION_FUNCTION);
+			Command deleteCommand = CreateRemoveSeiWithFileStructureCommand.create(sei,
+					RemoveFileStructureCommand.DELETE_RESOURCE_OPERATION_FUNCTION);
 			ApiErrorHelper.executeCommandIffCanExecute(deleteCommand, parentResource.getEd(), parentResource.getUser());
-			
 			// Sync after delete
 			parentResource.synchronize();
 			return Response.ok().build();
@@ -209,5 +162,4 @@ public class StructuralElementInstanceResource {
 			return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 		}
 	}
-	
 }


### PR DESCRIPTION
Currently the post route of the SEi resource does not consider the name query parameter (eventhough its states in the OpenAPI spec).
Furthermore the type property in the response was wrongly set, which is also fixed.