### PR TITLE
Feature/1196 post request fix name param

### DIFF
--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/VirSatServerApplication.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/VirSatServerApplication.java
@@ -101,7 +101,9 @@ public class VirSatServerApplication implements IApplication {
 		jettyServer = new VirSatJettyServer();
 		jettyServer.setServerPort(port);
 		jettyServer.init();
-		jettyServer.start().join();
+		jettyServer.start();
+		System.out.println("Jetty Server started.");
+		jettyServer.join();
 		
 		System.out.println("--------------------------------------------------");
 		System.out.println("The server stopped, I am about to shut down.");

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/model/StructuralElementInstanceResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/model/StructuralElementInstanceResource.java
@@ -9,6 +9,27 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.server.resources.model;
 
+import org.eclipse.emf.common.command.Command;
+
+import de.dlr.sc.virsat.model.concept.types.factory.BeanStructuralElementInstanceFactory;
+import de.dlr.sc.virsat.model.concept.types.structural.ABeanStructuralElementInstance;
+import de.dlr.sc.virsat.model.concept.types.structural.IBeanStructuralElementInstance;
+import de.dlr.sc.virsat.model.dvlm.structural.StructuralElementInstance;
+import de.dlr.sc.virsat.project.structure.command.CreateRemoveSeiWithFileStructureCommand;
+import de.dlr.sc.virsat.project.structure.command.RemoveFileStructureCommand;
+import de.dlr.sc.virsat.server.dataaccess.RepositoryUtility;
+import de.dlr.sc.virsat.server.resources.ApiErrorHelper;
+import de.dlr.sc.virsat.server.resources.modelaccess.ModelAccessResource;
+import de.dlr.sc.virsat.server.resources.modelaccess.RepositoryAccessResource;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -20,28 +41,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-
-import org.eclipse.emf.common.command.Command;
-import de.dlr.sc.virsat.model.concept.types.factory.BeanStructuralElementInstanceFactory;
-import de.dlr.sc.virsat.model.concept.types.structural.ABeanStructuralElementInstance;
-import de.dlr.sc.virsat.model.concept.types.structural.BeanStructuralElementInstance;
-import de.dlr.sc.virsat.model.concept.types.structural.IBeanStructuralElementInstance;
-import de.dlr.sc.virsat.model.dvlm.structural.StructuralElementInstance;
-import de.dlr.sc.virsat.project.structure.command.CreateRemoveSeiWithFileStructureCommand;
-import de.dlr.sc.virsat.project.structure.command.RemoveFileStructureCommand;
-import de.dlr.sc.virsat.server.dataaccess.RepositoryUtility;
-import de.dlr.sc.virsat.server.resources.ApiErrorHelper;
-import de.dlr.sc.virsat.server.resources.modelaccess.RepositoryAccessResource;
-import de.dlr.sc.virsat.server.resources.modelaccess.ModelAccessResource;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.security.SecurityScheme;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = RepositoryAccessResource.TAG_SEI)
 @SecurityScheme(
@@ -153,7 +152,8 @@ public class StructuralElementInstanceResource {
 			})
 	public Response createSei(@PathParam("seiUuid") @Parameter(description = "parent uuid", required = true) String parentUuid,
 			@QueryParam(value = RepositoryAccessResource.QP_FULL_QUALIFIED_NAME)
-			@Parameter(description = "Full qualified name of the SEI type", required = true) String fullQualifiedName) {
+			@Parameter(description = "Full qualified name of the SEI type", required = true) String fullQualifiedName,
+			@QueryParam(value = RepositoryAccessResource.QP_NAME) @Parameter(description = "name of the new SEI", required = false) String name) {
 		try {
 			parentResource.synchronize();
 			
@@ -162,7 +162,7 @@ public class StructuralElementInstanceResource {
 			if (parentSei == null) {
 				return ApiErrorHelper.createNotFoundErrorResponse();
 			}
-			BeanStructuralElementInstance newSeiBean = ModelAccessResource.createSeiFromFqn(fullQualifiedName, parentSei, parentResource.getEd(), parentResource.getUser());
+			IBeanStructuralElementInstance newSeiBean = ModelAccessResource.createSeiFromFqn(fullQualifiedName, parentSei, parentResource.getEd(), parentResource.getUser(), name);
 			
 			parentResource.synchronize();
 			return Response.ok(newSeiBean).build();

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/ModelAccessResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/ModelAccessResource.java
@@ -13,26 +13,17 @@ package de.dlr.sc.virsat.server.resources.modelaccess;
 import java.util.ArrayList;
 import java.util.List;
 
-import jakarta.annotation.security.RolesAllowed;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DefaultValue;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.GenericEntity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.ecore.EObject;
+
 import de.dlr.sc.virsat.model.concept.types.factory.BeanStructuralElementInstanceFactory;
 import de.dlr.sc.virsat.model.concept.types.roles.BeanDiscipline;
 import de.dlr.sc.virsat.model.concept.types.structural.ABeanStructuralElementInstance;
-import de.dlr.sc.virsat.model.concept.types.structural.BeanStructuralElementInstance;
+import de.dlr.sc.virsat.model.concept.types.structural.IBeanStructuralElementInstance;
 import de.dlr.sc.virsat.model.dvlm.Repository;
 import de.dlr.sc.virsat.model.dvlm.concepts.Concept;
 import de.dlr.sc.virsat.model.dvlm.concepts.registry.ActiveConceptConfigurationElement;
@@ -57,12 +48,23 @@ import de.dlr.sc.virsat.server.resources.model.StructuralElementInstanceResource
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.GenericEntity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 /**
 	 * The resource to access the VirSat data model of a specific server repository
@@ -273,11 +275,12 @@ public class ModelAccessResource {
 					description = ApiErrorHelper.INTERNAL_SERVER_ERROR)
 			})
 	public Response createRootSei(@QueryParam(value = RepositoryAccessResource.QP_FULL_QUALIFIED_NAME) 
-		@Parameter(description = "Full qualified name of the SEI type", required = true) String fullQualifiedName) {
+		@Parameter(description = "Full qualified name of the SEI type", required = true) String fullQualifiedName,
+		@QueryParam(value = RepositoryAccessResource.QP_NAME) @Parameter(description = "name of the new SEI", required = false) String name) {
 		try {
 			serverRepository.syncRepository();
 			
-			BeanStructuralElementInstance newSeiBean = createSeiFromFqn(fullQualifiedName, repository, ed, userContext);
+			IBeanStructuralElementInstance newSeiBean = createSeiFromFqn(fullQualifiedName, repository, ed, userContext, name);
 			
 			serverRepository.syncRepository();
 			return Response.ok(newSeiBean).build();
@@ -476,8 +479,9 @@ public class ModelAccessResource {
 	 * @param editingDomain the editing domain
 	 * @param iUserContext the user context
 	 * @return uuid of the created sei
+	 * @throws CoreException 
 	 */
-	public static BeanStructuralElementInstance createSeiFromFqn(String fullQualifiedName, EObject owner, VirSatTransactionalEditingDomain editingDomain, IUserContext iUserContext) {
+	public static IBeanStructuralElementInstance createSeiFromFqn(String fullQualifiedName, EObject owner, VirSatTransactionalEditingDomain editingDomain, IUserContext iUserContext, String name) throws CoreException {
 		ActiveConceptHelper helper = new ActiveConceptHelper(editingDomain.getResourceSet().getRepository());
 		StructuralElement se = helper.getStructuralElement(fullQualifiedName);
 		StructuralElementInstance newSei = new StructuralInstantiator().generateInstance(se, null);
@@ -490,7 +494,7 @@ public class ModelAccessResource {
 		Command createCommand = CreateAddSeiWithFileStructureCommand.create(editingDomain, owner, newSei);
 		ApiErrorHelper.executeCommandIffCanExecute(createCommand, editingDomain, iUserContext);
 		
-		return new BeanStructuralElementInstance(newSei);
+		return new BeanStructuralElementInstanceFactory().getInstanceFor(newSei);
 	}
 
 }

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/ModelAccessResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/modelaccess/ModelAccessResource.java
@@ -484,7 +484,7 @@ public class ModelAccessResource {
 	public static IBeanStructuralElementInstance createSeiFromFqn(String fullQualifiedName, EObject owner, VirSatTransactionalEditingDomain editingDomain, IUserContext iUserContext, String name) throws CoreException {
 		ActiveConceptHelper helper = new ActiveConceptHelper(editingDomain.getResourceSet().getRepository());
 		StructuralElement se = helper.getStructuralElement(fullQualifiedName);
-		StructuralElementInstance newSei = new StructuralInstantiator().generateInstance(se, null);
+		StructuralElementInstance newSei = new StructuralInstantiator().generateInstance(se, name);
 		
 		if (owner instanceof IAssignedDiscipline) {
 			Discipline parentDiscipline = ((IAssignedDiscipline) owner).getAssignedDiscipline();


### PR DESCRIPTION
Re-done the changes from PR #1197 on new code base of 4.17.X

Currently the post route of the SEi resource does not consider the name query parameter (eventhough its states in the OpenAPI spec).
Furthermore the type property in the response was wrongly set, which is also fixed.