### PR TITLE
Fix creation of CAs in server so that it returns the CA

### DIFF
--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/model/CategoryAssignmentResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/model/CategoryAssignmentResource.java
@@ -129,7 +129,7 @@ public class CategoryAssignmentResource {
 	public Response putCa(@Parameter(description = "CA to put", required = true) ABeanCategoryAssignment bean) {
 		try {
 			parentResource.synchronize();
-			return Response.status(Response.Status.OK).build();
+			return Response.status(Response.Status.OK).entity(bean).build();
 		} catch (Exception e) {
 			return ApiErrorHelper.createInternalErrorResponse(e.getMessage());
 		}
@@ -175,6 +175,7 @@ public class CategoryAssignmentResource {
 			ActiveConceptHelper helper = new ActiveConceptHelper(parentResource.getEd().getResourceSet().getRepository());
 			Category category = helper.getCategory(fullQualifiedName);
 			CategoryAssignment newCa = new CategoryInstantiator().generateInstance(category, null);
+			newCa.setName(category.getName());
 			
 			Command createCommand = AddCommand.create(parentResource.getEd(), parentSei, CategoriesPackage.Literals.ICATEGORY_ASSIGNMENT_CONTAINER__CATEGORY_ASSIGNMENTS, Collections.singletonList(newCa));
 			ApiErrorHelper.executeCommandIffCanExecute(createCommand, parentResource.getEd(), parentResource.getUser());

--- a/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/model/CategoryAssignmentResource.java
+++ b/de.dlr.sc.virsat.server/src/de/dlr/sc/virsat/server/resources/model/CategoryAssignmentResource.java
@@ -9,6 +9,33 @@
  *******************************************************************************/
 package de.dlr.sc.virsat.server.resources.model;
 
+import java.util.Collections;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.edit.command.AddCommand;
+
+import de.dlr.sc.virsat.model.concept.types.category.ABeanCategoryAssignment;
+import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
+import de.dlr.sc.virsat.model.concept.types.factory.BeanCategoryAssignmentFactory;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoriesPackage;
+import de.dlr.sc.virsat.model.dvlm.categories.Category;
+import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
+import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
+import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
+import de.dlr.sc.virsat.model.dvlm.structural.StructuralElementInstance;
+import de.dlr.sc.virsat.server.dataaccess.RepositoryUtility;
+import de.dlr.sc.virsat.server.resources.ApiErrorHelper;
+import de.dlr.sc.virsat.server.resources.modelaccess.ModelAccessResource;
+import de.dlr.sc.virsat.server.resources.modelaccess.RepositoryAccessResource;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -20,32 +47,6 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-
-import org.eclipse.emf.common.command.Command;
-import org.eclipse.emf.edit.command.AddCommand;
-import de.dlr.sc.virsat.model.concept.types.category.ABeanCategoryAssignment;
-import de.dlr.sc.virsat.model.concept.types.category.BeanCategoryAssignment;
-import de.dlr.sc.virsat.model.concept.types.category.IBeanCategoryAssignment;
-import de.dlr.sc.virsat.model.concept.types.factory.BeanCategoryAssignmentFactory;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoriesPackage;
-import de.dlr.sc.virsat.model.dvlm.categories.Category;
-import de.dlr.sc.virsat.model.dvlm.categories.CategoryAssignment;
-import de.dlr.sc.virsat.model.dvlm.categories.util.CategoryInstantiator;
-import de.dlr.sc.virsat.model.dvlm.concepts.util.ActiveConceptHelper;
-import de.dlr.sc.virsat.model.dvlm.structural.StructuralElementInstance;
-import de.dlr.sc.virsat.server.dataaccess.RepositoryUtility;
-import de.dlr.sc.virsat.server.resources.ApiErrorHelper;
-import de.dlr.sc.virsat.server.resources.modelaccess.RepositoryAccessResource;
-import de.dlr.sc.virsat.server.resources.modelaccess.ModelAccessResource;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.security.SecurityScheme;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 
 @Tag(name = RepositoryAccessResource.TAG_CA)
@@ -175,13 +176,12 @@ public class CategoryAssignmentResource {
 			Category category = helper.getCategory(fullQualifiedName);
 			CategoryAssignment newCa = new CategoryInstantiator().generateInstance(category, null);
 			
-			Command createCommand = AddCommand.create(parentResource.getEd(), parentSei, CategoriesPackage.Literals.ICATEGORY_ASSIGNMENT_CONTAINER__CATEGORY_ASSIGNMENTS, newCa);
+			Command createCommand = AddCommand.create(parentResource.getEd(), parentSei, CategoriesPackage.Literals.ICATEGORY_ASSIGNMENT_CONTAINER__CATEGORY_ASSIGNMENTS, Collections.singletonList(newCa));
 			ApiErrorHelper.executeCommandIffCanExecute(createCommand, parentResource.getEd(), parentResource.getUser());
+			IBeanCategoryAssignment newCaBean = new BeanCategoryAssignmentFactory().getInstanceFor(newCa);
 			
 			parentResource.synchronize();
-			
-			BeanCategoryAssignment newCaBean = new BeanCategoryAssignment();
-			newCaBean.setTypeInstance(newCa);
+	
 			return Response.ok(newCaBean).build();
 		} catch (IllegalArgumentException e) {
 			return Response.status(Response.Status.FORBIDDEN).entity("Forbidden").build();


### PR DESCRIPTION
When creating a CA via post request on our server, it currently only returns the typename as string... Which is not comliant to our specification as JSON return.
We changed it so that it returns the newly created CA as JSON object.