### PR TITLE
Updated the error message for CAD Import Wizard

### DIFF
--- a/de.dlr.sc.virsat.model.extension.mechanical.ui/src/de/dlr/sc/virsat/model/extension/mechanical/ui/wizards/CadImportWizard.java
+++ b/de.dlr.sc.virsat.model.extension.mechanical.ui/src/de/dlr/sc/virsat/model/extension/mechanical/ui/wizards/CadImportWizard.java
@@ -99,7 +99,7 @@ public class CadImportWizard extends Wizard implements IWorkbenchWizard {
 					Command importCommnd = importer.transform(editingDomain, jsonContent, mapping);
 					if (!importCommnd.canExecute()) {
 						Status status = new Status(Status.ERROR, Activator.getPluginId(),
-								"CadImportWizard: The import command is not exectuable!");
+								"CadImportWizard: File imported successfully without changes!");
 						StatusManager.getManager().handle(status, StatusManager.LOG | StatusManager.SHOW);
 						return Status.CANCEL_STATUS;
 					}


### PR DESCRIPTION
Updated the error message to reflect the correct status: changed from "Import command not executable" to "File imported successfully without changes."