### PR TITLE
Feature/task 101 rectangular lines by default in graphiti

### DIFF
--- a/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/abstractConnection/AbstractConnectionAddFeature.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/abstractConnection/AbstractConnectionAddFeature.java
@@ -17,6 +17,7 @@ import org.eclipse.graphiti.features.context.IAddContext;
 import org.eclipse.graphiti.mm.algorithms.Polyline;
 import org.eclipse.graphiti.mm.algorithms.Text;
 import org.eclipse.graphiti.mm.algorithms.styles.LineStyle;
+import org.eclipse.graphiti.mm.algorithms.styles.Point;
 import org.eclipse.graphiti.mm.pictograms.Anchor;
 import org.eclipse.graphiti.mm.pictograms.ConnectionDecorator;
 import org.eclipse.graphiti.mm.pictograms.FreeFormConnection;
@@ -100,24 +101,36 @@ public abstract class AbstractConnectionAddFeature extends VirSatAddConnectionFe
 
 		FreeFormConnection connection = null;
 		if (fromAnchor != null && toAnchor != null) {
-			// Create a Polyline connection
-
+			
+			// Create a Rectangular connection by default
 			connection = peCreateService.createFreeFormConnection(getDiagram());
 			connection.setStart(fromAnchor);
 			connection.setEnd(toAnchor);
 			
 			var locRelDiagFromAnchor = Graphiti.getLayoutService().getLocationRelativeToDiagram(fromAnchor);
 			var locRelDiagToAnchor = Graphiti.getLayoutService().getLocationRelativeToDiagram(toAnchor);
-			
-			// ,with rectangular lines
+ 
 			ICreateService createService = Graphiti.getCreateService();
 			var itbProvider = getFeatureProvider().getDiagramTypeProvider().getCurrentToolBehaviorProvider();
 			
+			// creates transition as rectangular lines
 			if (itbProvider instanceof StateMachineDiagramToolBehaviorProvider) {
-				int distanceX = (locRelDiagToAnchor.getX() + locRelDiagFromAnchor.getX()) / 2;
+				int distanceX = Math.abs(locRelDiagToAnchor.getX() - locRelDiagFromAnchor.getX());
+				int distanceY = Math.abs(locRelDiagToAnchor.getY() - locRelDiagFromAnchor.getY());
+				int bendPointPosX = Math.abs((locRelDiagToAnchor.getX() + locRelDiagFromAnchor.getX()) / 2);
+				int bendPointPosY = Math.abs((locRelDiagToAnchor.getY() + locRelDiagFromAnchor.getY()) / 2);
 				
-				var pointA = createService.createPoint(distanceX, locRelDiagFromAnchor.getY());
-				var pointB = createService.createPoint(distanceX, locRelDiagToAnchor.getY());
+				Point pointA = null;
+				Point pointB = null;
+				
+				if (distanceX >= distanceY) {
+					pointA = createService.createPoint(bendPointPosX, locRelDiagFromAnchor.getY());
+					pointB = createService.createPoint(bendPointPosX, locRelDiagToAnchor.getY());
+				} 
+				if (distanceX < distanceY) {
+					pointA = createService.createPoint(locRelDiagFromAnchor.getX(), bendPointPosY);
+					pointB = createService.createPoint(locRelDiagToAnchor.getX(), bendPointPosY);
+				}
 
 				var bendPoints = connection.getBendpoints();
 				bendPoints.add(pointA);

--- a/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/abstractConnection/AbstractConnectionAddFeature.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/abstractConnection/AbstractConnectionAddFeature.java
@@ -106,10 +106,41 @@ public abstract class AbstractConnectionAddFeature extends VirSatAddConnectionFe
 			connection.setStart(fromAnchor);
 			connection.setEnd(toAnchor);
 			
+			var locRelDiagFromAnchor = Graphiti.getLayoutService().getLocationRelativeToDiagram(fromAnchor);
+			var locRelDiagToAnchor = Graphiti.getLayoutService().getLocationRelativeToDiagram(toAnchor);
+			
+			// ,with rectangular lines
+			ICreateService createService = Graphiti.getCreateService();
+			var itbProvider = getFeatureProvider().getDiagramTypeProvider().getCurrentToolBehaviorProvider();
+			
+			if (itbProvider instanceof StateMachineDiagramToolBehaviorProvider) {
+				var stateA = fromAnchor.getReferencedGraphicsAlgorithm();
+				var stateB = toAnchor.getReferencedGraphicsAlgorithm();
+				var heightA = stateA.getHeight();
+				var heightB = stateB.getHeight();
+				int distanceX = (locRelDiagToAnchor.getX() + locRelDiagFromAnchor.getX())/2;
+//				int distanceY = (locRelDiagToAnchor.getY() + locRelDiagFromAnchor.getY())/2;
+				
+				var pointA = createService.createPoint(distanceX, locRelDiagFromAnchor.getY());
+				var pointB = createService.createPoint(distanceX, locRelDiagToAnchor.getY());
+
+//				var pointA = createService.createPoint(stateA.getWidth() + distanceX*3 / 2, heightA / 2);
+//				var pointB = createService.createPoint(distanceX *3 / -2, heightB / 2);
+				
+//				var pointA = createService.createPoint(distanceBetweenStates, heightA / 2);
+//				var pointB = createService.createPoint(distanceBetweenStates, heightB / 2);
+				
+//				so if B's X is greater than A's x, then A
+				
+				var bendPoints = connection.getBendpoints();
+				bendPoints.add(pointA);
+				bendPoints.add(pointB);
+			}
+			
 			// if the transition is a self-loop, generate some additional bend points to make it more visible
 			if (fromAnchor.equals(toAnchor)) {
-				ICreateService createService = Graphiti.getCreateService();
-				var itbProvider = getFeatureProvider().getDiagramTypeProvider().getCurrentToolBehaviorProvider();
+				/* ICreateService */ createService = Graphiti.getCreateService();
+//				var itbProvider = getFeatureProvider().getDiagramTypeProvider().getCurrentToolBehaviorProvider();
 				
 				if (itbProvider instanceof StateMachineDiagramToolBehaviorProvider) {
 					var stateGa = fromAnchor.getReferencedGraphicsAlgorithm();

--- a/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/abstractConnection/AbstractConnectionAddFeature.java
+++ b/de.dlr.sc.virsat.model.extension.statemachines.ui/src/de/dlr/sc/virsat/model/extension/statemachines/ui/diagram/features/abstractConnection/AbstractConnectionAddFeature.java
@@ -114,24 +114,11 @@ public abstract class AbstractConnectionAddFeature extends VirSatAddConnectionFe
 			var itbProvider = getFeatureProvider().getDiagramTypeProvider().getCurrentToolBehaviorProvider();
 			
 			if (itbProvider instanceof StateMachineDiagramToolBehaviorProvider) {
-				var stateA = fromAnchor.getReferencedGraphicsAlgorithm();
-				var stateB = toAnchor.getReferencedGraphicsAlgorithm();
-				var heightA = stateA.getHeight();
-				var heightB = stateB.getHeight();
-				int distanceX = (locRelDiagToAnchor.getX() + locRelDiagFromAnchor.getX())/2;
-//				int distanceY = (locRelDiagToAnchor.getY() + locRelDiagFromAnchor.getY())/2;
+				int distanceX = (locRelDiagToAnchor.getX() + locRelDiagFromAnchor.getX()) / 2;
 				
 				var pointA = createService.createPoint(distanceX, locRelDiagFromAnchor.getY());
 				var pointB = createService.createPoint(distanceX, locRelDiagToAnchor.getY());
 
-//				var pointA = createService.createPoint(stateA.getWidth() + distanceX*3 / 2, heightA / 2);
-//				var pointB = createService.createPoint(distanceX *3 / -2, heightB / 2);
-				
-//				var pointA = createService.createPoint(distanceBetweenStates, heightA / 2);
-//				var pointB = createService.createPoint(distanceBetweenStates, heightB / 2);
-				
-//				so if B's X is greater than A's x, then A
-				
 				var bendPoints = connection.getBendpoints();
 				bendPoints.add(pointA);
 				bendPoints.add(pointB);
@@ -139,8 +126,7 @@ public abstract class AbstractConnectionAddFeature extends VirSatAddConnectionFe
 			
 			// if the transition is a self-loop, generate some additional bend points to make it more visible
 			if (fromAnchor.equals(toAnchor)) {
-				/* ICreateService */ createService = Graphiti.getCreateService();
-//				var itbProvider = getFeatureProvider().getDiagramTypeProvider().getCurrentToolBehaviorProvider();
+				createService = Graphiti.getCreateService();
 				
 				if (itbProvider instanceof StateMachineDiagramToolBehaviorProvider) {
 					var stateGa = fromAnchor.getReferencedGraphicsAlgorithm();

--- a/known_authors.txt
+++ b/known_authors.txt
@@ -9,3 +9,4 @@ pchrszon-dlr
 DimitriDiantos
 mbou_fr
 kain-ap
+tamp_ry


### PR DESCRIPTION
* Issue: #101 Rectangular Lines by Default in Graphiti

* Already accomplished To-Do:
	[X] Rectangular Lines as Default Transition Connection is now possible
* Accomplished in this commit:
	[X] Solved the issue where the anchor points and lines are offset when the distance 
	    between states are too small. Now it is possible for rectangular lines to be made
	    in between two states without overlapping, regardless of the states' position on
	    the diagram.
