### PR TITLE
* Issue: #240 Implement .getRoot() for given BeanSei (and StructuralElementInstance)

### DIFF
--- a/de.dlr.sc.virsat.apps.test/src/de/dlr/sc/virsat/apps/api/external/ModelAPIAppsTest.java
+++ b/de.dlr.sc.virsat.apps.test/src/de/dlr/sc/virsat/apps/api/external/ModelAPIAppsTest.java
@@ -181,17 +181,28 @@ public class ModelAPIAppsTest {
 		StructuralElementInstance sei = StructuralFactory.eINSTANCE.createStructuralElementInstance();
 		StructuralElementInstance seiParent = StructuralFactory.eINSTANCE.createStructuralElementInstance();
 		StructuralElementInstance seiRoot = StructuralFactory.eINSTANCE.createStructuralElementInstance();
+		
+		sei.setParent(seiParent);
+		seiParent.setParent(seiRoot);
+		
+		assertTrue("sei.getRoot() function returns seiRoot", sei.getRoot().equals(seiRoot));
+		assertFalse("sei.getRoot() is faulty", !sei.getRoot().equals(seiRoot));
+	}
+	
+	@Test
+	public void testGetRootBean() {
+		StructuralElementInstance sei = StructuralFactory.eINSTANCE.createStructuralElementInstance();
+		StructuralElementInstance seiParent = StructuralFactory.eINSTANCE.createStructuralElementInstance();
+		StructuralElementInstance seiRoot = StructuralFactory.eINSTANCE.createStructuralElementInstance();
 		BeanStructuralElementInstance beanSei = new BeanStructuralElementInstance(sei);
 		BeanStructuralElementInstance beanSeiParent = new BeanStructuralElementInstance(seiParent);
 		BeanStructuralElementInstance beanSeiRoot = new BeanStructuralElementInstance(seiRoot);
 		
-		sei.setParent(seiParent);
-		seiParent.setParent(seiRoot);
 		beanSei.setParent(beanSeiParent);
 		beanSeiParent.setParent(beanSeiRoot);
-
-		assertTrue("beanSei.getRoot() function returns beanSeiRoot", beanSei.getRoot().equals(beanSeiRoot) && sei.getRoot().equals(seiRoot));
-		assertFalse("beanSei.getRoot() is faulty", !beanSei.getRoot().equals(beanSeiRoot) || !sei.getRoot().equals(seiRoot));
+		
+		assertTrue("beanSei.getRoot() function returns beanSeiRoot", beanSei.getRoot().equals(beanSeiRoot));
+		assertFalse("beanSei.getRoot() is faulty", !beanSei.getRoot().equals(beanSeiRoot));
 	}
 	
 	@Test

--- a/de.dlr.sc.virsat.apps.test/src/de/dlr/sc/virsat/apps/api/external/ModelAPIAppsTest.java
+++ b/de.dlr.sc.virsat.apps.test/src/de/dlr/sc/virsat/apps/api/external/ModelAPIAppsTest.java
@@ -177,6 +177,24 @@ public class ModelAPIAppsTest {
 	}
 	
 	@Test
+	public void testGetRoot() {
+		StructuralElementInstance sei = StructuralFactory.eINSTANCE.createStructuralElementInstance();
+		StructuralElementInstance seiParent = StructuralFactory.eINSTANCE.createStructuralElementInstance();
+		StructuralElementInstance seiRoot = StructuralFactory.eINSTANCE.createStructuralElementInstance();
+		BeanStructuralElementInstance beanSei = new BeanStructuralElementInstance(sei);
+		BeanStructuralElementInstance beanSeiParent = new BeanStructuralElementInstance(seiParent);
+		BeanStructuralElementInstance beanSeiRoot = new BeanStructuralElementInstance(seiRoot);
+		
+		sei.setParent(seiParent);
+		seiParent.setParent(seiRoot);
+		beanSei.setParent(beanSeiParent);
+		beanSeiParent.setParent(beanSeiRoot);
+
+		assertTrue("beanSei.getRoot() function returns beanSeiRoot", beanSei.getRoot().equals(beanSeiRoot) && sei.getRoot().equals(seiRoot));
+		assertFalse("beanSei.getRoot() is faulty", !beanSei.getRoot().equals(beanSeiRoot) || !sei.getRoot().equals(seiRoot));
+	}
+	
+	@Test
 	public void testPerformInheritance() {
 		StructuralElement se = StructuralFactory.eINSTANCE.createStructuralElement();
 		se.setIsCanInheritFromAll(true);

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/structural/ABeanStructuralElementInstance.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/structural/ABeanStructuralElementInstance.java
@@ -379,6 +379,16 @@ public abstract class ABeanStructuralElementInstance implements IBeanStructuralE
 	}
 	
 	@Override
+	public BeanStructuralElementInstance getRoot() {
+		StructuralElementInstance parentSei = VirSatEcoreUtil.getEContainerOfClass(sei, StructuralElementInstance.class);
+		if (parentSei != null) {
+			return new BeanStructuralElementInstance(parentSei).getRoot();
+		} else {
+			return new BeanStructuralElementInstance(sei);
+		}
+	}	
+	
+	@Override
 	public void delete() {
 		EcoreUtil.delete(sei);
 	}

--- a/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/structural/IBeanStructuralElementInstance.java
+++ b/de.dlr.sc.virsat.model.edit/src/de/dlr/sc/virsat/model/concept/types/structural/IBeanStructuralElementInstance.java
@@ -253,6 +253,13 @@ public interface IBeanStructuralElementInstance extends IBeanUuid, IBeanDelete, 
 	void setParent(BeanStructuralElementInstance newParent);
 	
 	/**
+	 * Call this method to get the root SEI bean of this bean
+	 * The generic type is used, because we don't want to un-/marshall the concrete type.
+	 * @return parent SEI bean or recurses until the parent is found
+	 */
+	BeanStructuralElementInstance getRoot();
+	
+	/**
 	 * Removes all CA beans in the given List from this SEI bean
 	 * @param beanList list containing IBeanCategoryAssignment elements
 	 */

--- a/de.dlr.sc.virsat.model/META-INF/MANIFEST.MF
+++ b/de.dlr.sc.virsat.model/META-INF/MANIFEST.MF
@@ -9,8 +9,7 @@ Require-Bundle: de.dlr.sc.virsat.external.lib.commons.cli,
  org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.emf.ecore.xmi;visibility:=reexport,
  de.dlr.sc.virsat.external.lib.jersey;bundle-version="4.16.0";visibility:=reexport,
- de.dlr.sc.virsat.external.lib.swagger;visibility:=reexport,
- de.dlr.sc.virsat.model.edit
+ de.dlr.sc.virsat.external.lib.swagger;visibility:=reexport
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/de.dlr.sc.virsat.model/META-INF/MANIFEST.MF
+++ b/de.dlr.sc.virsat.model/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Require-Bundle: de.dlr.sc.virsat.external.lib.commons.cli,
  org.eclipse.emf.ecore;visibility:=reexport,
  org.eclipse.emf.ecore.xmi;visibility:=reexport,
  de.dlr.sc.virsat.external.lib.jersey;bundle-version="4.16.0";visibility:=reexport,
- de.dlr.sc.virsat.external.lib.swagger;visibility:=reexport
+ de.dlr.sc.virsat.external.lib.swagger;visibility:=reexport,
+ de.dlr.sc.virsat.model.edit
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/de.dlr.sc.virsat.model/src-gen/de/dlr/sc/virsat/model/dvlm/structural/StructuralElementInstance.java
+++ b/de.dlr.sc.virsat.model/src-gen/de/dlr/sc/virsat/model/dvlm/structural/StructuralElementInstance.java
@@ -131,6 +131,11 @@ public interface StructuralElementInstance extends IUuid, IDescription, IName, I
 	void setParent(StructuralElementInstance value);
 
 	/**
+	 * Returns the value of the root '<em><b>Parent</b></em>' container reference.
+	 */
+	StructuralElementInstance getRoot();
+	
+	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * <!-- begin-model-doc -->

--- a/de.dlr.sc.virsat.model/src-gen/de/dlr/sc/virsat/model/dvlm/structural/impl/StructuralElementInstanceImpl.java
+++ b/de.dlr.sc.virsat.model/src-gen/de/dlr/sc/virsat/model/dvlm/structural/impl/StructuralElementInstanceImpl.java
@@ -40,6 +40,8 @@ import de.dlr.sc.virsat.model.dvlm.types.TypesPackage;
 import de.dlr.sc.virsat.model.dvlm.types.impl.VirSatUuid;
 
 import de.dlr.sc.virsat.model.dvlm.util.DVLMUnresolvedReferenceException;
+import de.dlr.sc.virsat.model.ecore.VirSatEcoreUtil;
+
 import java.lang.reflect.InvocationTargetException;
 
 import java.util.Collection;
@@ -430,7 +432,7 @@ public class StructuralElementInstanceImpl extends MinimalEObjectImpl.Container 
 		}
 		return relationInstances;
 	}
-
+	
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -502,6 +504,25 @@ public class StructuralElementInstanceImpl extends MinimalEObjectImpl.Container 
 			eNotify(new ENotificationImpl(this, Notification.SET, StructuralPackage.STRUCTURAL_ELEMENT_INSTANCE__PARENT, newParent, newParent));
 	}
 
+	
+//	public StructuralElementInstance getParent() {
+//		if (eContainerFeatureID() != StructuralPackage.STRUCTURAL_ELEMENT_INSTANCE__PARENT) return null;
+//		return (StructuralElementInstance)eContainer();
+//	}
+
+	/**
+	 * returns Root 
+	 */
+	public StructuralElementInstance getRoot() {
+		StructuralElementInstance parentSei = VirSatEcoreUtil.getEContainerOfClass(this, StructuralElementInstance.class);
+		if (parentSei != null) {
+			return parentSei.getRoot();
+		} else {
+			return this;
+		}
+	}
+
+	
 	/**
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->

--- a/known_authors.txt
+++ b/known_authors.txt
@@ -9,3 +9,4 @@ pchrszon-dlr
 DimitriDiantos
 mbou_fr
 kain-ap
+tamp_ry


### PR DESCRIPTION
* Accomplished in this commit:
	[X] implemented a .rootSei() for types BeanStructuralElementInstance
	    as well as StructuralElementInstance
* Notes:
	(*) created test case testGetRoot() in ModelAPIAppsTest.java
	    to test the functionality of the newly implemented methods