### PR TITLE
* Issue: #339 Height of tables too small & Chance of disappearing entry

### DIFF
--- a/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/editor/snippets/AUiSnippetGenericTable.java
+++ b/de.dlr.sc.virsat.uiengine.ui/src/de/dlr/sc/virsat/uiengine/ui/editor/snippets/AUiSnippetGenericTable.java
@@ -376,6 +376,7 @@ public abstract class AUiSnippetGenericTable extends AUiCategorySectionSnippet {
 	 */
 	protected Table createDefaultTable(FormToolkit toolkit, Composite sectionBody) {
 		GridData gridDataTable = createDefaultGridData();
+		gridDataTable.grabExcessVerticalSpace = true;
 		gridDataTable.horizontalSpan = 1;
 		gridDataTable.minimumHeight = DEFAULT_TABLE_HEIGHT;
 		gridDataTable.heightHint = DEFAULT_TABLE_HEIGHT;

--- a/known_authors.txt
+++ b/known_authors.txt
@@ -9,3 +9,4 @@ pchrszon-dlr
 DimitriDiantos
 mbou_fr
 kain-ap
+ReyTamDLR


### PR DESCRIPTION
* Issue: #339 
Height of tables too small & Chance of disappearing entry if clicked on

* Accomplished in this commit:
	[X] Height of tables no longer impractically small, 
	    all tables now can have the preassigned minimum height.
* Notes:
	- none